### PR TITLE
feat(token): JWT creation service (access_token, id_token)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2248,6 +2248,28 @@ files = [
 windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
+name = "pyjwt"
+version = "2.12.1"
+description = "JSON Web Token implementation in Python"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "extra == \"server\""
+files = [
+    {file = "pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c"},
+    {file = "pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b"},
+]
+
+[package.dependencies]
+typing_extensions = {version = ">=4.0", markers = "python_version < \"3.11\""}
+
+[package.extras]
+crypto = ["cryptography (>=3.4.0)"]
+dev = ["coverage[toml] (==7.10.7)", "cryptography (>=3.4.0)", "pre-commit", "pytest (>=8.4.2,<9.0.0)", "sphinx", "sphinx-rtd-theme", "zope.interface"]
+docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
+tests = ["coverage[toml] (==7.10.7)", "pytest (>=8.4.2,<9.0.0)"]
+
+[[package]]
 name = "pymdown-extensions"
 version = "10.16.1"
 description = "Extension pack for Python Markdown."
@@ -3197,10 +3219,10 @@ files = [
 ]
 
 [extras]
-server = ["alembic", "argon2-cffi", "asyncpg", "cryptography", "fastapi", "jinja2", "sqlalchemy", "uvicorn"]
+server = ["alembic", "argon2-cffi", "asyncpg", "cryptography", "fastapi", "jinja2", "pyjwt", "sqlalchemy", "uvicorn"]
 worker = ["celery"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10"
-content-hash = "2c6f008e2ee574f58238c16968cadba3043dd37412d10a373a3046291abcfb2b"
+content-hash = "67165a82b81f7ca095770c45d3e4785938e11c8de238432d92464485abd96cf9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,9 +59,10 @@ alembic = {version = "*", optional = true}
 celery = {extras = ["redis"], version = "*", optional = true}
 argon2-cffi = {version = "*", optional = true}
 cryptography = {version = "*", optional = true}
+pyjwt = {version = "*", optional = true}
 
 [tool.poetry.extras]
-server = ["fastapi", "uvicorn", "jinja2", "sqlalchemy", "asyncpg", "alembic", "argon2-cffi", "cryptography"]
+server = ["fastapi", "uvicorn", "jinja2", "sqlalchemy", "asyncpg", "alembic", "argon2-cffi", "cryptography", "pyjwt"]
 worker = ["celery"]
 
 [tool.poetry.group.dev]

--- a/src/shomer/core/settings.py
+++ b/src/shomer/core/settings.py
@@ -111,6 +111,12 @@ class Settings(BaseSettings):
         Base64-encoded AES-256 key for encrypting JWK private keys.
     rsa_key_size : int
         RSA key size in bits (2048 or 4096).
+    jwt_issuer : str
+        ``iss`` claim value for issued JWTs.
+    jwt_access_token_exp : int
+        Access token lifetime in seconds (default 3600).
+    jwt_id_token_exp : int
+        ID token lifetime in seconds (default 3600).
     celery_backend_password : str
         Celery result backend Redis password (loaded via ``get_credential``).
     """
@@ -146,9 +152,12 @@ class Settings(BaseSettings):
     redis_db: int = 0
     redis_password: str = ""
 
-    # JWK / RSA
+    # JWK / RSA / JWT
     jwk_encryption_key: str = ""
     rsa_key_size: int = 2048
+    jwt_issuer: str = "https://auth.shomer.local"
+    jwt_access_token_exp: int = 3600
+    jwt_id_token_exp: int = 3600
 
     # Email / SMTP
     smtp_host: str = "localhost"

--- a/src/shomer/services/jwt_service.py
+++ b/src/shomer/services/jwt_service.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""JWT creation service using RS256."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import jwt
+from cryptography.hazmat.primitives.serialization import load_pem_private_key
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from shomer.core.security import AESEncryption
+from shomer.core.settings import Settings
+from shomer.services.jwk_service import JWKService
+
+
+class JWTService:
+    """Create signed JWTs (access tokens and ID tokens) using the active RSA key.
+
+    Attributes
+    ----------
+    settings : Settings
+        Application configuration.
+    jwk_service : JWKService
+        Key management service for retrieving the active signing key.
+    encryption : AESEncryption
+        Cipher for decrypting private key material.
+    """
+
+    def __init__(
+        self,
+        settings: Settings,
+        session: AsyncSession,
+        encryption: AESEncryption,
+    ) -> None:
+        self.settings = settings
+        self.encryption = encryption
+        self.jwk_service = JWKService(
+            session, encryption, key_size=settings.rsa_key_size
+        )
+
+    async def create_access_token(
+        self,
+        *,
+        sub: str,
+        aud: str | list[str],
+        scopes: list[str] | None = None,
+        extra_claims: dict[str, Any] | None = None,
+    ) -> str:
+        """Create a signed access token.
+
+        Parameters
+        ----------
+        sub : str
+            Subject identifier (user ID).
+        aud : str or list[str]
+            Audience claim.
+        scopes : list[str] or None
+            OAuth2 scopes to embed in the ``scope`` claim.
+        extra_claims : dict[str, Any] or None
+            Additional claims to include.
+
+        Returns
+        -------
+        str
+            Encoded JWT string.
+
+        Raises
+        ------
+        RuntimeError
+            If no active signing key exists.
+        """
+        claims: dict[str, Any] = {}
+        if scopes:
+            claims["scope"] = " ".join(scopes)
+        if extra_claims:
+            claims.update(extra_claims)
+
+        return await self._sign(
+            sub=sub,
+            aud=aud,
+            exp_seconds=self.settings.jwt_access_token_exp,
+            extra_claims=claims,
+            token_type="access_token",
+        )
+
+    async def create_id_token(
+        self,
+        *,
+        sub: str,
+        aud: str | list[str],
+        nonce: str | None = None,
+        extra_claims: dict[str, Any] | None = None,
+    ) -> str:
+        """Create a signed OIDC ID token.
+
+        Parameters
+        ----------
+        sub : str
+            Subject identifier (user ID).
+        aud : str or list[str]
+            Audience claim (client_id).
+        nonce : str or None
+            Nonce from the authorization request.
+        extra_claims : dict[str, Any] or None
+            Additional OIDC claims (name, email, etc.).
+
+        Returns
+        -------
+        str
+            Encoded JWT string.
+
+        Raises
+        ------
+        RuntimeError
+            If no active signing key exists.
+        """
+        claims: dict[str, Any] = {}
+        if nonce:
+            claims["nonce"] = nonce
+        if extra_claims:
+            claims.update(extra_claims)
+
+        return await self._sign(
+            sub=sub,
+            aud=aud,
+            exp_seconds=self.settings.jwt_id_token_exp,
+            extra_claims=claims,
+            token_type="id_token",
+        )
+
+    async def _sign(
+        self,
+        *,
+        sub: str,
+        aud: str | list[str],
+        exp_seconds: int,
+        extra_claims: dict[str, Any],
+        token_type: str,
+    ) -> str:
+        """Build and sign a JWT with standard claims.
+
+        Parameters
+        ----------
+        sub : str
+            Subject identifier.
+        aud : str or list[str]
+            Audience claim.
+        exp_seconds : int
+            Token lifetime in seconds.
+        extra_claims : dict[str, Any]
+            Extra claims merged into the payload.
+        token_type : str
+            Token type hint (for future extensibility).
+
+        Returns
+        -------
+        str
+            Signed JWT.
+
+        Raises
+        ------
+        RuntimeError
+            If no active signing key is available.
+        """
+        active_key = await self.jwk_service.get_active_signing_key()
+        if active_key is None:
+            raise RuntimeError("No active signing key available")
+
+        now = datetime.now(timezone.utc)
+        payload: dict[str, Any] = {
+            "iss": self.settings.jwt_issuer,
+            "sub": sub,
+            "aud": aud,
+            "exp": now + timedelta(seconds=exp_seconds),
+            "iat": now,
+            "jti": uuid.uuid4().hex,
+            **extra_claims,
+        }
+
+        # Decrypt private key
+        private_pem = self.encryption.decrypt(active_key.private_key_enc)
+        private_key = load_pem_private_key(private_pem, password=None)
+
+        return jwt.encode(
+            payload,
+            private_key,  # type: ignore[arg-type]
+            algorithm=active_key.algorithm,
+            headers={"kid": active_key.kid},
+        )

--- a/tests/services/test_jwt_service.py
+++ b/tests/services/test_jwt_service.py
@@ -1,0 +1,271 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Unit tests for JWT creation service."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Iterator
+
+import jwt
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from shomer.core.database import Base
+from shomer.core.security import AESEncryption
+from shomer.core.settings import Settings
+from shomer.models.jwk import JWK  # noqa: F401
+from shomer.models.password_reset_token import PasswordResetToken  # noqa: F401
+from shomer.models.session import Session  # noqa: F401
+from shomer.models.user import User  # noqa: F401
+from shomer.models.user_email import UserEmail  # noqa: F401
+from shomer.models.user_password import UserPassword  # noqa: F401
+from shomer.models.user_profile import UserProfile  # noqa: F401
+from shomer.models.verification_code import VerificationCode  # noqa: F401
+from shomer.services.jwk_service import JWKService
+from shomer.services.jwt_service import JWTService
+
+_ENGINE = create_async_engine(
+    "sqlite+aiosqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+_SESSION_FACTORY = async_sessionmaker(_ENGINE, expire_on_commit=False)
+
+
+@pytest.fixture(autouse=True)
+def _setup_db() -> Iterator[None]:
+    """Create and drop tables for each test."""
+
+    async def _create() -> None:
+        async with _ENGINE.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+    asyncio.run(_create())
+    yield
+
+    async def _drop() -> None:
+        async with _ENGINE.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+
+    asyncio.run(_drop())
+
+
+def _make_settings(**overrides: object) -> Settings:
+    defaults = {
+        "jwt_issuer": "https://test.shomer.local",
+        "jwt_access_token_exp": 3600,
+        "jwt_id_token_exp": 1800,
+        "rsa_key_size": 2048,
+    }
+    defaults.update(overrides)
+    return Settings(**defaults)  # type: ignore[arg-type]
+
+
+class TestCreateAccessToken:
+    """Tests for JWTService.create_access_token()."""
+
+    def test_creates_signed_jwt(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as session:
+                key = AESEncryption.generate_key()
+                enc = AESEncryption(key)
+                settings = _make_settings()
+
+                # Generate a signing key first
+                jwk_svc = JWKService(session, enc, key_size=2048)
+                active_key = await jwk_svc.generate_key()
+
+                svc = JWTService(settings, session, enc)
+                token = await svc.create_access_token(sub="user-123", aud="client-abc")
+
+                # Decode with public key
+                pub_jwk = json.loads(active_key.public_key)
+                pub_key = jwt.algorithms.RSAAlgorithm.from_jwk(pub_jwk)
+                decoded = jwt.decode(
+                    token,
+                    pub_key,  # type: ignore[arg-type]
+                    algorithms=["RS256"],
+                    audience="client-abc",
+                    issuer="https://test.shomer.local",
+                )
+                assert decoded["sub"] == "user-123"
+                assert decoded["aud"] == "client-abc"
+                assert decoded["iss"] == "https://test.shomer.local"
+
+        asyncio.run(_run())
+
+    def test_includes_standard_claims(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as session:
+                key = AESEncryption.generate_key()
+                enc = AESEncryption(key)
+                settings = _make_settings()
+
+                jwk_svc = JWKService(session, enc, key_size=2048)
+                active_key = await jwk_svc.generate_key()
+
+                svc = JWTService(settings, session, enc)
+                token = await svc.create_access_token(sub="u1", aud="c1")
+
+                pub_jwk = json.loads(active_key.public_key)
+                pub_key = jwt.algorithms.RSAAlgorithm.from_jwk(pub_jwk)
+                decoded = jwt.decode(
+                    token,
+                    pub_key,  # type: ignore[arg-type]
+                    algorithms=["RS256"],
+                    audience="c1",
+                )
+                assert "iat" in decoded
+                assert "exp" in decoded
+                assert "jti" in decoded
+
+        asyncio.run(_run())
+
+    def test_embeds_scopes(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as session:
+                key = AESEncryption.generate_key()
+                enc = AESEncryption(key)
+                settings = _make_settings()
+
+                jwk_svc = JWKService(session, enc, key_size=2048)
+                active_key = await jwk_svc.generate_key()
+
+                svc = JWTService(settings, session, enc)
+                token = await svc.create_access_token(
+                    sub="u1", aud="c1", scopes=["openid", "profile"]
+                )
+
+                pub_jwk = json.loads(active_key.public_key)
+                pub_key = jwt.algorithms.RSAAlgorithm.from_jwk(pub_jwk)
+                decoded = jwt.decode(
+                    token,
+                    pub_key,  # type: ignore[arg-type]
+                    algorithms=["RS256"],
+                    audience="c1",
+                )
+                assert decoded["scope"] == "openid profile"
+
+        asyncio.run(_run())
+
+    def test_kid_header(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as session:
+                key = AESEncryption.generate_key()
+                enc = AESEncryption(key)
+                settings = _make_settings()
+
+                jwk_svc = JWKService(session, enc, key_size=2048)
+                active_key = await jwk_svc.generate_key()
+
+                svc = JWTService(settings, session, enc)
+                token = await svc.create_access_token(sub="u1", aud="c1")
+
+                header = jwt.get_unverified_header(token)
+                assert header["kid"] == active_key.kid
+                assert header["alg"] == "RS256"
+
+        asyncio.run(_run())
+
+    def test_raises_without_active_key(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as session:
+                key = AESEncryption.generate_key()
+                enc = AESEncryption(key)
+                settings = _make_settings()
+
+                svc = JWTService(settings, session, enc)
+                with pytest.raises(RuntimeError, match="No active signing key"):
+                    await svc.create_access_token(sub="u1", aud="c1")
+
+        asyncio.run(_run())
+
+
+class TestCreateIdToken:
+    """Tests for JWTService.create_id_token()."""
+
+    def test_creates_id_token_with_nonce(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as session:
+                key = AESEncryption.generate_key()
+                enc = AESEncryption(key)
+                settings = _make_settings()
+
+                jwk_svc = JWKService(session, enc, key_size=2048)
+                active_key = await jwk_svc.generate_key()
+
+                svc = JWTService(settings, session, enc)
+                token = await svc.create_id_token(sub="u1", aud="c1", nonce="abc123")
+
+                pub_jwk = json.loads(active_key.public_key)
+                pub_key = jwt.algorithms.RSAAlgorithm.from_jwk(pub_jwk)
+                decoded = jwt.decode(
+                    token,
+                    pub_key,  # type: ignore[arg-type]
+                    algorithms=["RS256"],
+                    audience="c1",
+                )
+                assert decoded["nonce"] == "abc123"
+
+        asyncio.run(_run())
+
+    def test_id_token_uses_configured_exp(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as session:
+                key = AESEncryption.generate_key()
+                enc = AESEncryption(key)
+                settings = _make_settings(jwt_id_token_exp=600)
+
+                jwk_svc = JWKService(session, enc, key_size=2048)
+                active_key = await jwk_svc.generate_key()
+
+                svc = JWTService(settings, session, enc)
+                token = await svc.create_id_token(sub="u1", aud="c1")
+
+                pub_jwk = json.loads(active_key.public_key)
+                pub_key = jwt.algorithms.RSAAlgorithm.from_jwk(pub_jwk)
+                decoded = jwt.decode(
+                    token,
+                    pub_key,  # type: ignore[arg-type]
+                    algorithms=["RS256"],
+                    audience="c1",
+                )
+                # exp - iat should be ~600
+                diff = decoded["exp"] - decoded["iat"]
+                assert diff == 600
+
+        asyncio.run(_run())
+
+    def test_extra_claims(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as session:
+                key = AESEncryption.generate_key()
+                enc = AESEncryption(key)
+                settings = _make_settings()
+
+                jwk_svc = JWKService(session, enc, key_size=2048)
+                active_key = await jwk_svc.generate_key()
+
+                svc = JWTService(settings, session, enc)
+                token = await svc.create_id_token(
+                    sub="u1",
+                    aud="c1",
+                    extra_claims={"email": "user@example.com", "name": "Test"},
+                )
+
+                pub_jwk = json.loads(active_key.public_key)
+                pub_key = jwt.algorithms.RSAAlgorithm.from_jwk(pub_jwk)
+                decoded = jwt.decode(
+                    token,
+                    pub_key,  # type: ignore[arg-type]
+                    algorithms=["RS256"],
+                    audience="c1",
+                )
+                assert decoded["email"] == "user@example.com"
+                assert decoded["name"] == "Test"
+
+        asyncio.run(_run())


### PR DESCRIPTION
## feat(token): JWT creation service (access_token, id_token)

## Summary

JWT signing service using RS256 for access_token and id_token. Standard claims: iss, sub, aud, exp, iat, jti. Support for scopes and OIDC claims.

## Changes

- [x] JWT creation with RS256 signing via active JWK
- [x] Standard claims population (iss, sub, aud, exp, iat, jti)
- [x] Scope embedding in token claims
- [x] `kid` header from active signing key
- [x] Configurable expiration per token type
- [x] Unit tests

## Dependencies

- #12 - RSA key service

## Related Issue

Closes #14

## Test Plan

- [x] `make format` - code formatted
- [x] `make lint` - no linting errors
- [x] `make typecheck` - type checks pass
- [x] `make test` - all unit tests pass (206 passed)
- [x] `make bdd` - all BDD tests pass (6 scenarios, 20 steps)
- [x] `make check-license` - SPDX headers present