### PR TITLE
fix(bdd): docker compose down --volumes for clean BDD reruns

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -36,4 +36,4 @@ def after_all(context):
     context.browser.close()
     context.playwright.stop()
     if context.manage_compose:
-        subprocess.run(["docker", "compose", "down"], check=True)
+        subprocess.run(["docker", "compose", "down", "--volumes"], check=True)


### PR DESCRIPTION
## Summary

- Add `--volumes` flag to `docker compose down` in `features/environment.py`
- Prevents PostgreSQL data from persisting between BDD runs (duplicate emails, stale state)

## Test Plan

- [x] `make format` - code formatted
- [x] `make lint` - no linting errors
- [x] `make typecheck` - type checks pass
- [x] `make test` - all unit tests pass (256 passed)
- [x] `make bdd` - all BDD tests pass (14 scenarios, 47 steps)
- [x] `make check-license` - SPDX headers present
- [x] Verified idempotent: `make bdd && make bdd` passes twice consecutively

Closes #168