### PR TITLE
chore(infra): Makefile install target missing --extras worker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ help: ## Show this help
 env: ## Set up virtual environment
 	@if ! test -x $(VENV)/bin/python; then \
 		echo "🔧 Installing dependencies with Poetry..."; \
-		poetry install --with dev --with docs --with test --extras server; \
+		poetry install --with dev --with docs --with test --extras server --extras worker; \
 	fi
 
 install: env ## Install dependencies with Poetry


### PR DESCRIPTION
## chore(infra): Makefile install target missing --extras worker

## Summary

The `make install` target only installs the `server` extra. Add `--extras worker` so Celery dependencies are available locally.

## Changes

- [x] Update the `install` target in `Makefile` to include `--extras worker`
- [x] Verify `make install && make test` passes with Celery imports

## Dependencies

None.

## Related Issue

Closes #144

## Test Plan

- [ ] ~~`make format` - code formatted~~
- [ ] ~~`make lint` - no linting errors~~
- [ ] ~~`make typecheck` - type checks pass~~
- [ ] ~~`make test` - all unit tests pass~~
- [ ] ~~`make bdd` - all BDD tests pass~~
- [ ] ~~`make check-license` - SPDX headers present~~
