### PR TITLE
feat(models): AccessToken and RefreshToken

### DIFF
--- a/alembic/versions/0007_add_access_and_refresh_tokens.py
+++ b/alembic/versions/0007_add_access_and_refresh_tokens.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Add access_tokens and refresh_tokens tables.
+
+Revision ID: 0007
+Revises: 0006
+Create Date: 2026-03-18
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0007"
+down_revision: Union[str, None] = "0006"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create access_tokens and refresh_tokens tables."""
+    op.create_table(
+        "access_tokens",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("jti", sa.String(255), nullable=False),
+        sa.Column("user_id", sa.Uuid(), nullable=False),
+        sa.Column("client_id", sa.String(255), nullable=False),
+        sa.Column("scopes", sa.Text(), nullable=False, server_default=""),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("revoked", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_access_tokens")),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            name=op.f("fk_access_tokens_user_id_users"),
+            ondelete="CASCADE",
+        ),
+        sa.UniqueConstraint("jti", name=op.f("uq_access_tokens_jti")),
+    )
+    op.create_index(op.f("ix_access_tokens_jti"), "access_tokens", ["jti"])
+    op.create_index(op.f("ix_access_tokens_user_id"), "access_tokens", ["user_id"])
+
+    op.create_table(
+        "refresh_tokens",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("token_hash", sa.Text(), nullable=False),
+        sa.Column("family_id", sa.Uuid(), nullable=False),
+        sa.Column("user_id", sa.Uuid(), nullable=False),
+        sa.Column("client_id", sa.String(255), nullable=False),
+        sa.Column("scopes", sa.Text(), nullable=False, server_default=""),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("revoked", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column("replaced_by", sa.Uuid(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_refresh_tokens")),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            name=op.f("fk_refresh_tokens_user_id_users"),
+            ondelete="CASCADE",
+        ),
+    )
+    op.create_index(
+        op.f("ix_refresh_tokens_family_id"), "refresh_tokens", ["family_id"]
+    )
+    op.create_index(op.f("ix_refresh_tokens_user_id"), "refresh_tokens", ["user_id"])
+
+
+def downgrade() -> None:
+    """Drop refresh_tokens and access_tokens tables."""
+    op.drop_table("refresh_tokens")
+    op.drop_table("access_tokens")

--- a/src/shomer/models/access_token.py
+++ b/src/shomer/models/access_token.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""AccessToken model for token storage and revocation."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+if TYPE_CHECKING:
+    from shomer.models.user import User
+
+from shomer.core.database import Base, TimestampMixin, UUIDMixin
+
+
+class AccessToken(Base, UUIDMixin, TimestampMixin):
+    """Persisted access token for lookup and revocation.
+
+    Attributes
+    ----------
+    id : uuid.UUID
+        Primary key (from UUIDMixin).
+    jti : str
+        JWT ID (unique token identifier, indexed).
+    user_id : uuid.UUID
+        Foreign key to the users table.
+    client_id : str
+        OAuth2 client that requested the token.
+    scopes : str
+        Space-separated list of granted scopes.
+    expires_at : datetime
+        Token expiration timestamp.
+    revoked : bool
+        Whether the token has been revoked.
+    created_at : datetime
+        Row creation timestamp (from TimestampMixin).
+    updated_at : datetime
+        Last update timestamp (from TimestampMixin).
+    """
+
+    __tablename__ = "access_tokens"
+
+    jti: Mapped[str] = mapped_column(
+        String(255),
+        unique=True,
+        nullable=False,
+        index=True,
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    client_id: Mapped[str] = mapped_column(
+        String(255),
+        nullable=False,
+    )
+    scopes: Mapped[str] = mapped_column(
+        Text,
+        default="",
+        nullable=False,
+    )
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+    )
+    revoked: Mapped[bool] = mapped_column(
+        Boolean,
+        default=False,
+        nullable=False,
+    )
+
+    # Relationships
+    user: Mapped[User] = relationship(back_populates="access_tokens")
+
+    def __repr__(self) -> str:
+        return f"<AccessToken jti={self.jti} revoked={self.revoked}>"

--- a/src/shomer/models/refresh_token.py
+++ b/src/shomer/models/refresh_token.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""RefreshToken model with rotation chain and reuse detection."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, String, Text, Uuid
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+if TYPE_CHECKING:
+    from shomer.models.user import User
+
+from shomer.core.database import Base, TimestampMixin, UUIDMixin
+
+
+class RefreshToken(Base, UUIDMixin, TimestampMixin):
+    """Persisted refresh token with rotation tracking.
+
+    The ``family_id`` groups all tokens in a rotation chain.
+    When a token is rotated, ``replaced_by`` points to the new token's ID.
+    If a revoked token's ``family_id`` is reused, the entire family
+    should be revoked (reuse detection).
+
+    Attributes
+    ----------
+    id : uuid.UUID
+        Primary key (from UUIDMixin).
+    token_hash : str
+        Hashed refresh token value.
+    family_id : uuid.UUID
+        Rotation family identifier for reuse detection.
+    user_id : uuid.UUID
+        Foreign key to the users table.
+    client_id : str
+        OAuth2 client that requested the token.
+    scopes : str
+        Space-separated list of granted scopes.
+    expires_at : datetime
+        Token expiration timestamp.
+    revoked : bool
+        Whether the token has been revoked.
+    replaced_by : uuid.UUID or None
+        ID of the token that replaced this one on rotation.
+    created_at : datetime
+        Row creation timestamp (from TimestampMixin).
+    updated_at : datetime
+        Last update timestamp (from TimestampMixin).
+    """
+
+    __tablename__ = "refresh_tokens"
+
+    token_hash: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+    )
+    family_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid,
+        nullable=False,
+        index=True,
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    client_id: Mapped[str] = mapped_column(
+        String(255),
+        nullable=False,
+    )
+    scopes: Mapped[str] = mapped_column(
+        Text,
+        default="",
+        nullable=False,
+    )
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+    )
+    revoked: Mapped[bool] = mapped_column(
+        Boolean,
+        default=False,
+        nullable=False,
+    )
+    replaced_by: Mapped[uuid.UUID | None] = mapped_column(
+        Uuid,
+        nullable=True,
+    )
+
+    # Relationships
+    user: Mapped[User] = relationship(back_populates="refresh_tokens")
+
+    def __repr__(self) -> str:
+        return f"<RefreshToken family={self.family_id} revoked={self.revoked}>"

--- a/src/shomer/models/user.py
+++ b/src/shomer/models/user.py
@@ -11,7 +11,9 @@ from sqlalchemy import Boolean, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 if TYPE_CHECKING:
+    from shomer.models.access_token import AccessToken
     from shomer.models.password_reset_token import PasswordResetToken
+    from shomer.models.refresh_token import RefreshToken
     from shomer.models.session import Session
     from shomer.models.user_email import UserEmail
     from shomer.models.user_password import UserPassword
@@ -70,6 +72,14 @@ class User(Base, UUIDMixin, TimestampMixin):
         cascade="all, delete-orphan",
     )
     password_reset_tokens: Mapped[list[PasswordResetToken]] = relationship(
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )
+    access_tokens: Mapped[list[AccessToken]] = relationship(
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )
+    refresh_tokens: Mapped[list[RefreshToken]] = relationship(
         back_populates="user",
         cascade="all, delete-orphan",
     )

--- a/tests/models/test_access_token.py
+++ b/tests/models/test_access_token.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Unit tests for AccessToken model."""
+
+import uuid
+from datetime import datetime, timezone
+
+from shomer.models.access_token import AccessToken
+from shomer.models.user import User  # noqa: F401
+from shomer.models.user_email import UserEmail  # noqa: F401
+from shomer.models.user_password import UserPassword  # noqa: F401
+from shomer.models.user_profile import UserProfile  # noqa: F401
+
+
+class TestAccessTokenModel:
+    """Tests for AccessToken SQLAlchemy model definition."""
+
+    def test_tablename(self) -> None:
+        assert AccessToken.__tablename__ == "access_tokens"
+
+    def test_required_fields(self) -> None:
+        now = datetime.now(timezone.utc)
+        at = AccessToken(
+            jti="abc123",
+            user_id=uuid.uuid4(),
+            client_id="my-client",
+            scopes="openid profile",
+            expires_at=now,
+        )
+        assert at.jti == "abc123"
+        assert at.client_id == "my-client"
+        assert at.scopes == "openid profile"
+        assert at.expires_at == now
+
+    def test_revoked_default(self) -> None:
+        col = AccessToken.__table__.c.revoked
+        assert col.nullable is False
+        assert col.default.arg is False
+
+    def test_jti_unique(self) -> None:
+        col = AccessToken.__table__.c.jti
+        assert col.unique is True
+
+    def test_jti_indexed(self) -> None:
+        col = AccessToken.__table__.c.jti
+        assert col.index is True
+
+    def test_user_id_indexed(self) -> None:
+        col = AccessToken.__table__.c.user_id
+        assert col.index is True
+
+    def test_user_id_not_nullable(self) -> None:
+        col = AccessToken.__table__.c.user_id
+        assert col.nullable is False
+
+    def test_user_id_foreign_key(self) -> None:
+        col = AccessToken.__table__.c.user_id
+        fk = list(col.foreign_keys)[0]
+        assert fk.column.table.name == "users"
+
+    def test_repr(self) -> None:
+        at = AccessToken(
+            jti="x",
+            user_id=uuid.uuid4(),
+            client_id="c",
+            expires_at=datetime.now(timezone.utc),
+        )
+        assert "jti=x" in repr(at)
+
+
+class TestAccessTokenRelationship:
+    """Tests for AccessToken <-> User relationship."""
+
+    def test_user_relationship_exists(self) -> None:
+        rel = AccessToken.__mapper__.relationships["user"]
+        assert rel.back_populates == "access_tokens"
+
+    def test_user_model_has_access_tokens(self) -> None:
+        rel = User.__mapper__.relationships["access_tokens"]
+        assert rel.back_populates == "user"

