### PR TITLE
feat(jwks): JWK model with encrypted private key

### DIFF
--- a/alembic/versions/0006_add_jwks.py
+++ b/alembic/versions/0006_add_jwks.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Add jwks table.
+
+Revision ID: 0006
+Revises: 0005
+Create Date: 2026-03-18
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0006"
+down_revision: Union[str, None] = "0005"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create jwks table."""
+    op.create_table(
+        "jwks",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("kid", sa.String(255), nullable=False),
+        sa.Column("algorithm", sa.String(20), nullable=False),
+        sa.Column("public_key", sa.Text(), nullable=False),
+        sa.Column("private_key_enc", sa.LargeBinary(), nullable=False),
+        sa.Column(
+            "status",
+            sa.String(7),
+            nullable=False,
+            server_default="active",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_jwks")),
+        sa.UniqueConstraint("kid", name=op.f("uq_jwks_kid")),
+    )
+    op.create_index(op.f("ix_jwks_kid"), "jwks", ["kid"])
+    op.create_index(op.f("ix_jwks_status"), "jwks", ["status"])
+
+
+def downgrade() -> None:
+    """Drop jwks table."""
+    op.drop_table("jwks")

--- a/src/shomer/models/jwk.py
+++ b/src/shomer/models/jwk.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""JWK model with encrypted private key storage."""
+
+from __future__ import annotations
+
+import enum
+
+from sqlalchemy import Enum, LargeBinary, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from shomer.core.database import Base, TimestampMixin, UUIDMixin
+
+
+class JWKStatus(str, enum.Enum):
+    """Lifecycle status of a JSON Web Key.
+
+    Attributes
+    ----------
+    ACTIVE
+        Key is in use for signing.
+    ROTATED
+        Key has been replaced but can still verify old tokens.
+    REVOKED
+        Key is permanently disabled.
+    """
+
+    ACTIVE = "active"
+    ROTATED = "rotated"
+    REVOKED = "revoked"
+
+
+class JWK(Base, UUIDMixin, TimestampMixin):
+    """JSON Web Key with AES-256-GCM encrypted private key.
+
+    The private key is stored as AES-256-GCM ciphertext (nonce + ciphertext).
+    The public key is stored as a JWK JSON string in clear text.
+
+    Attributes
+    ----------
+    id : uuid.UUID
+        Primary key (from UUIDMixin).
+    kid : str
+        Key ID (unique, indexed).
+    algorithm : str
+        JWA algorithm identifier (e.g. ``RS256``).
+    public_key : str
+        Public key in JWK JSON format.
+    private_key_enc : bytes
+        AES-256-GCM encrypted private key material.
+    status : JWKStatus
+        Key lifecycle status.
+    created_at : datetime
+        Row creation timestamp (from TimestampMixin).
+    updated_at : datetime
+        Last update timestamp (from TimestampMixin).
+    """
+
+    __tablename__ = "jwks"
+
+    kid: Mapped[str] = mapped_column(
+        String(255),
+        unique=True,
+        nullable=False,
+        index=True,
+    )
+    algorithm: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+    )
+    public_key: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+    )
+    private_key_enc: Mapped[bytes] = mapped_column(
+        LargeBinary,
+        nullable=False,
+    )
+    status: Mapped[JWKStatus] = mapped_column(
+        Enum(JWKStatus, name="jwk_status", native_enum=False),
+        default=JWKStatus.ACTIVE,
+        nullable=False,
+        index=True,
+    )
+
+    def __repr__(self) -> str:
+        return f"<JWK kid={self.kid} alg={self.algorithm} status={self.status.value}>"

