### PR TITLE
chore(ci): skip CI workflows on draft pull requests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ name: CI
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches: ["main"]
 
@@ -19,6 +20,7 @@ jobs:
 
   lint:
     name: Lint
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: ⬇️ Checkout
@@ -45,6 +47,7 @@ jobs:
 
   license:
     name: License Headers
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: ⬇️ Checkout
@@ -70,6 +73,7 @@ jobs:
 
   typecheck:
     name: Type Check
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: ⬇️ Checkout
@@ -97,6 +101,7 @@ jobs:
 
   test:
     name: Unit Tests (Python ${{ matrix.python-version }})
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     needs: [lint, license, typecheck]
     strategy:
@@ -142,6 +147,7 @@ jobs:
 
   bdd:
     name: BDD Tests
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     needs: [test]
     steps:
@@ -176,6 +182,7 @@ jobs:
 
   helm:
     name: Helm Tests
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     needs: [test]
     steps:


### PR DESCRIPTION
## chore(ci): skip CI workflows on draft pull requests

## Summary

Configure GitHub Actions workflows to skip execution when a pull request is in draft state. CI only runs when the PR is marked as "Ready for review".

## Changes

- [x] Add `if: github.event.pull_request.draft == false` condition to CI workflows
- [x] Ensure CI triggers when a PR is moved from draft to ready
- [x] Verify CI still runs on pushes to `main`

## Dependencies

None.

## Related Issue

Closes #142

## Test Plan

- [ ] ~~`make format` - code formatted~~
- [ ] ~~`make lint` - no linting errors~~
- [ ] ~~`make typecheck` - type checks pass~~
- [ ] ~~`make test` - all unit tests pass~~
- [ ] ~~`make bdd` - all BDD tests pass~~
- [ ] ~~`make check-license` - SPDX headers present~~
