### PR TITLE
feat(token): JWT validation service (signature, claims, expiry)

### DIFF
--- a/src/shomer/core/settings.py
+++ b/src/shomer/core/settings.py
@@ -117,6 +117,8 @@ class Settings(BaseSettings):
         Access token lifetime in seconds (default 3600).
     jwt_id_token_exp : int
         ID token lifetime in seconds (default 3600).
+    jwt_clock_skew : int
+        Allowed clock skew in seconds for token validation.
     celery_backend_password : str
         Celery result backend Redis password (loaded via ``get_credential``).
     """
@@ -158,6 +160,7 @@ class Settings(BaseSettings):
     jwt_issuer: str = "https://auth.shomer.local"
     jwt_access_token_exp: int = 3600
     jwt_id_token_exp: int = 3600
+    jwt_clock_skew: int = 30
 
     # Email / SMTP
     smtp_host: str = "localhost"

--- a/src/shomer/services/jwt_validation_service.py
+++ b/src/shomer/services/jwt_validation_service.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""JWT validation service with signature verification and claims checking."""
+
+from __future__ import annotations
+
+import enum
+import json
+from dataclasses import dataclass
+from typing import Any
+
+import jwt
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from shomer.core.settings import Settings
+from shomer.models.jwk import JWK, JWKStatus
+
+
+class TokenError(enum.Enum):
+    """Specific error codes for JWT validation failures.
+
+    Attributes
+    ----------
+    EXPIRED
+        The token has expired.
+    INVALID_SIGNATURE
+        The signature does not match any known key.
+    INVALID_CLAIMS
+        Required claims are missing or invalid (iss, aud).
+    KEY_NOT_FOUND
+        The ``kid`` in the token header does not match any non-revoked key.
+    DECODE_ERROR
+        The token is malformed or cannot be decoded.
+    """
+
+    EXPIRED = "expired"
+    INVALID_SIGNATURE = "invalid_signature"
+    INVALID_CLAIMS = "invalid_claims"
+    KEY_NOT_FOUND = "key_not_found"
+    DECODE_ERROR = "decode_error"
+
+
+@dataclass(frozen=True)
+class TokenValidationResult:
+    """Result of a JWT validation attempt.
+
+    Attributes
+    ----------
+    valid : bool
+        Whether the token is valid.
+    claims : dict[str, Any] or None
+        Decoded claims if valid, ``None`` otherwise.
+    error : TokenError or None
+        Error code if invalid, ``None`` otherwise.
+    error_message : str
+        Human-readable error description.
+    """
+
+    valid: bool
+    claims: dict[str, Any] | None = None
+    error: TokenError | None = None
+    error_message: str = ""
+
+
+class JWTValidationService:
+    """Validate JWTs using RS256 with kid-based key lookup.
+
+    Attributes
+    ----------
+    settings : Settings
+        Application configuration.
+    session : AsyncSession
+        Database session for key lookup.
+    """
+
+    def __init__(self, settings: Settings, session: AsyncSession) -> None:
+        self.settings = settings
+        self.session = session
+
+    async def validate(
+        self,
+        token: str,
+        *,
+        audience: str | list[str] | None = None,
+    ) -> TokenValidationResult:
+        """Validate a JWT token.
+
+        Performs kid-based key lookup, RS256 signature verification,
+        and claims validation (iss, aud, exp, nbf) with configurable
+        clock skew tolerance.
+
+        Parameters
+        ----------
+        token : str
+            Encoded JWT string.
+        audience : str or list[str] or None
+            Expected audience. If ``None``, audience is not checked.
+
+        Returns
+        -------
+        TokenValidationResult
+            Validation result with claims or error details.
+        """
+        # Extract kid from header
+        try:
+            header = jwt.get_unverified_header(token)
+        except jwt.exceptions.DecodeError:
+            return TokenValidationResult(
+                valid=False,
+                error=TokenError.DECODE_ERROR,
+                error_message="Token is malformed",
+            )
+
+        kid = header.get("kid")
+        if not kid:
+            return TokenValidationResult(
+                valid=False,
+                error=TokenError.KEY_NOT_FOUND,
+                error_message="Token header missing kid",
+            )
+
+        # Look up key by kid (active or rotated)
+        public_key = await self._get_public_key(kid)
+        if public_key is None:
+            return TokenValidationResult(
+                valid=False,
+                error=TokenError.KEY_NOT_FOUND,
+                error_message=f"No non-revoked key found for kid={kid}",
+            )
+
+        # Verify signature and decode claims
+        decode_options: dict[str, Any] = {}
+        decode_kwargs: dict[str, Any] = {
+            "algorithms": ["RS256"],
+            "issuer": self.settings.jwt_issuer,
+            "leeway": self.settings.jwt_clock_skew,
+            "options": decode_options,
+        }
+        if audience is not None:
+            decode_kwargs["audience"] = audience
+        else:
+            decode_options["verify_aud"] = False
+
+        try:
+            claims = jwt.decode(token, public_key, **decode_kwargs)
+        except jwt.ExpiredSignatureError:
+            return TokenValidationResult(
+                valid=False,
+                error=TokenError.EXPIRED,
+                error_message="Token has expired",
+            )
+        except jwt.InvalidSignatureError:
+            return TokenValidationResult(
+                valid=False,
+                error=TokenError.INVALID_SIGNATURE,
+                error_message="Invalid token signature",
+            )
+        except (jwt.InvalidIssuerError, jwt.InvalidAudienceError) as exc:
+            return TokenValidationResult(
+                valid=False,
+                error=TokenError.INVALID_CLAIMS,
+                error_message=str(exc),
+            )
+        except jwt.DecodeError:
+            return TokenValidationResult(
+                valid=False,
+                error=TokenError.DECODE_ERROR,
+                error_message="Token decode failed",
+            )
+
+        return TokenValidationResult(valid=True, claims=claims)
+
+    async def _get_public_key(self, kid: str) -> Any:
+        """Look up a public key by kid from non-revoked keys.
+
+        Parameters
+        ----------
+        kid : str
+            Key ID from the JWT header.
+
+        Returns
+        -------
+        RSAPublicKey or None
+            The public key object, or ``None`` if not found.
+        """
+        stmt = select(JWK).where(
+            JWK.kid == kid,
+            JWK.status != JWKStatus.REVOKED,
+        )
+        result = await self.session.execute(stmt)
+        jwk = result.scalar_one_or_none()
+        if jwk is None:
+            return None
+
+        pub_jwk = json.loads(jwk.public_key)
+        return jwt.algorithms.RSAAlgorithm.from_jwk(pub_jwk)

