### PR TITLE
feat(email): email sending service (SMTP/Mailler) via Celery

### DIFF
--- a/src/shomer/core/settings.py
+++ b/src/shomer/core/settings.py
@@ -75,6 +75,20 @@ class Settings(BaseSettings):
         Celery result backend Redis port. Defaults to ``redis_port``.
     celery_backend_db : int
         Celery result backend Redis database number.
+    smtp_host : str
+        SMTP server hostname.
+    smtp_port : int
+        SMTP server port.
+    smtp_user : str
+        SMTP authentication username.
+    smtp_password : str
+        SMTP authentication password.
+    smtp_use_tls : bool
+        Whether to use STARTTLS for SMTP connections.
+    email_from_address : str
+        Default sender email address.
+    email_from_name : str
+        Default sender display name.
     celery_backend_password : str
         Celery result backend Redis password (loaded via ``get_credential``).
     """
@@ -96,6 +110,15 @@ class Settings(BaseSettings):
     redis_port: int = 6379
     redis_db: int = 0
     redis_password: str = ""
+
+    # Email / SMTP
+    smtp_host: str = "localhost"
+    smtp_port: int = 587
+    smtp_user: str = ""
+    smtp_password: str = ""
+    smtp_use_tls: bool = True
+    email_from_address: str = "noreply@shomer.local"
+    email_from_name: str = "Shomer"
 
     # Celery result backend (defaults to broker Redis when empty)
     celery_backend_host: str = ""

--- a/src/shomer/email/__init__.py
+++ b/src/shomer/email/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Email sending service for Shomer."""

