### PR TITLE
feat(models): VerificationCode and PasswordResetToken

### DIFF
--- a/alembic/versions/0005_add_verification_and_password_reset.py
+++ b/alembic/versions/0005_add_verification_and_password_reset.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Add verification_codes and password_reset_tokens tables.
+
+Revision ID: 0005
+Revises: 0004
+Create Date: 2026-03-18
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0005"
+down_revision: Union[str, None] = "0004"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create verification_codes and password_reset_tokens tables."""
+    op.create_table(
+        "verification_codes",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("email", sa.String(255), nullable=False),
+        sa.Column("code", sa.String(6), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("used", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_verification_codes")),
+    )
+    op.create_index(
+        op.f("ix_verification_codes_email"),
+        "verification_codes",
+        ["email"],
+    )
+
+    op.create_table(
+        "password_reset_tokens",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("token", sa.Uuid(), nullable=False),
+        sa.Column("user_id", sa.Uuid(), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("used", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_password_reset_tokens")),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            name=op.f("fk_password_reset_tokens_user_id_users"),
+            ondelete="CASCADE",
+        ),
+        sa.UniqueConstraint("token", name=op.f("uq_password_reset_tokens_token")),
+    )
+    op.create_index(
+        op.f("ix_password_reset_tokens_token"),
+        "password_reset_tokens",
+        ["token"],
+    )
+    op.create_index(
+        op.f("ix_password_reset_tokens_user_id"),
+        "password_reset_tokens",
+        ["user_id"],
+    )
+
+
+def downgrade() -> None:
+    """Drop password_reset_tokens and verification_codes tables."""
+    op.drop_table("password_reset_tokens")
+    op.drop_table("verification_codes")

--- a/src/shomer/models/password_reset_token.py
+++ b/src/shomer/models/password_reset_token.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""PasswordResetToken model for password reset flows."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, Uuid
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+if TYPE_CHECKING:
+    from shomer.models.user import User
+
+from shomer.core.database import Base, TimestampMixin, UUIDMixin
+
+
+class PasswordResetToken(Base, UUIDMixin, TimestampMixin):
+    """Password reset token with expiration and single-use flag.
+
+    Attributes
+    ----------
+    id : uuid.UUID
+        Primary key (from UUIDMixin).
+    token : uuid.UUID
+        Unique token sent to the user (distinct from the PK).
+    user_id : uuid.UUID
+        Foreign key to the users table.
+    expires_at : datetime
+        Expiration timestamp.
+    used : bool
+        Whether the token has already been consumed.
+    created_at : datetime
+        Row creation timestamp (from TimestampMixin).
+    updated_at : datetime
+        Last update timestamp (from TimestampMixin).
+    """
+
+    __tablename__ = "password_reset_tokens"
+
+    token: Mapped[uuid.UUID] = mapped_column(
+        Uuid,
+        default=uuid.uuid4,
+        unique=True,
+        nullable=False,
+        index=True,
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+    )
+    used: Mapped[bool] = mapped_column(
+        Boolean,
+        default=False,
+        nullable=False,
+    )
+
+    # Relationships
+    user: Mapped[User] = relationship(back_populates="password_reset_tokens")
+
+    def __repr__(self) -> str:
+        return f"<PasswordResetToken user_id={self.user_id} used={self.used}>"

--- a/src/shomer/models/user.py
+++ b/src/shomer/models/user.py
@@ -11,6 +11,7 @@ from sqlalchemy import Boolean, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 if TYPE_CHECKING:
+    from shomer.models.password_reset_token import PasswordResetToken
     from shomer.models.session import Session
     from shomer.models.user_email import UserEmail
     from shomer.models.user_password import UserPassword
@@ -65,6 +66,10 @@ class User(Base, UUIDMixin, TimestampMixin):
         uselist=False,
     )
     sessions: Mapped[list[Session]] = relationship(
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )
+    password_reset_tokens: Mapped[list[PasswordResetToken]] = relationship(
         back_populates="user",
         cascade="all, delete-orphan",
     )

--- a/src/shomer/models/verification_code.py
+++ b/src/shomer/models/verification_code.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""VerificationCode model for email verification."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from shomer.core.database import Base, TimestampMixin, UUIDMixin
+
+
+class VerificationCode(Base, UUIDMixin, TimestampMixin):
+    """Email verification code with expiration and single-use flag.
+
+    Attributes
+    ----------
+    id : uuid.UUID
+        Primary key (from UUIDMixin).
+    email : str
+        Email address this code was sent to.
+    code : str
+        Six-digit verification code.
+    expires_at : datetime
+        Expiration timestamp.
+    used : bool
+        Whether the code has already been consumed.
+    created_at : datetime
+        Row creation timestamp (from TimestampMixin).
+    updated_at : datetime
+        Last update timestamp (from TimestampMixin).
+    """
+
+    __tablename__ = "verification_codes"
+
+    email: Mapped[str] = mapped_column(
+        String(255),
+        nullable=False,
+        index=True,
+    )
+    code: Mapped[str] = mapped_column(
+        String(6),
+        nullable=False,
+    )
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+    )
+    used: Mapped[bool] = mapped_column(
+        Boolean,
+        default=False,
+        nullable=False,
+    )
+
+    def __repr__(self) -> str:
+        return f"<VerificationCode email={self.email} used={self.used}>"

--- a/tests/models/test_password_reset_token.py
+++ b/tests/models/test_password_reset_token.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Unit tests for PasswordResetToken model."""
+
+import uuid
+from datetime import datetime, timezone
+
+from shomer.models.password_reset_token import PasswordResetToken
+from shomer.models.user import User  # noqa: F401 — register mapper
+from shomer.models.user_email import UserEmail  # noqa: F401 — register mapper
+from shomer.models.user_password import UserPassword  # noqa: F401 — register mapper
+from shomer.models.user_profile import UserProfile  # noqa: F401 — register mapper
+
+
+class TestPasswordResetTokenModel:
+    """Tests for PasswordResetToken SQLAlchemy model definition."""
+
+    def test_tablename(self) -> None:
+        assert PasswordResetToken.__tablename__ == "password_reset_tokens"
+
+    def test_required_fields(self) -> None:
+        now = datetime.now(timezone.utc)
+        uid = uuid.uuid4()
+        tok = uuid.uuid4()
+        prt = PasswordResetToken(
+            token=tok,
+            user_id=uid,
+            expires_at=now,
+        )
+        assert prt.token == tok
+        assert prt.user_id == uid
+        assert prt.expires_at == now
+
+    def test_used_column_defaults(self) -> None:
+        col = PasswordResetToken.__table__.c.used
+        assert col.nullable is False
+        assert col.default.arg is False
+
+    def test_token_column_unique(self) -> None:
+        col = PasswordResetToken.__table__.c.token
+        assert col.unique is True
+
+    def test_token_column_indexed(self) -> None:
+        col = PasswordResetToken.__table__.c.token
+        assert col.index is True
+
+    def test_token_column_not_nullable(self) -> None:
+        col = PasswordResetToken.__table__.c.token
+        assert col.nullable is False
+
+    def test_user_id_column_not_nullable(self) -> None:
+        col = PasswordResetToken.__table__.c.user_id
+        assert col.nullable is False
+
+    def test_user_id_column_indexed(self) -> None:
+        col = PasswordResetToken.__table__.c.user_id
+        assert col.index is True
+
+    def test_expires_at_not_nullable(self) -> None:
+        col = PasswordResetToken.__table__.c.expires_at
+        assert col.nullable is False
+
+    def test_user_id_foreign_key(self) -> None:
+        col = PasswordResetToken.__table__.c.user_id
+        fk = list(col.foreign_keys)[0]
+        assert fk.column.table.name == "users"
+        assert fk.column.name == "id"
+
+    def test_repr(self) -> None:
+        now = datetime.now(timezone.utc)
+        uid = uuid.uuid4()
+        prt = PasswordResetToken(
+            token=uuid.uuid4(),
+            user_id=uid,
+            expires_at=now,
+        )
+        assert f"user_id={uid}" in repr(prt)
+
+
+class TestPasswordResetTokenRelationship:
+    """Tests for PasswordResetToken <-> User relationship."""
+
+    def test_user_relationship_exists(self) -> None:
+        rel = PasswordResetToken.__mapper__.relationships["user"]
+        assert rel.back_populates == "password_reset_tokens"
+
+    def test_user_model_has_password_reset_tokens_relationship(self) -> None:
+        rel = User.__mapper__.relationships["password_reset_tokens"]
+        assert rel.back_populates == "user"

