### PR TITLE
test(security): Argon2id benchmark MIN_HASH_MS too high for CI runners

### DIFF
--- a/tests/core/test_security_bench.py
+++ b/tests/core/test_security_bench.py
@@ -16,7 +16,7 @@ from shomer.core.security import (
 )
 
 # Acceptable range for default params (time_cost=3, memory=64MiB)
-MIN_HASH_MS = 50
+MIN_HASH_MS = 20
 MAX_HASH_MS = 2000
 
 


### PR DESCRIPTION
## test(security): Argon2id benchmark MIN_HASH_MS too high for CI runners

## Summary

Lower MIN_HASH_MS from 50ms to 20ms. CI runners hash faster than expected (~40ms), causing benchmark tests to fail on Python 3.11, 3.12, 3.13.

## Changes

- [x] Lower MIN_HASH_MS to 20ms to accommodate fast CI runners

## Related Issue

Closes #150

## Test Plan

- [x] `make format` - code formatted
- [x] `make lint` - no linting errors
- [x] `make typecheck` - type checks pass
- [x] `make test` - all unit tests pass
- [x] `make bdd` - all BDD tests pass
- [x] `make check-license` - SPDX headers present
