### PR TITLE
test(bdd): add Gherkin features for JWKS endpoint

### DIFF
--- a/features/jwks.feature
+++ b/features/jwks.feature
@@ -1,0 +1,16 @@
+Feature: JWKS endpoint (RFC 7517)
+
+  Scenario: JWKS returns valid JSON with keys array
+    When I send a GET request to "/.well-known/jwks.json"
+    Then the response status code should be 200
+    And the response should have JSON key "keys"
+
+  Scenario: JWKS returns Cache-Control header
+    When I send a GET request to "/.well-known/jwks.json"
+    Then the response status code should be 200
+    And the response should have header "Cache-Control" containing "max-age"
+
+  Scenario: JWKS content type is JSON
+    When I send a GET request to "/.well-known/jwks.json"
+    Then the response status code should be 200
+    And the response content type should be json

--- a/features/steps/http_steps.py
+++ b/features/steps/http_steps.py
@@ -51,3 +51,15 @@ def step_check_json_key(context, key):
 def step_check_html_content_type(context):
     content_type = context.response.headers.get("Content-Type", "")
     assert "text/html" in content_type
+
+
+@then("the response content type should be json")
+def step_check_json_content_type(context):
+    content_type = context.response.headers.get("Content-Type", "")
+    assert "application/json" in content_type
+
+
+@then('the response should have header "{name}" containing "{value}"')
+def step_check_response_header(context, name, value):
+    header = context.response.headers.get(name, "")
+    assert value in header, f"Header '{name}' = '{header}' does not contain '{value}'"


### PR DESCRIPTION
## Summary

- Add BDD feature for `GET /.well-known/jwks.json` (JSON keys array, Cache-Control header, JSON content type)
- Add reusable http_steps: `response content type should be json`, `response should have header X containing Y`

## Test Plan

- [x] `make format` - code formatted
- [x] `make lint` - no linting errors
- [x] `make typecheck` - type checks pass
- [x] `make test` - all unit tests pass (243 passed)
- [x] `make bdd` - all BDD tests pass (9 scenarios, 29 steps)
- [x] `make check-license` - SPDX headers present

Closes #166