--- a/src/shomer/email/backend.py
+++ b/src/shomer/email/backend.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Email backend interface and SMTP implementation."""
+
+from __future__ import annotations
+
+import smtplib
+from abc import ABC, abstractmethod
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+
+from shomer.core.settings import Settings
+
+
+class EmailBackend(ABC):
+    """Abstract base class for email backends.
+
+    Attributes
+    ----------
+    settings : Settings
+        Application configuration.
+    """
+
+    def __init__(self, settings: Settings) -> None:
+        self.settings = settings
+
+    @abstractmethod
+    def send(
+        self,
+        *,
+        to: str,
+        subject: str,
+        html_body: str,
+    ) -> None:
+        """Send an email.
+
+        Parameters
+        ----------
+        to : str
+            Recipient email address.
+        subject : str
+            Email subject line.
+        html_body : str
+            Rendered HTML body.
+        """
+
+
+class SmtpBackend(EmailBackend):
+    """SMTP email backend.
+
+    Connects to the configured SMTP server and delivers messages
+    using STARTTLS when enabled.
+    """
+
+    def send(
+        self,
+        *,
+        to: str,
+        subject: str,
+        html_body: str,
+    ) -> None:
+        """Send an email via SMTP.
+
+        Parameters
+        ----------
+        to : str
+            Recipient email address.
+        subject : str
+            Email subject line.
+        html_body : str
+            Rendered HTML body.
+
+        Raises
+        ------
+        smtplib.SMTPException
+            If the SMTP server rejects the message.
+        """
+        msg = MIMEMultipart("alternative")
+        msg["From"] = (
+            f"{self.settings.email_from_name} <{self.settings.email_from_address}>"
+        )
+        msg["To"] = to
+        msg["Subject"] = subject
+        msg.attach(MIMEText(html_body, "html"))
+
+        with smtplib.SMTP(self.settings.smtp_host, self.settings.smtp_port) as server:
+            if self.settings.smtp_use_tls:
+                server.starttls()
+            if self.settings.smtp_user:
+                server.login(self.settings.smtp_user, self.settings.smtp_password)
+            server.sendmail(self.settings.email_from_address, [to], msg.as_string())

--- a/src/shomer/email/renderer.py
+++ b/src/shomer/email/renderer.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Jinja2 template rendering engine for email bodies."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+#: Default directory for email templates.
+_TEMPLATE_DIR = Path(__file__).parent.parent / "templates" / "email"
+
+
+def create_env(template_dir: Path | None = None) -> Environment:
+    """Create a Jinja2 environment for email templates.
+
+    Parameters
+    ----------
+    template_dir : Path or None
+        Directory containing the templates.  Defaults to
+        ``src/shomer/templates/email/``.
+
+    Returns
+    -------
+    Environment
+        Configured Jinja2 environment.
+    """
+    directory = template_dir or _TEMPLATE_DIR
+    return Environment(
+        loader=FileSystemLoader(str(directory)),
+        autoescape=select_autoescape(["html", "xml"]),
+    )
+
+
+def render_template(
+    template_name: str,
+    context: dict[str, object],
+    *,
+    template_dir: Path | None = None,
+) -> str:
+    """Render an email template to a string.
+
+    Parameters
+    ----------
+    template_name : str
+        Template file name (e.g. ``"verification.html"``).
+    context : dict[str, object]
+        Variables passed to the template.
+    template_dir : Path or None
+        Override template directory.
+
+    Returns
+    -------
+    str
+        Rendered HTML string.
+    """
+    env = create_env(template_dir)
+    template = env.get_template(template_name)
+    return template.render(context)

--- a/src/shomer/email/service.py
+++ b/src/shomer/email/service.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""High-level email service."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from shomer.core.settings import Settings
+from shomer.email.backend import EmailBackend, SmtpBackend
+from shomer.email.renderer import render_template
+
+
+class EmailService:
+    """Orchestrates template rendering and email dispatch.
+
+    Attributes
+    ----------
+    backend : EmailBackend
+        The delivery backend (SMTP by default).
+    """
+
+    def __init__(
+        self,
+        settings: Settings,
+        *,
+        backend: EmailBackend | None = None,
+    ) -> None:
+        self.settings = settings
+        self.backend = backend or SmtpBackend(settings)
+
+    def send_email(
+        self,
+        *,
+        to: str,
+        subject: str,
+        template: str,
+        context: dict[str, object] | None = None,
+        template_dir: Path | None = None,
+    ) -> None:
+        """Render a template and send the resulting email.
+
+        Parameters
+        ----------
+        to : str
+            Recipient email address.
+        subject : str
+            Email subject line.
+        template : str
+            Template file name (e.g. ``"verification.html"``).
+        context : dict[str, object] or None
+            Variables passed to the template.
+        template_dir : Path or None
+            Override template directory.
+        """
+        html_body = render_template(template, context or {}, template_dir=template_dir)
+        self.backend.send(to=to, subject=subject, html_body=html_body)

--- a/src/shomer/tasks/email.py
+++ b/src/shomer/tasks/email.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Celery tasks for asynchronous email dispatch."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from celery import Task
+
+from shomer.core.settings import get_settings
+from shomer.email.service import EmailService
+from shomer.worker import app
+
+#: Maximum number of retry attempts for transient SMTP failures.
+MAX_RETRIES = 3
+
+#: Backoff interval between retries (in seconds).
+RETRY_BACKOFF = 60
+
+
+@app.task(  # type: ignore[misc]
+    bind=True,
+    max_retries=MAX_RETRIES,
+    default_retry_delay=RETRY_BACKOFF,
+    autoretry_for=(OSError,),
+    retry_backoff=True,
+    retry_jitter=True,
+)
+def send_email_task(
+    self: Task,  # noqa: ARG001
+    *,
+    to: str,
+    subject: str,
+    template: str,
+    context: dict[str, Any] | None = None,
+) -> None:
+    """Send an email asynchronously via Celery.
+
+    Retries up to ``MAX_RETRIES`` times with exponential backoff on
+    transient network/SMTP errors (``OSError`` subclasses).
+
+    Parameters
+    ----------
+    self : celery.Task
+        Bound task instance (for retry support).
+    to : str
+        Recipient email address.
+    subject : str
+        Email subject line.
+    template : str
+        Template file name.
+    context : dict[str, Any] or None
+        Variables for template rendering.
+    """
+    settings = get_settings()
+    service = EmailService(settings)
+    service.send_email(
+        to=to,
+        subject=subject,
+        template=template,
+        context=context,
+    )

--- a/src/shomer/templates/email/base.html
+++ b/src/shomer/templates/email/base.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"></head>
+<body>{% block content %}{% endblock %}</body>
+</html>

--- a/tests/email_service/__init__.py
+++ b/tests/email_service/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Tests for email service."""

