### PR TITLE
feat(session): browser session management service

### DIFF
--- a/src/shomer/services/session_service.py
+++ b/src/shomer/services/session_service.py
@@ -1,0 +1,209 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Browser session management service."""
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from shomer.models.session import Session
+
+#: Default session lifetime.
+SESSION_TTL = timedelta(hours=24)
+
+#: Sliding window extension on each renewal.
+SESSION_RENEWAL_WINDOW = timedelta(hours=1)
+
+
+class SessionService:
+    """Manage browser sessions: create, validate, renew, delete.
+
+    Attributes
+    ----------
+    db : AsyncSession
+        Database session.
+    """
+
+    def __init__(self, db: AsyncSession) -> None:
+        self.db = db
+
+    async def create(
+        self,
+        *,
+        user_id: uuid.UUID,
+        user_agent: str | None = None,
+        ip_address: str | None = None,
+        tenant_id: uuid.UUID | None = None,
+    ) -> tuple[Session, str]:
+        """Create a new browser session.
+
+        Parameters
+        ----------
+        user_id : uuid.UUID
+            Owner of the session.
+        user_agent : str or None
+            Browser User-Agent string.
+        ip_address : str or None
+            Client IP address.
+        tenant_id : uuid.UUID or None
+            Optional tenant identifier.
+
+        Returns
+        -------
+        tuple[Session, str]
+            The persisted session and the raw (unhashed) token.
+        """
+        raw_token = uuid.uuid4().hex
+        token_hash = self._hash_token(raw_token)
+        csrf_token = uuid.uuid4().hex
+        now = datetime.now(timezone.utc)
+
+        session = Session(
+            user_id=user_id,
+            tenant_id=tenant_id,
+            token_hash=token_hash,
+            csrf_token=csrf_token,
+            user_agent=user_agent,
+            ip_address=ip_address,
+            last_activity=now,
+            expires_at=now + SESSION_TTL,
+        )
+        self.db.add(session)
+        await self.db.flush()
+        return session, raw_token
+
+    async def validate(self, token: str) -> Session | None:
+        """Look up and validate a session by its raw token.
+
+        Returns ``None`` if the session does not exist or has expired.
+
+        Parameters
+        ----------
+        token : str
+            Raw session token (from the cookie).
+
+        Returns
+        -------
+        Session or None
+            The valid session, or ``None``.
+        """
+        token_hash = self._hash_token(token)
+        stmt = select(Session).where(Session.token_hash == token_hash)
+        result = await self.db.execute(stmt)
+        session = result.scalar_one_or_none()
+
+        if session is None:
+            return None
+
+        now = datetime.now(timezone.utc)
+        expires_at = session.expires_at
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=timezone.utc)
+        if expires_at < now:
+            return None
+
+        return session
+
+    async def renew(self, session: Session) -> Session:
+        """Extend the session expiration (sliding window).
+
+        Parameters
+        ----------
+        session : Session
+            The session to renew.
+
+        Returns
+        -------
+        Session
+            The renewed session.
+        """
+        now = datetime.now(timezone.utc)
+        session.last_activity = now
+        session.expires_at = now + SESSION_RENEWAL_WINDOW
+        await self.db.flush()
+        return session
+
+    async def delete(self, session_id: uuid.UUID) -> bool:
+        """Delete a single session.
+
+        Parameters
+        ----------
+        session_id : uuid.UUID
+            ID of the session to delete.
+
+        Returns
+        -------
+        bool
+            ``True`` if the session was deleted.
+        """
+        stmt = delete(Session).where(Session.id == session_id)
+        result = await self.db.execute(stmt)
+        await self.db.flush()
+        rc: int = getattr(result, "rowcount", 0) or 0
+        return rc > 0
+
+    async def delete_all_for_user(self, user_id: uuid.UUID) -> int:
+        """Delete all sessions for a user.
+
+        Parameters
+        ----------
+        user_id : uuid.UUID
+            User whose sessions should be deleted.
+
+        Returns
+        -------
+        int
+            Number of sessions deleted.
+        """
+        stmt = delete(Session).where(Session.user_id == user_id)
+        result = await self.db.execute(stmt)
+        await self.db.flush()
+        rc: int = getattr(result, "rowcount", 0) or 0
+        return rc
+
+    async def list_active(self, user_id: uuid.UUID) -> list[Session]:
+        """List all active (non-expired) sessions for a user.
+
+        Parameters
+        ----------
+        user_id : uuid.UUID
+            User ID.
+
+        Returns
+        -------
+        list[Session]
+            Active sessions ordered by last activity (most recent first).
+        """
+        now = datetime.now(timezone.utc)
+        stmt = (
+            select(Session)
+            .where(
+                Session.user_id == user_id,
+                Session.expires_at > now,
+            )
+            .order_by(Session.last_activity.desc())
+        )
+        result = await self.db.execute(stmt)
+        return list(result.scalars().all())
+
+    @staticmethod
+    def _hash_token(token: str) -> str:
+        """Hash a raw session token with SHA-256.
+
+        Parameters
+        ----------
+        token : str
+            Raw token string.
+
+        Returns
+        -------
+        str
+            Hex-encoded SHA-256 hash.
+        """
+        return hashlib.sha256(token.encode()).hexdigest()

--- a/tests/services/test_session_service.py
+++ b/tests/services/test_session_service.py
@@ -1,0 +1,254 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Unit tests for SessionService."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from collections.abc import Iterator
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from shomer.core.database import Base
+from shomer.models.access_token import AccessToken  # noqa: F401
+from shomer.models.jwk import JWK  # noqa: F401
+from shomer.models.password_reset_token import PasswordResetToken  # noqa: F401
+from shomer.models.refresh_token import RefreshToken  # noqa: F401
+from shomer.models.user import User
+from shomer.models.user_email import UserEmail  # noqa: F401
+from shomer.models.user_password import UserPassword  # noqa: F401
+from shomer.models.user_profile import UserProfile  # noqa: F401
+from shomer.models.verification_code import VerificationCode  # noqa: F401
+from shomer.services.session_service import SessionService
+
+_ENGINE = create_async_engine(
+    "sqlite+aiosqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+_SESSION_FACTORY = async_sessionmaker(_ENGINE, expire_on_commit=False)
+
+
+@pytest.fixture(autouse=True)
+def _setup_db() -> Iterator[None]:
+    """Create and drop tables for each test."""
+
+    async def _create() -> None:
+        async with _ENGINE.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+    asyncio.run(_create())
+    yield
+
+    async def _drop() -> None:
+        async with _ENGINE.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+
+    asyncio.run(_drop())
+
+
+async def _create_user(db: AsyncSession) -> uuid.UUID:
+    """Insert a minimal user and return its ID."""
+    user = User(username="test")
+    db.add(user)
+    await db.flush()
+    assert user.id is not None
+    return user.id
+
+
+class TestCreate:
+    """Tests for SessionService.create()."""
+
+    def test_creates_session(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                uid = await _create_user(db)
+                svc = SessionService(db)
+                session, raw_token = await svc.create(user_id=uid)
+                assert session.user_id == uid
+                assert session.token_hash is not None
+                assert session.csrf_token is not None
+                assert len(raw_token) == 32
+
+        asyncio.run(_run())
+
+    def test_stores_metadata(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                uid = await _create_user(db)
+                svc = SessionService(db)
+                session, _ = await svc.create(
+                    user_id=uid,
+                    user_agent="Mozilla/5.0",
+                    ip_address="10.0.0.1",
+                )
+                assert session.user_agent == "Mozilla/5.0"
+                assert session.ip_address == "10.0.0.1"
+
+        asyncio.run(_run())
+
+    def test_sets_expiration(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                uid = await _create_user(db)
+                svc = SessionService(db)
+                session, _ = await svc.create(user_id=uid)
+                assert session.expires_at > datetime.now(timezone.utc)
+
+        asyncio.run(_run())
+
+
+class TestValidate:
+    """Tests for SessionService.validate()."""
+
+    def test_valid_token(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                uid = await _create_user(db)
+                svc = SessionService(db)
+                _, raw_token = await svc.create(user_id=uid)
+                result = await svc.validate(raw_token)
+                assert result is not None
+                assert result.user_id == uid
+
+        asyncio.run(_run())
+
+    def test_invalid_token_returns_none(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                svc = SessionService(db)
+                result = await svc.validate("nonexistent-token")
+                assert result is None
+
+        asyncio.run(_run())
+
+    def test_expired_session_returns_none(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                uid = await _create_user(db)
+                svc = SessionService(db)
+                session, raw_token = await svc.create(user_id=uid)
+                # Manually expire
+                session.expires_at = datetime.now(timezone.utc) - timedelta(hours=1)
+                await db.flush()
+                result = await svc.validate(raw_token)
+                assert result is None
+
+        asyncio.run(_run())
+
+
+class TestRenew:
+    """Tests for SessionService.renew()."""
+
+    def test_extends_expiration(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                uid = await _create_user(db)
+                svc = SessionService(db)
+                session, _ = await svc.create(user_id=uid)
+                renewed = await svc.renew(session)
+                assert renewed.last_activity is not None
+                assert renewed.expires_at is not None
+
+        asyncio.run(_run())
+
+
+class TestDelete:
+    """Tests for SessionService.delete()."""
+
+    def test_deletes_session(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                uid = await _create_user(db)
+                svc = SessionService(db)
+                session, raw_token = await svc.create(user_id=uid)
+                deleted = await svc.delete(session.id)
+                assert deleted is True
+                result = await svc.validate(raw_token)
+                assert result is None
+
+        asyncio.run(_run())
+
+    def test_delete_nonexistent_returns_false(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                svc = SessionService(db)
+                deleted = await svc.delete(uuid.uuid4())
+                assert deleted is False
+
+        asyncio.run(_run())
+
+
+class TestDeleteAllForUser:
+    """Tests for SessionService.delete_all_for_user()."""
+
+    def test_deletes_all_user_sessions(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                uid = await _create_user(db)
+                svc = SessionService(db)
+                await svc.create(user_id=uid)
+                await svc.create(user_id=uid)
+                await svc.create(user_id=uid)
+                count = await svc.delete_all_for_user(uid)
+                assert count == 3
+
+        asyncio.run(_run())
+
+    def test_does_not_delete_other_users(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                uid1 = await _create_user(db)
+                uid2 = await _create_user(db)
+                svc = SessionService(db)
+                await svc.create(user_id=uid1)
+                _, token2 = await svc.create(user_id=uid2)
+                await svc.delete_all_for_user(uid1)
+                result = await svc.validate(token2)
+                assert result is not None
+
+        asyncio.run(_run())
+
+
+class TestListActive:
+    """Tests for SessionService.list_active()."""
+
+    def test_lists_active_sessions(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                uid = await _create_user(db)
+                svc = SessionService(db)
+                await svc.create(user_id=uid)
+                await svc.create(user_id=uid)
+                sessions = await svc.list_active(uid)
+                assert len(sessions) == 2
+
+        asyncio.run(_run())
+
+    def test_excludes_expired(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                uid = await _create_user(db)
+                svc = SessionService(db)
+                session, _ = await svc.create(user_id=uid)
+                session.expires_at = datetime.now(timezone.utc) - timedelta(hours=1)
+                await db.flush()
+                await svc.create(user_id=uid)
+                sessions = await svc.list_active(uid)
+                assert len(sessions) == 1
+
+        asyncio.run(_run())
+
+    def test_empty_for_unknown_user(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                svc = SessionService(db)
+                sessions = await svc.list_active(uuid.uuid4())
+                assert sessions == []
+
+        asyncio.run(_run())


### PR DESCRIPTION
## feat(session): browser session management service

## Summary

Complete session management service: create, validate, renew, delete, list by user. Session token hashed with SHA-256 stored in HttpOnly cookie.

## Changes

- [x] Session creation with SHA-256 hashed token + CSRF token
- [x] Session validation and lookup by token (with expiration check)
- [x] Session renewal (sliding expiration window)
- [x] Session deletion (single session)
- [x] Delete all sessions for a user
- [x] List active sessions by user (ordered by last activity)
- [x] Unit tests (14 tests with aiosqlite async DB)

## Dependencies

- #1 - AES-256-GCM encryption
- #6 - Session model

## Related Issue

Closes #20

## Test Plan

- [x] `make format` - code formatted
- [x] `make lint` - no linting errors
- [x] `make typecheck` - type checks pass
- [x] `make test` - all unit tests pass (283 passed)
- [x] `make bdd` - all BDD tests pass (17 scenarios, 55 steps)
- [x] `make check-license` - SPDX headers present