--- a/tests/services/test_jwt_validation_service.py
+++ b/tests/services/test_jwt_validation_service.py
@@ -1,0 +1,454 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Unit tests for JWT validation service."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from collections.abc import Iterator
+from datetime import datetime, timedelta, timezone
+
+import jwt as pyjwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from shomer.core.database import Base
+from shomer.core.security import AESEncryption
+from shomer.core.settings import Settings
+from shomer.models.jwk import JWK, JWKStatus
+from shomer.models.password_reset_token import PasswordResetToken  # noqa: F401
+from shomer.models.session import Session  # noqa: F401
+from shomer.models.user import User  # noqa: F401
+from shomer.models.user_email import UserEmail  # noqa: F401
+from shomer.models.user_password import UserPassword  # noqa: F401
+from shomer.models.user_profile import UserProfile  # noqa: F401
+from shomer.models.verification_code import VerificationCode  # noqa: F401
+from shomer.services.jwt_validation_service import (
+    JWTValidationService,
+    TokenError,
+)
+
+_ENGINE = create_async_engine(
+    "sqlite+aiosqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+_SESSION_FACTORY = async_sessionmaker(_ENGINE, expire_on_commit=False)
+_ISSUER = "https://test.shomer.local"
+
+
+@pytest.fixture(autouse=True)
+def _setup_db() -> Iterator[None]:
+    """Create and drop tables for each test."""
+
+    async def _create() -> None:
+        async with _ENGINE.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+    asyncio.run(_create())
+    yield
+
+    async def _drop() -> None:
+        async with _ENGINE.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+
+    asyncio.run(_drop())
+
+
+def _settings(**overrides: object) -> Settings:
+    defaults = {"jwt_issuer": _ISSUER, "jwt_clock_skew": 5}
+    defaults.update(overrides)
+    return Settings(**defaults)  # type: ignore[arg-type]
+
+
+def _generate_rsa_pair() -> tuple[rsa.RSAPrivateKey, bytes]:
+    """Generate an RSA key pair, return (private_key, public_jwk_json)."""
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pub = private_key.public_key().public_numbers()
+    import base64
+
+    n_bytes = pub.n.to_bytes((pub.n.bit_length() + 7) // 8, byteorder="big")
+    e_bytes = pub.e.to_bytes((pub.e.bit_length() + 7) // 8, byteorder="big")
+    kid = f"test-{uuid.uuid4().hex[:8]}"
+    pub_jwk = json.dumps(
+        {
+            "kty": "RSA",
+            "kid": kid,
+            "alg": "RS256",
+            "use": "sig",
+            "n": base64.urlsafe_b64encode(n_bytes).rstrip(b"=").decode(),
+            "e": base64.urlsafe_b64encode(e_bytes).rstrip(b"=").decode(),
+        }
+    )
+    return private_key, pub_jwk.encode()
+
+
+async def _insert_key(
+    status: JWKStatus = JWKStatus.ACTIVE,
+) -> tuple[rsa.RSAPrivateKey, str]:
+    """Insert a JWK into the DB and return (private_key, kid)."""
+    private_key, pub_jwk_bytes = _generate_rsa_pair()
+    pub_jwk = json.loads(pub_jwk_bytes)
+    kid = pub_jwk["kid"]
+
+    enc_key = AESEncryption.generate_key()
+    enc = AESEncryption(enc_key)
+    priv_pem = private_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    )
+
+    async with _SESSION_FACTORY() as session:
+        jwk = JWK(
+            kid=kid,
+            algorithm="RS256",
+            public_key=pub_jwk_bytes.decode(),
+            private_key_enc=enc.encrypt(priv_pem),
+            status=status,
+        )
+        session.add(jwk)
+        await session.commit()
+
+    return private_key, kid
+
+
+def _sign_token(
+    private_key: rsa.RSAPrivateKey,
+    kid: str,
+    claims: dict[str, object],
+) -> str:
+    """Create a signed JWT."""
+    return pyjwt.encode(
+        claims,
+        private_key,
+        algorithm="RS256",
+        headers={"kid": kid},
+    )
+
+
+class TestValidToken:
+    """Tests for successful validation."""
+
+    def test_valid_token(self) -> None:
+        async def _run() -> None:
+            private_key, kid = await _insert_key()
+            now = datetime.now(timezone.utc)
+            token = _sign_token(
+                private_key,
+                kid,
+                {
+                    "iss": _ISSUER,
+                    "sub": "user-1",
+                    "aud": "client-1",
+                    "exp": now + timedelta(hours=1),
+                    "iat": now,
+                    "jti": uuid.uuid4().hex,
+                },
+            )
+
+            async with _SESSION_FACTORY() as session:
+                svc = JWTValidationService(_settings(), session)
+                result = await svc.validate(token, audience="client-1")
+                assert result.valid is True
+                assert result.claims is not None
+                assert result.claims["sub"] == "user-1"
+                assert result.error is None
+
+        asyncio.run(_run())
+
+    def test_valid_without_audience_check(self) -> None:
+        async def _run() -> None:
+            private_key, kid = await _insert_key()
+            now = datetime.now(timezone.utc)
+            token = _sign_token(
+                private_key,
+                kid,
+                {
+                    "iss": _ISSUER,
+                    "sub": "u",
+                    "exp": now + timedelta(hours=1),
+                    "iat": now,
+                },
+            )
+
+            async with _SESSION_FACTORY() as session:
+                svc = JWTValidationService(_settings(), session)
+                result = await svc.validate(token)
+                assert result.valid is True
+
+        asyncio.run(_run())
+
+    def test_rotated_key_still_valid(self) -> None:
+        async def _run() -> None:
+            private_key, kid = await _insert_key(status=JWKStatus.ROTATED)
+            now = datetime.now(timezone.utc)
+            token = _sign_token(
+                private_key,
+                kid,
+                {
+                    "iss": _ISSUER,
+                    "sub": "u",
+                    "exp": now + timedelta(hours=1),
+                    "iat": now,
+                },
+            )
+
+            async with _SESSION_FACTORY() as session:
+                svc = JWTValidationService(_settings(), session)
+                result = await svc.validate(token)
+                assert result.valid is True
+
+        asyncio.run(_run())
+
+
+class TestExpiredToken:
+    """Tests for expired tokens."""
+
+    def test_expired_token(self) -> None:
+        async def _run() -> None:
+            private_key, kid = await _insert_key()
+            now = datetime.now(timezone.utc)
+            token = _sign_token(
+                private_key,
+                kid,
+                {
+                    "iss": _ISSUER,
+                    "sub": "u",
+                    "exp": now - timedelta(hours=1),
+                    "iat": now,
+                },
+            )
+
+            async with _SESSION_FACTORY() as session:
+                svc = JWTValidationService(_settings(), session)
+                result = await svc.validate(token)
+                assert result.valid is False
+                assert result.error == TokenError.EXPIRED
+
+        asyncio.run(_run())
+
+
+class TestInvalidSignature:
+    """Tests for signature mismatches."""
+
+    def test_wrong_key_signature(self) -> None:
+        async def _run() -> None:
+            _, kid = await _insert_key()
+            # Sign with a different key
+            other_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+            now = datetime.now(timezone.utc)
+            token = _sign_token(
+                other_key,
+                kid,
+                {
+                    "iss": _ISSUER,
+                    "sub": "u",
+                    "exp": now + timedelta(hours=1),
+                    "iat": now,
+                },
+            )
+
+            async with _SESSION_FACTORY() as session:
+                svc = JWTValidationService(_settings(), session)
+                result = await svc.validate(token)
+                assert result.valid is False
+                assert result.error == TokenError.INVALID_SIGNATURE
+
+        asyncio.run(_run())
+
+
+class TestKeyNotFound:
+    """Tests for missing or revoked keys."""
+
+    def test_unknown_kid(self) -> None:
+        async def _run() -> None:
+            private_key, _ = await _insert_key()
+            now = datetime.now(timezone.utc)
+            token = _sign_token(
+                private_key,
+                "nonexistent-kid",
+                {
+                    "iss": _ISSUER,
+                    "sub": "u",
+                    "exp": now + timedelta(hours=1),
+                    "iat": now,
+                },
+            )
+
+            async with _SESSION_FACTORY() as session:
+                svc = JWTValidationService(_settings(), session)
+                result = await svc.validate(token)
+                assert result.valid is False
+                assert result.error == TokenError.KEY_NOT_FOUND
+
+        asyncio.run(_run())
+
+    def test_revoked_key_rejected(self) -> None:
+        async def _run() -> None:
+            private_key, kid = await _insert_key(status=JWKStatus.REVOKED)
+            now = datetime.now(timezone.utc)
+            token = _sign_token(
+                private_key,
+                kid,
+                {
+                    "iss": _ISSUER,
+                    "sub": "u",
+                    "exp": now + timedelta(hours=1),
+                    "iat": now,
+                },
+            )
+
+            async with _SESSION_FACTORY() as session:
+                svc = JWTValidationService(_settings(), session)
+                result = await svc.validate(token)
+                assert result.valid is False
+                assert result.error == TokenError.KEY_NOT_FOUND
+
+        asyncio.run(_run())
+
+
+class TestInvalidClaims:
+    """Tests for claims validation."""
+
+    def test_wrong_issuer(self) -> None:
+        async def _run() -> None:
+            private_key, kid = await _insert_key()
+            now = datetime.now(timezone.utc)
+            token = _sign_token(
+                private_key,
+                kid,
+                {
+                    "iss": "https://evil.com",
+                    "sub": "u",
+                    "exp": now + timedelta(hours=1),
+                    "iat": now,
+                },
+            )
+
+            async with _SESSION_FACTORY() as session:
+                svc = JWTValidationService(_settings(), session)
+                result = await svc.validate(token)
+                assert result.valid is False
+                assert result.error == TokenError.INVALID_CLAIMS
+
+        asyncio.run(_run())
+
+    def test_wrong_audience(self) -> None:
+        async def _run() -> None:
+            private_key, kid = await _insert_key()
+            now = datetime.now(timezone.utc)
+            token = _sign_token(
+                private_key,
+                kid,
+                {
+                    "iss": _ISSUER,
+                    "sub": "u",
+                    "aud": "other-client",
+                    "exp": now + timedelta(hours=1),
+                    "iat": now,
+                },
+            )
+
+            async with _SESSION_FACTORY() as session:
+                svc = JWTValidationService(_settings(), session)
+                result = await svc.validate(token, audience="expected-client")
+                assert result.valid is False
+                assert result.error == TokenError.INVALID_CLAIMS
+
+        asyncio.run(_run())
+
+
+class TestDecodeError:
+    """Tests for malformed tokens."""
+
+    def test_malformed_token(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as session:
+                svc = JWTValidationService(_settings(), session)
+                result = await svc.validate("not.a.jwt.at.all")
+                assert result.valid is False
+                assert result.error == TokenError.DECODE_ERROR
+
+        asyncio.run(_run())
+
+    def test_missing_kid_header(self) -> None:
+        async def _run() -> None:
+            private_key, _ = await _insert_key()
+            now = datetime.now(timezone.utc)
+            # Sign without kid header
+            token = pyjwt.encode(
+                {
+                    "iss": _ISSUER,
+                    "sub": "u",
+                    "exp": now + timedelta(hours=1),
+                    "iat": now,
+                },
+                private_key,
+                algorithm="RS256",
+            )
+
+            async with _SESSION_FACTORY() as session:
+                svc = JWTValidationService(_settings(), session)
+                result = await svc.validate(token)
+                assert result.valid is False
+                assert result.error == TokenError.KEY_NOT_FOUND
+
+        asyncio.run(_run())
+
+
+class TestClockSkew:
+    """Tests for clock skew tolerance."""
+
+    def test_within_skew_tolerance(self) -> None:
+        async def _run() -> None:
+            private_key, kid = await _insert_key()
+            now = datetime.now(timezone.utc)
+            # Token expired 3 seconds ago, skew is 5
+            token = _sign_token(
+                private_key,
+                kid,
+                {
+                    "iss": _ISSUER,
+                    "sub": "u",
+                    "exp": now - timedelta(seconds=3),
+                    "iat": now,
+                },
+            )
+
+            async with _SESSION_FACTORY() as session:
+                svc = JWTValidationService(_settings(jwt_clock_skew=5), session)
+                result = await svc.validate(token)
+                assert result.valid is True
+
+        asyncio.run(_run())
+
+    def test_beyond_skew_tolerance(self) -> None:
+        async def _run() -> None:
+            private_key, kid = await _insert_key()
+            now = datetime.now(timezone.utc)
+            # Token expired 10 seconds ago, skew is 5
+            token = _sign_token(
+                private_key,
+                kid,
+                {
+                    "iss": _ISSUER,
+                    "sub": "u",
+                    "exp": now - timedelta(seconds=10),
+                    "iat": now,
+                },
+            )
+
+            async with _SESSION_FACTORY() as session:
+                svc = JWTValidationService(_settings(jwt_clock_skew=5), session)
+                result = await svc.validate(token)
+                assert result.valid is False
+                assert result.error == TokenError.EXPIRED
+
+        asyncio.run(_run())


### PR DESCRIPTION
## feat(token): JWT validation service (signature, claims, expiry)

## Summary

JWT validation service: RS256 signature verification, claims validation (iss, aud, exp), multi-key support via kid lookup in JWKS.

## Changes

- [x] Signature verification with kid-based key lookup
- [x] Claims validation (iss, aud, exp, nbf)
- [x] Clock skew tolerance (configurable)
- [x] Specific error codes (expired, invalid_signature, invalid_claims)
- [x] Unit tests

## Dependencies

- #12 - RSA key service

## Related Issue

Closes #15

## Test Plan

- [x] `make format` - code formatted
- [x] `make lint` - no linting errors
- [x] `make typecheck` - type checks pass
- [x] `make test` - all unit tests pass (211 passed)
- [x] `make bdd` - all BDD tests pass (6 scenarios, 20 steps)
- [x] `make check-license` - SPDX headers present