--- a/tests/email_service/test_backend.py
+++ b/tests/email_service/test_backend.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Unit tests for email backends with mock SMTP server."""
+
+import smtplib
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from shomer.core.settings import Settings
+from shomer.email.backend import EmailBackend, SmtpBackend
+
+
+class TestEmailBackendInterface:
+    """Tests for EmailBackend ABC."""
+
+    def test_cannot_instantiate_directly(self) -> None:
+        with pytest.raises(TypeError):
+            EmailBackend(Settings())  # type: ignore[abstract]
+
+
+class TestSmtpBackend:
+    """Tests for SmtpBackend with mock SMTP."""
+
+    def _settings(self, **kwargs: object) -> Settings:
+        defaults = {
+            "smtp_host": "mail.example.com",
+            "smtp_port": 587,
+            "smtp_user": "user",
+            "smtp_password": "pass",
+            "smtp_use_tls": True,
+            "email_from_address": "noreply@example.com",
+            "email_from_name": "Test",
+        }
+        defaults.update(kwargs)
+        return Settings(**defaults)  # type: ignore[arg-type]
+
+    @patch("shomer.email.backend.smtplib.SMTP")
+    def test_sends_email(self, mock_smtp_cls: MagicMock) -> None:
+        mock_server = MagicMock()
+        mock_smtp_cls.return_value.__enter__ = MagicMock(return_value=mock_server)
+        mock_smtp_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        backend = SmtpBackend(self._settings())
+        backend.send(
+            to="user@example.com",
+            subject="Test",
+            html_body="<p>Hello</p>",
+        )
+
+        mock_smtp_cls.assert_called_once_with("mail.example.com", 587)
+        mock_server.starttls.assert_called_once()
+        mock_server.login.assert_called_once_with("user", "pass")
+        mock_server.sendmail.assert_called_once()
+
+    @patch("shomer.email.backend.smtplib.SMTP")
+    def test_no_tls_when_disabled(self, mock_smtp_cls: MagicMock) -> None:
+        mock_server = MagicMock()
+        mock_smtp_cls.return_value.__enter__ = MagicMock(return_value=mock_server)
+        mock_smtp_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        backend = SmtpBackend(self._settings(smtp_use_tls=False))
+        backend.send(to="a@b.com", subject="S", html_body="<p>X</p>")
+
+        mock_server.starttls.assert_not_called()
+
+    @patch("shomer.email.backend.smtplib.SMTP")
+    def test_no_login_when_user_empty(self, mock_smtp_cls: MagicMock) -> None:
+        mock_server = MagicMock()
+        mock_smtp_cls.return_value.__enter__ = MagicMock(return_value=mock_server)
+        mock_smtp_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        backend = SmtpBackend(self._settings(smtp_user=""))
+        backend.send(to="a@b.com", subject="S", html_body="<p>X</p>")
+
+        mock_server.login.assert_not_called()
+
+    @patch("shomer.email.backend.smtplib.SMTP")
+    def test_smtp_error_propagates(self, mock_smtp_cls: MagicMock) -> None:
+        mock_server = MagicMock()
+        mock_smtp_cls.return_value.__enter__ = MagicMock(return_value=mock_server)
+        mock_smtp_cls.return_value.__exit__ = MagicMock(return_value=False)
+        mock_server.sendmail.side_effect = smtplib.SMTPException("fail")
+
+        backend = SmtpBackend(self._settings())
+        with pytest.raises(smtplib.SMTPException, match="fail"):
+            backend.send(to="a@b.com", subject="S", html_body="<p>X</p>")
+
+    @patch("shomer.email.backend.smtplib.SMTP")
+    def test_from_header_format(self, mock_smtp_cls: MagicMock) -> None:
+        mock_server = MagicMock()
+        mock_smtp_cls.return_value.__enter__ = MagicMock(return_value=mock_server)
+        mock_smtp_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        backend = SmtpBackend(self._settings())
+        backend.send(to="a@b.com", subject="S", html_body="<p>X</p>")
+
+        sent_msg = mock_server.sendmail.call_args[0][2]
+        assert "Test <noreply@example.com>" in sent_msg

--- a/tests/email_service/test_renderer.py
+++ b/tests/email_service/test_renderer.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Unit tests for Jinja2 email template renderer."""
+
+from pathlib import Path
+from textwrap import dedent
+
+from shomer.email.renderer import create_env, render_template
+
+
+class TestCreateEnv:
+    """Tests for create_env()."""
+
+    def test_returns_environment(self, tmp_path: Path) -> None:
+        env = create_env(tmp_path)
+        assert env is not None
+
+    def test_autoescape_enabled(self, tmp_path: Path) -> None:
+        env = create_env(tmp_path)
+        assert callable(env.autoescape) or env.autoescape is True
+
+
+class TestRenderTemplate:
+    """Tests for render_template()."""
+
+    def test_renders_simple_template(self, tmp_path: Path) -> None:
+        (tmp_path / "hello.html").write_text("Hello {{ name }}!")
+        result = render_template("hello.html", {"name": "World"}, template_dir=tmp_path)
+        assert result == "Hello World!"
+
+    def test_autoescapes_html(self, tmp_path: Path) -> None:
+        (tmp_path / "escape.html").write_text("{{ value }}")
+        result = render_template(
+            "escape.html", {"value": "<script>alert(1)</script>"}, template_dir=tmp_path
+        )
+        assert "<script>" not in result
+        assert "&lt;script&gt;" in result
+
+    def test_renders_with_block_inheritance(self, tmp_path: Path) -> None:
+        (tmp_path / "base.html").write_text(
+            dedent("""\
+            <html>{% block content %}{% endblock %}</html>""")
+        )
+        (tmp_path / "child.html").write_text(
+            dedent("""\
+            {% extends "base.html" %}
+            {% block content %}Hi {{ name }}{% endblock %}""")
+        )
+        result = render_template("child.html", {"name": "Alice"}, template_dir=tmp_path)
+        assert "<html>Hi Alice</html>" == result
+
+    def test_empty_context(self, tmp_path: Path) -> None:
+        (tmp_path / "static.html").write_text("No variables here.")
+        result = render_template("static.html", {}, template_dir=tmp_path)
+        assert result == "No variables here."

