### PR TITLE
feat(models): UserProfile with standard OIDC claims

### DIFF
--- a/alembic/versions/0003_add_user_profiles.py
+++ b/alembic/versions/0003_add_user_profiles.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Add user_profiles table.
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2026-03-18
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0003"
+down_revision: Union[str, None] = "0002"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create user_profiles table."""
+    op.create_table(
+        "user_profiles",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("user_id", sa.Uuid(), nullable=False),
+        sa.Column("name", sa.String(255), nullable=True),
+        sa.Column("given_name", sa.String(255), nullable=True),
+        sa.Column("family_name", sa.String(255), nullable=True),
+        sa.Column("middle_name", sa.String(255), nullable=True),
+        sa.Column("nickname", sa.String(255), nullable=True),
+        sa.Column("preferred_username", sa.String(255), nullable=True),
+        sa.Column("profile_url", sa.String(2048), nullable=True),
+        sa.Column("picture_url", sa.String(2048), nullable=True),
+        sa.Column("website", sa.String(2048), nullable=True),
+        sa.Column("gender", sa.String(50), nullable=True),
+        sa.Column("birthdate", sa.String(10), nullable=True),
+        sa.Column("zoneinfo", sa.String(50), nullable=True),
+        sa.Column("locale", sa.String(10), nullable=True),
+        sa.Column("address_formatted", sa.Text(), nullable=True),
+        sa.Column("address_street", sa.String(500), nullable=True),
+        sa.Column("address_locality", sa.String(255), nullable=True),
+        sa.Column("address_region", sa.String(255), nullable=True),
+        sa.Column("address_postal_code", sa.String(50), nullable=True),
+        sa.Column("address_country", sa.String(100), nullable=True),
+        sa.Column("phone_number", sa.String(50), nullable=True),
+        sa.Column(
+            "phone_number_verified",
+            sa.Boolean(),
+            nullable=False,
+            server_default="false",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_user_profiles")),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            name=op.f("fk_user_profiles_user_id_users"),
+            ondelete="CASCADE",
+        ),
+        sa.UniqueConstraint("user_id", name=op.f("uq_user_profiles_user_id")),
+    )
+    op.create_index(op.f("ix_user_profiles_user_id"), "user_profiles", ["user_id"])
+
+
+def downgrade() -> None:
+    """Drop user_profiles table."""
+    op.drop_table("user_profiles")

--- a/src/shomer/models/user.py
+++ b/src/shomer/models/user.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 if TYPE_CHECKING:
     from shomer.models.user_email import UserEmail
     from shomer.models.user_password import UserPassword
+    from shomer.models.user_profile import UserProfile
 
 from shomer.core.database import Base, TimestampMixin, UUIDMixin
 
@@ -32,6 +33,8 @@ class User(Base, UUIDMixin, TimestampMixin):
         Row creation timestamp (from TimestampMixin).
     updated_at : datetime
         Last update timestamp (from TimestampMixin).
+    profile : UserProfile or None
+        One-to-one OIDC profile (lazy-loaded).
     """
 
     __tablename__ = "users"
@@ -54,6 +57,11 @@ class User(Base, UUIDMixin, TimestampMixin):
     passwords: Mapped[list[UserPassword]] = relationship(
         back_populates="user",
         cascade="all, delete-orphan",
+    )
+    profile: Mapped[UserProfile | None] = relationship(
+        back_populates="user",
+        cascade="all, delete-orphan",
+        uselist=False,
     )
 
     def __repr__(self) -> str:

--- a/src/shomer/models/user_profile.py
+++ b/src/shomer/models/user_profile.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""UserProfile model for OIDC standard claims."""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Boolean, ForeignKey, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from shomer.core.database import Base, TimestampMixin, UUIDMixin
+
+if TYPE_CHECKING:
+    from shomer.models.user import User
+
+
+class UserProfile(Base, UUIDMixin, TimestampMixin):
+    """User profile storing standard OIDC claims.
+
+    See `OpenID Connect Core 1.0 §5.1
+    <https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims>`_.
+
+    Attributes
+    ----------
+    id : uuid.UUID
+        Primary key (from UUIDMixin).
+    user_id : uuid.UUID
+        Foreign key to the users table (unique, one-to-one).
+    name : str or None
+        Full name.
+    given_name : str or None
+        First name.
+    family_name : str or None
+        Last name.
+    middle_name : str or None
+        Middle name.
+    nickname : str or None
+        Casual name.
+    preferred_username : str or None
+        Preferred username.
+    profile_url : str or None
+        Profile page URL.
+    picture_url : str or None
+        Profile picture URL.
+    website : str or None
+        Personal website URL.
+    gender : str or None
+        Gender.
+    birthdate : str or None
+        Birthday in YYYY-MM-DD format.
+    zoneinfo : str or None
+        Time zone (e.g. ``Europe/Paris``).
+    locale : str or None
+        Locale (e.g. ``en-US``).
+    address_formatted : str or None
+        Full mailing address, formatted.
+    address_street : str or None
+        Street address.
+    address_locality : str or None
+        City or locality.
+    address_region : str or None
+        State, province or region.
+    address_postal_code : str or None
+        Postal / ZIP code.
+    address_country : str or None
+        Country.
+    phone_number : str or None
+        Phone number.
+    phone_number_verified : bool
+        Whether the phone number has been verified.
+    """
+
+    __tablename__ = "user_profiles"
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+
+    # Standard OIDC profile claims
+    name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    given_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    family_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    middle_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    nickname: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    preferred_username: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    profile_url: Mapped[str | None] = mapped_column(String(2048), nullable=True)
+    picture_url: Mapped[str | None] = mapped_column(String(2048), nullable=True)
+    website: Mapped[str | None] = mapped_column(String(2048), nullable=True)
+    gender: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    birthdate: Mapped[str | None] = mapped_column(String(10), nullable=True)
+    zoneinfo: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    locale: Mapped[str | None] = mapped_column(String(10), nullable=True)
+
+    # Address claims
+    address_formatted: Mapped[str | None] = mapped_column(Text, nullable=True)
+    address_street: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    address_locality: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    address_region: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    address_postal_code: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    address_country: Mapped[str | None] = mapped_column(String(100), nullable=True)
+
+    # Phone claims
+    phone_number: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    phone_number_verified: Mapped[bool] = mapped_column(
+        Boolean, default=False, nullable=False
+    )
+
+    # Relationships
+    user: Mapped[User] = relationship(back_populates="profile")
+
+    def __repr__(self) -> str:
+        return f"<UserProfile user_id={self.user_id} name={self.name}>"

--- a/tests/models/test_user_profile.py
+++ b/tests/models/test_user_profile.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Unit tests for UserProfile model."""
+
+import uuid
+
+from shomer.models.user import User  # noqa: F401 — register mapper
+from shomer.models.user_email import UserEmail  # noqa: F401 — register mapper
+from shomer.models.user_password import UserPassword  # noqa: F401 — register mapper
+from shomer.models.user_profile import UserProfile
+
+
+class TestUserProfileModel:
+    """Tests for UserProfile SQLAlchemy model definition."""
+
+    def test_tablename(self) -> None:
+        assert UserProfile.__tablename__ == "user_profiles"
+
+    def test_phone_number_verified_column(self) -> None:
+        col = UserProfile.__table__.c.phone_number_verified
+        assert col.nullable is False
+        assert col.default.arg is False
+
+    def test_nullable_claim_fields(self) -> None:
+        profile = UserProfile(user_id=uuid.uuid4())
+        assert profile.name is None
+        assert profile.given_name is None
+        assert profile.family_name is None
+        assert profile.middle_name is None
+        assert profile.nickname is None
+        assert profile.preferred_username is None
+        assert profile.profile_url is None
+        assert profile.picture_url is None
+        assert profile.website is None
+        assert profile.gender is None
+        assert profile.birthdate is None
+        assert profile.zoneinfo is None
+        assert profile.locale is None
+
+    def test_nullable_address_fields(self) -> None:
+        profile = UserProfile(user_id=uuid.uuid4())
+        assert profile.address_formatted is None
+        assert profile.address_street is None
+        assert profile.address_locality is None
+        assert profile.address_region is None
+        assert profile.address_postal_code is None
+        assert profile.address_country is None
+
+    def test_nullable_phone_fields(self) -> None:
+        profile = UserProfile(user_id=uuid.uuid4())
+        assert profile.phone_number is None
+
+    def test_set_claim_fields(self) -> None:
+        profile = UserProfile(
+            user_id=uuid.uuid4(),
+            name="Jane Doe",
+            given_name="Jane",
+            family_name="Doe",
+            nickname="jdoe",
+            locale="en-US",
+            zoneinfo="America/New_York",
+            birthdate="1990-01-15",
+            gender="female",
+            website="https://example.com",
+        )
+        assert profile.name == "Jane Doe"
+        assert profile.given_name == "Jane"
+        assert profile.family_name == "Doe"
+        assert profile.nickname == "jdoe"
+        assert profile.locale == "en-US"
+        assert profile.zoneinfo == "America/New_York"
+        assert profile.birthdate == "1990-01-15"
+        assert profile.gender == "female"
+        assert profile.website == "https://example.com"
+
+    def test_set_address_fields(self) -> None:
+        profile = UserProfile(
+            user_id=uuid.uuid4(),
+            address_formatted="123 Main St, Springfield, IL 62704, US",
+            address_street="123 Main St",
+            address_locality="Springfield",
+            address_region="IL",
+            address_postal_code="62704",
+            address_country="US",
+        )
+        assert profile.address_street == "123 Main St"
+        assert profile.address_locality == "Springfield"
+        assert profile.address_region == "IL"
+        assert profile.address_postal_code == "62704"
+        assert profile.address_country == "US"
+
+    def test_repr(self) -> None:
+        uid = uuid.uuid4()
+        profile = UserProfile(user_id=uid, name="Test")
+        assert f"user_id={uid}" in repr(profile)
+        assert "name=Test" in repr(profile)
+
+    def test_user_id_column_is_required(self) -> None:
+        col = UserProfile.__table__.c.user_id
+        assert col.nullable is False
+
+    def test_user_id_column_is_unique(self) -> None:
+        col = UserProfile.__table__.c.user_id
+        assert col.unique is True
+
+    def test_user_id_column_is_indexed(self) -> None:
+        col = UserProfile.__table__.c.user_id
+        assert col.index is True
+
+    def test_user_id_foreign_key(self) -> None:
+        col = UserProfile.__table__.c.user_id
+        fk = list(col.foreign_keys)[0]
+        assert fk.column.table.name == "users"
+        assert fk.column.name == "id"
+
+
+class TestUserProfileRelationship:
+    """Tests for UserProfile ↔ User relationship configuration."""
+
+    def test_user_relationship_exists(self) -> None:
+        rel = UserProfile.__mapper__.relationships["user"]
+        assert rel.back_populates == "profile"
+
+    def test_user_model_has_profile_relationship(self) -> None:
+
+        rel = User.__mapper__.relationships["profile"]
+        assert rel.back_populates == "user"
+        assert rel.uselist is False


### PR DESCRIPTION
## feat(models): UserProfile with standard OIDC claims

## Summary

UserProfile model storing standard OIDC claims: name, given_name, family_name, nickname, picture, locale, zoneinfo, birthdate, gender, website, etc.

## Changes

- [x] UserProfile model with all standard OIDC claim fields
- [x] One-to-one relationship with User
- [x] Alembic migration

## Dependencies

- #4 - User model

## Related Issue

Closes #5

## Test Plan

- [x] `make format` - code formatted
- [x] `make lint` - no linting errors
- [x] `make typecheck` - type checks pass
- [x] `make test` - all unit tests pass (83 passed)
- [x] `make bdd` - all BDD tests pass (6 scenarios, 20 steps)
- [x] `make check-license` - SPDX headers present