--- a/tests/models/test_jwk.py
+++ b/tests/models/test_jwk.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Unit tests for JWK model."""
+
+import json
+
+from shomer.core.security import AESEncryption
+from shomer.models.jwk import JWK, JWKStatus
+
+
+class TestJWKStatus:
+    """Tests for JWKStatus enum."""
+
+    def test_active_value(self) -> None:
+        assert JWKStatus.ACTIVE.value == "active"
+
+    def test_rotated_value(self) -> None:
+        assert JWKStatus.ROTATED.value == "rotated"
+
+    def test_revoked_value(self) -> None:
+        assert JWKStatus.REVOKED.value == "revoked"
+
+    def test_is_str_enum(self) -> None:
+        assert isinstance(JWKStatus.ACTIVE, str)
+
+
+class TestJWKModel:
+    """Tests for JWK SQLAlchemy model definition."""
+
+    def test_tablename(self) -> None:
+        assert JWK.__tablename__ == "jwks"
+
+    def test_required_fields(self) -> None:
+        enc = AESEncryption(AESEncryption.generate_key())
+        priv_enc = enc.encrypt(b"private-key-material")
+        pub_json = json.dumps({"kty": "RSA", "n": "...", "e": "AQAB"})
+
+        jwk = JWK(
+            kid="key-2026-01",
+            algorithm="RS256",
+            public_key=pub_json,
+            private_key_enc=priv_enc,
+        )
+        assert jwk.kid == "key-2026-01"
+        assert jwk.algorithm == "RS256"
+        assert jwk.public_key == pub_json
+        assert jwk.private_key_enc == priv_enc
+
+    def test_encrypted_private_key_roundtrip(self) -> None:
+        key = AESEncryption.generate_key()
+        enc = AESEncryption(key)
+        plaintext = b"super-secret-rsa-key"
+        ciphertext = enc.encrypt(plaintext)
+
+        jwk = JWK(
+            kid="rt-1",
+            algorithm="RS256",
+            public_key="{}",
+            private_key_enc=ciphertext,
+        )
+
+        dec = AESEncryption(key)
+        assert dec.decrypt(jwk.private_key_enc) == plaintext
+
+    def test_status_default(self) -> None:
+        col = JWK.__table__.c.status
+        assert col.default.arg is JWKStatus.ACTIVE
+
+    def test_kid_column_unique(self) -> None:
+        col = JWK.__table__.c.kid
+        assert col.unique is True
+
+    def test_kid_column_indexed(self) -> None:
+        col = JWK.__table__.c.kid
+        assert col.index is True
+
+    def test_kid_column_not_nullable(self) -> None:
+        col = JWK.__table__.c.kid
+        assert col.nullable is False
+
+    def test_status_column_indexed(self) -> None:
+        col = JWK.__table__.c.status
+        assert col.index is True
+
+    def test_status_column_not_nullable(self) -> None:
+        col = JWK.__table__.c.status
+        assert col.nullable is False
+
+    def test_public_key_not_nullable(self) -> None:
+        col = JWK.__table__.c.public_key
+        assert col.nullable is False
+
+    def test_private_key_enc_not_nullable(self) -> None:
+        col = JWK.__table__.c.private_key_enc
+        assert col.nullable is False
+
+    def test_algorithm_not_nullable(self) -> None:
+        col = JWK.__table__.c.algorithm
+        assert col.nullable is False
+
+    def test_repr(self) -> None:
+        jwk = JWK(
+            kid="test-kid",
+            algorithm="RS256",
+            public_key="{}",
+            private_key_enc=b"enc",
+            status=JWKStatus.ROTATED,
+        )
+        r = repr(jwk)
+        assert "kid=test-kid" in r
+        assert "alg=RS256" in r
+        assert "status=rotated" in r
+
+    def test_all_statuses_assignable(self) -> None:
+        for status in JWKStatus:
+            jwk = JWK(
+                kid=f"k-{status.value}",
+                algorithm="RS256",
+                public_key="{}",
+                private_key_enc=b"x",
+                status=status,
+            )
+            assert jwk.status == status


### PR DESCRIPTION
## feat(jwks): JWK model with encrypted private key

## Summary

JWK model storing kid, algorithm, public key in clear text, and private key encrypted with AES-256-GCM. Supports key statuses: active, rotated, revoked.

## Changes

- [x] JWK model with status enum (active, rotated, revoked)
- [x] AES-256-GCM encrypted private key column
- [x] Public key stored as JWK JSON
- [x] Indexes on kid and status
- [x] Alembic migration

## Dependencies

- #1 - AES-256-GCM encryption module
- #3 - declarative base

## Related Issue

Closes #11

## Test Plan

- [x] `make format` - code formatted
- [x] `make lint` - no linting errors
- [x] `make typecheck` - type checks pass
- [x] `make test` - all unit tests pass (183 passed)
- [x] `make bdd` - all BDD tests pass (6 scenarios, 20 steps)
- [x] `make check-license` - SPDX headers present