--- a/tests/models/test_refresh_token.py
+++ b/tests/models/test_refresh_token.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Unit tests for RefreshToken model."""
+
+import uuid
+from datetime import datetime, timezone
+
+from shomer.models.refresh_token import RefreshToken
+from shomer.models.user import User  # noqa: F401
+from shomer.models.user_email import UserEmail  # noqa: F401
+from shomer.models.user_password import UserPassword  # noqa: F401
+from shomer.models.user_profile import UserProfile  # noqa: F401
+
+
+class TestRefreshTokenModel:
+    """Tests for RefreshToken SQLAlchemy model definition."""
+
+    def test_tablename(self) -> None:
+        assert RefreshToken.__tablename__ == "refresh_tokens"
+
+    def test_required_fields(self) -> None:
+        now = datetime.now(timezone.utc)
+        fid = uuid.uuid4()
+        rt = RefreshToken(
+            token_hash="hashed_value",
+            family_id=fid,
+            user_id=uuid.uuid4(),
+            client_id="my-client",
+            scopes="openid",
+            expires_at=now,
+        )
+        assert rt.token_hash == "hashed_value"
+        assert rt.family_id == fid
+        assert rt.client_id == "my-client"
+        assert rt.scopes == "openid"
+
+    def test_revoked_default(self) -> None:
+        col = RefreshToken.__table__.c.revoked
+        assert col.nullable is False
+        assert col.default.arg is False
+
+    def test_replaced_by_nullable(self) -> None:
+        col = RefreshToken.__table__.c.replaced_by
+        assert col.nullable is True
+
+    def test_family_id_indexed(self) -> None:
+        col = RefreshToken.__table__.c.family_id
+        assert col.index is True
+
+    def test_user_id_indexed(self) -> None:
+        col = RefreshToken.__table__.c.user_id
+        assert col.index is True
+
+    def test_user_id_not_nullable(self) -> None:
+        col = RefreshToken.__table__.c.user_id
+        assert col.nullable is False
+
+    def test_user_id_foreign_key(self) -> None:
+        col = RefreshToken.__table__.c.user_id
+        fk = list(col.foreign_keys)[0]
+        assert fk.column.table.name == "users"
+
+    def test_token_hash_not_nullable(self) -> None:
+        col = RefreshToken.__table__.c.token_hash
+        assert col.nullable is False
+
+    def test_family_id_not_nullable(self) -> None:
+        col = RefreshToken.__table__.c.family_id
+        assert col.nullable is False
+
+    def test_repr(self) -> None:
+        fid = uuid.uuid4()
+        rt = RefreshToken(
+            token_hash="h",
+            family_id=fid,
+            user_id=uuid.uuid4(),
+            client_id="c",
+            expires_at=datetime.now(timezone.utc),
+        )
+        assert f"family={fid}" in repr(rt)
+
+
+class TestRefreshTokenRelationship:
+    """Tests for RefreshToken <-> User relationship."""
+
+    def test_user_relationship_exists(self) -> None:
+        rel = RefreshToken.__mapper__.relationships["user"]
+        assert rel.back_populates == "refresh_tokens"
+
+    def test_user_model_has_refresh_tokens(self) -> None:
+        rel = User.__mapper__.relationships["refresh_tokens"]
+        assert rel.back_populates == "user"


### PR DESCRIPTION
## feat(models): AccessToken and RefreshToken

## Summary

Token storage models. AccessToken (jti, user_id, client_id, scopes, expiry). RefreshToken (token hash, rotation chain, family_id for reuse detection).

## Changes

- [x] AccessToken model (jti, user_id, client_id, scopes, expires_at, revoked)
- [x] RefreshToken model (token_hash, family_id, user_id, client_id, scopes, expires_at, revoked, replaced_by)
- [x] Indexes on jti, user_id, family_id
- [x] Alembic migration

## Dependencies

- #3 - declarative base

## Related Issue

Closes #16

## Test Plan

- [x] `make format` - code formatted
- [x] `make lint` - no linting errors
- [x] `make typecheck` - type checks pass
- [x] `make test` - all unit tests pass (243 passed)
- [x] `make bdd` - all BDD tests pass (6 scenarios, 20 steps)
- [x] `make check-license` - SPDX headers present