--- a/tests/email_service/test_service.py
+++ b/tests/email_service/test_service.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Unit tests for EmailService."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from shomer.core.settings import Settings
+from shomer.email.backend import EmailBackend
+from shomer.email.service import EmailService
+
+
+class TestEmailService:
+    """Tests for EmailService.send_email()."""
+
+    def test_renders_and_sends(self, tmp_path: Path) -> None:
+        (tmp_path / "test.html").write_text("Hello {{ name }}!")
+
+        mock_backend = MagicMock(spec=EmailBackend)
+        service = EmailService(Settings(), backend=mock_backend)
+        service.send_email(
+            to="user@example.com",
+            subject="Welcome",
+            template="test.html",
+            context={"name": "Bob"},
+            template_dir=tmp_path,
+        )
+
+        mock_backend.send.assert_called_once_with(
+            to="user@example.com",
+            subject="Welcome",
+            html_body="Hello Bob!",
+        )
+
+    def test_empty_context_defaults_to_empty_dict(self, tmp_path: Path) -> None:
+        (tmp_path / "static.html").write_text("Static content")
+
+        mock_backend = MagicMock(spec=EmailBackend)
+        service = EmailService(Settings(), backend=mock_backend)
+        service.send_email(
+            to="a@b.com",
+            subject="S",
+            template="static.html",
+            template_dir=tmp_path,
+        )
+
+        mock_backend.send.assert_called_once_with(
+            to="a@b.com",
+            subject="S",
+            html_body="Static content",
+        )
+
+    def test_uses_smtp_backend_by_default(self) -> None:
+        from shomer.email.backend import SmtpBackend
+
+        service = EmailService(Settings())
+        assert isinstance(service.backend, SmtpBackend)

--- a/tests/email_service/test_tasks.py
+++ b/tests/email_service/test_tasks.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Unit tests for Celery email tasks."""
+
+from shomer.tasks.email import MAX_RETRIES, RETRY_BACKOFF, send_email_task
+
+
+class TestSendEmailTask:
+    """Tests for send_email_task Celery task."""
+
+    def test_task_is_registered(self) -> None:
+        assert send_email_task.name is not None
+
+    def test_max_retries_configured(self) -> None:
+        assert send_email_task.max_retries == MAX_RETRIES
+
+    def test_retry_backoff_configured(self) -> None:
+        assert send_email_task.default_retry_delay == RETRY_BACKOFF
+
+    def test_autoretry_for_os_error(self) -> None:
+        assert OSError in send_email_task.autoretry_for


### PR DESCRIPTION
## feat(email): email sending service (SMTP) via Celery

## Summary

Async email sending service with SMTP backend, dispatched via Celery tasks. Jinja2 templates for HTML rendering.

## Changes

- [x] Email service interface (send_email with subject, to, template, context)
- [x] SMTP backend implementation
- [x] Celery task wrapper for async dispatch
- [x] Jinja2 template rendering engine
- [x] Unit tests with mock SMTP server
- [x] Retry policy for transient failures

## Dependencies

- #2 - configuration

## Related Issue

Closes #10

## Test Plan

- [x] `make format` - code formatted
- [x] `make lint` - no linting errors
- [x] `make typecheck` - type checks pass
- [x] `make test` - all unit tests pass (102 passed)
- [x] `make bdd` - all BDD tests pass (6 scenarios, 20 steps)
- [x] `make check-license` - SPDX headers present