--- a/tests/models/test_verification_code.py
+++ b/tests/models/test_verification_code.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Unit tests for VerificationCode model."""
+
+from datetime import datetime, timezone
+
+from shomer.models.verification_code import VerificationCode
+
+
+class TestVerificationCodeModel:
+    """Tests for VerificationCode SQLAlchemy model definition."""
+
+    def test_tablename(self) -> None:
+        assert VerificationCode.__tablename__ == "verification_codes"
+
+    def test_required_fields(self) -> None:
+        now = datetime.now(timezone.utc)
+        vc = VerificationCode(
+            email="user@example.com",
+            code="123456",
+            expires_at=now,
+        )
+        assert vc.email == "user@example.com"
+        assert vc.code == "123456"
+        assert vc.expires_at == now
+
+    def test_used_column_defaults(self) -> None:
+        col = VerificationCode.__table__.c.used
+        assert col.nullable is False
+        assert col.default.arg is False
+
+    def test_email_column_indexed(self) -> None:
+        col = VerificationCode.__table__.c.email
+        assert col.index is True
+
+    def test_email_column_not_nullable(self) -> None:
+        col = VerificationCode.__table__.c.email
+        assert col.nullable is False
+
+    def test_code_column_not_nullable(self) -> None:
+        col = VerificationCode.__table__.c.code
+        assert col.nullable is False
+
+    def test_expires_at_not_nullable(self) -> None:
+        col = VerificationCode.__table__.c.expires_at
+        assert col.nullable is False
+
+    def test_repr(self) -> None:
+        now = datetime.now(timezone.utc)
+        vc = VerificationCode(
+            email="a@b.com",
+            code="000000",
+            expires_at=now,
+        )
+        assert "email=a@b.com" in repr(vc)


### PR DESCRIPTION
## feat(models): VerificationCode and PasswordResetToken

## Summary

Models for email verification (6-digit code with expiration) and password reset (UUID token, expiration, single-use flag).

## Changes

- [x] VerificationCode model (code, email, expires_at, used)
- [x] PasswordResetToken model (token UUID, user_id, expires_at, used)
- [x] Alembic migration

## Dependencies

- #4 - User model

## Related Issue

Closes #7

## Test Plan

- [x] `make format` - code formatted
- [x] `make lint` - no linting errors
- [x] `make typecheck` - type checks pass
- [x] `make test` - all unit tests pass (104 passed)
- [x] `make bdd` - all BDD tests pass (6 scenarios, 20 steps)
- [x] `make check-license` - SPDX headers present