### PR TITLE
feat(models): Session with CSRF and multi-tenancy

### DIFF
--- a/alembic/versions/0004_add_sessions.py
+++ b/alembic/versions/0004_add_sessions.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Add sessions table.
+
+Revision ID: 0004
+Revises: 0003
+Create Date: 2026-03-18
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0004"
+down_revision: Union[str, None] = "0003"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create sessions table."""
+    op.create_table(
+        "sessions",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("user_id", sa.Uuid(), nullable=False),
+        sa.Column("tenant_id", sa.Uuid(), nullable=True),
+        sa.Column("token_hash", sa.Text(), nullable=False),
+        sa.Column("csrf_token", sa.String(255), nullable=False),
+        sa.Column("user_agent", sa.String(512), nullable=True),
+        sa.Column("ip_address", sa.String(45), nullable=True),
+        sa.Column(
+            "last_activity",
+            sa.DateTime(timezone=True),
+            nullable=False,
+        ),
+        sa.Column(
+            "expires_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_sessions")),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            name=op.f("fk_sessions_user_id_users"),
+            ondelete="CASCADE",
+        ),
+    )
+    op.create_index(op.f("ix_sessions_user_id"), "sessions", ["user_id"])
+    op.create_index(op.f("ix_sessions_tenant_id"), "sessions", ["tenant_id"])
+
+
+def downgrade() -> None:
+    """Drop sessions table."""
+    op.drop_table("sessions")

--- a/src/shomer/models/session.py
+++ b/src/shomer/models/session.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Session model with CSRF and multi-tenancy support."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import DateTime, ForeignKey, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+if TYPE_CHECKING:
+    from shomer.models.user import User
+
+from shomer.core.database import Base, TimestampMixin, UUIDMixin
+
+
+class Session(Base, UUIDMixin, TimestampMixin):
+    """Browser session with CSRF protection and multi-tenancy.
+
+    Attributes
+    ----------
+    id : uuid.UUID
+        Primary key (from UUIDMixin).
+    user_id : uuid.UUID
+        Foreign key to the users table.
+    tenant_id : uuid.UUID or None
+        Optional tenant identifier for multi-tenancy.
+    token_hash : str
+        Hashed session token (stored server-side).
+    csrf_token : str
+        CSRF protection token bound to this session.
+    user_agent : str or None
+        Browser User-Agent string.
+    ip_address : str or None
+        Client IP address at session creation.
+    last_activity : datetime
+        Timestamp of the last request using this session.
+    expires_at : datetime
+        Absolute expiration timestamp for sliding window.
+    created_at : datetime
+        Row creation timestamp (from TimestampMixin).
+    updated_at : datetime
+        Last update timestamp (from TimestampMixin).
+    """
+
+    __tablename__ = "sessions"
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    tenant_id: Mapped[uuid.UUID | None] = mapped_column(
+        nullable=True,
+        index=True,
+    )
+    token_hash: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+    )
+    csrf_token: Mapped[str] = mapped_column(
+        String(255),
+        nullable=False,
+    )
+    user_agent: Mapped[str | None] = mapped_column(
+        String(512),
+        nullable=True,
+    )
+    ip_address: Mapped[str | None] = mapped_column(
+        String(45),
+        nullable=True,
+    )
+    last_activity: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+    )
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+    )
+
+    # Relationships
+    user: Mapped[User] = relationship(back_populates="sessions")
+
+    def __repr__(self) -> str:
+        return f"<Session id={self.id} user_id={self.user_id}>"

--- a/src/shomer/models/user.py
+++ b/src/shomer/models/user.py
@@ -11,6 +11,7 @@ from sqlalchemy import Boolean, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 if TYPE_CHECKING:
+    from shomer.models.session import Session
     from shomer.models.user_email import UserEmail
     from shomer.models.user_password import UserPassword
     from shomer.models.user_profile import UserProfile
@@ -62,6 +63,10 @@ class User(Base, UUIDMixin, TimestampMixin):
         back_populates="user",
         cascade="all, delete-orphan",
         uselist=False,
+    )
+    sessions: Mapped[list[Session]] = relationship(
+        back_populates="user",
+        cascade="all, delete-orphan",
     )
 
     def __repr__(self) -> str:

--- a/tests/models/test_session.py
+++ b/tests/models/test_session.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Unit tests for Session model."""
+
+import uuid
+from datetime import datetime, timezone
+
+from shomer.models.session import Session
+from shomer.models.user import User  # noqa: F401 — register mapper
+from shomer.models.user_email import UserEmail  # noqa: F401 — register mapper
+from shomer.models.user_password import UserPassword  # noqa: F401 — register mapper
+
+
+class TestSessionModel:
+    """Tests for Session SQLAlchemy model definition."""
+
+    def test_tablename(self) -> None:
+        assert Session.__tablename__ == "sessions"
+
+    def test_required_fields(self) -> None:
+        now = datetime.now(timezone.utc)
+        session = Session(
+            user_id=uuid.uuid4(),
+            token_hash="hashed_token",
+            csrf_token="csrf_abc123",
+            last_activity=now,
+            expires_at=now,
+        )
+        assert session.token_hash == "hashed_token"
+        assert session.csrf_token == "csrf_abc123"
+        assert session.last_activity == now
+        assert session.expires_at == now
+
+    def test_nullable_fields_default_none(self) -> None:
+        now = datetime.now(timezone.utc)
+        session = Session(
+            user_id=uuid.uuid4(),
+            token_hash="h",
+            csrf_token="c",
+            last_activity=now,
+            expires_at=now,
+        )
+        assert session.tenant_id is None
+        assert session.user_agent is None
+        assert session.ip_address is None
+
+    def test_optional_fields(self) -> None:
+        now = datetime.now(timezone.utc)
+        tid = uuid.uuid4()
+        session = Session(
+            user_id=uuid.uuid4(),
+            tenant_id=tid,
+            token_hash="h",
+            csrf_token="c",
+            user_agent="Mozilla/5.0",
+            ip_address="192.168.1.1",
+            last_activity=now,
+            expires_at=now,
+        )
+        assert session.tenant_id == tid
+        assert session.user_agent == "Mozilla/5.0"
+        assert session.ip_address == "192.168.1.1"
+
+    def test_repr(self) -> None:
+        now = datetime.now(timezone.utc)
+        uid = uuid.uuid4()
+        session = Session(
+            user_id=uid,
+            token_hash="h",
+            csrf_token="c",
+            last_activity=now,
+            expires_at=now,
+        )
+        assert f"user_id={uid}" in repr(session)
+
+    def test_user_id_column_not_nullable(self) -> None:
+        col = Session.__table__.c.user_id
+        assert col.nullable is False
+
+    def test_user_id_column_indexed(self) -> None:
+        col = Session.__table__.c.user_id
+        assert col.index is True
+
+    def test_tenant_id_column_nullable(self) -> None:
+        col = Session.__table__.c.tenant_id
+        assert col.nullable is True
+
+    def test_tenant_id_column_indexed(self) -> None:
+        col = Session.__table__.c.tenant_id
+        assert col.index is True
+
+    def test_token_hash_not_nullable(self) -> None:
+        col = Session.__table__.c.token_hash
+        assert col.nullable is False
+
+    def test_csrf_token_not_nullable(self) -> None:
+        col = Session.__table__.c.csrf_token
+        assert col.nullable is False
+
+    def test_last_activity_not_nullable(self) -> None:
+        col = Session.__table__.c.last_activity
+        assert col.nullable is False
+
+    def test_expires_at_not_nullable(self) -> None:
+        col = Session.__table__.c.expires_at
+        assert col.nullable is False
+
+    def test_user_id_foreign_key(self) -> None:
+        col = Session.__table__.c.user_id
+        fk = list(col.foreign_keys)[0]
+        assert fk.column.table.name == "users"
+        assert fk.column.name == "id"
+
+
+class TestSessionRelationship:
+    """Tests for Session <-> User relationship configuration."""
+
+    def test_user_relationship_exists(self) -> None:
+        rel = Session.__mapper__.relationships["user"]
+        assert rel.back_populates == "sessions"
+
+    def test_user_model_has_sessions_relationship(self) -> None:
+        rel = User.__mapper__.relationships["sessions"]
+        assert rel.back_populates == "user"


### PR DESCRIPTION
## feat(models): Session with CSRF and multi-tenancy

## Summary

Session model with CSRF token, multi-tenancy support (tenant_id), user-agent, IP address, last activity timestamp, and sliding expiration.

## Changes

- [x] Session model (token_hash, csrf_token, user_id, tenant_id, user_agent, ip_address, last_activity, expires_at)
- [x] Indexes on user_id and tenant_id
- [x] Alembic migration

## Dependencies

- #4 - User model

## Related Issue

Closes #6

## Test Plan

- [x] `make format` - code formatted
- [x] `make lint` - no linting errors
- [x] `make typecheck` - type checks pass
- [x] `make test` - all unit tests pass (85 passed)
- [x] `make bdd` - all BDD tests pass (6 scenarios, 20 steps)
- [x] `make check-license` - SPDX headers present