### PR TITLE
feat(session): sliding session expiration middleware

### DIFF
--- a/src/shomer/app.py
+++ b/src/shomer/app.py
@@ -51,6 +51,7 @@ def create_app() -> FastAPI:
     )
 
     from shomer.middleware.cors import setup_cors
+    from shomer.middleware.session import SessionMiddleware
     from shomer.routes.auth import router as auth_router
     from shomer.routes.docs import router as docs_router
     from shomer.routes.health import router as health_router
@@ -58,6 +59,7 @@ def create_app() -> FastAPI:
     from shomer.routes.views import router as views_router
 
     setup_cors(application, settings)
+    application.add_middleware(SessionMiddleware)
 
     application.include_router(health_router)
     application.include_router(auth_router)

--- a/src/shomer/middleware/session.py
+++ b/src/shomer/middleware/session.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Sliding session expiration middleware."""
+
+from __future__ import annotations
+
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import Response
+
+from shomer.core.database import async_session
+from shomer.services.session_service import SessionService
+
+
+class SessionMiddleware(BaseHTTPMiddleware):
+    """Renew active sessions on each authenticated request.
+
+    Reads the ``session_id`` cookie, validates the session, and
+    extends its TTL via the sliding window mechanism. Unauthenticated
+    requests (no cookie or invalid session) are passed through unchanged.
+    """
+
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        """Process the request, renewing the session if present.
+
+        Parameters
+        ----------
+        request : Request
+            Incoming HTTP request.
+        call_next : RequestResponseEndpoint
+            Next middleware or route handler.
+
+        Returns
+        -------
+        Response
+            The response from downstream handlers.
+        """
+        session_token = request.cookies.get("session_id")
+        if session_token:
+            async with async_session() as db:
+                svc = SessionService(db)
+                session = await svc.validate(session_token)
+                if session is not None:
+                    await svc.renew(session)
+                    await db.commit()
+
+        return await call_next(request)

--- a/tests/middleware/test_session.py
+++ b/tests/middleware/test_session.py
@@ -1,0 +1,187 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Unit tests for sliding session expiration middleware."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import uuid
+from collections.abc import Iterator
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from shomer.app import app
+from shomer.core.database import Base
+from shomer.deps import get_db
+from shomer.models.access_token import AccessToken  # noqa: F401
+from shomer.models.jwk import JWK  # noqa: F401
+from shomer.models.password_reset_token import PasswordResetToken  # noqa: F401
+from shomer.models.refresh_token import RefreshToken  # noqa: F401
+from shomer.models.session import Session
+from shomer.models.user import User
+from shomer.models.user_email import UserEmail  # noqa: F401
+from shomer.models.user_password import UserPassword  # noqa: F401
+from shomer.models.user_profile import UserProfile  # noqa: F401
+from shomer.models.verification_code import VerificationCode  # noqa: F401
+
+_ENGINE = create_async_engine(
+    "sqlite+aiosqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+_SESSION_FACTORY = async_sessionmaker(_ENGINE, expire_on_commit=False)
+
+
+async def _override_get_db() -> AsyncSession:  # type: ignore[misc]
+    async with _SESSION_FACTORY() as session:
+        try:
+            yield session
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise
+
+
+@pytest.fixture(autouse=True)
+def _setup() -> Iterator[None]:
+    """Create tables, override DB, and patch middleware session factory."""
+
+    async def _create() -> None:
+        async with _ENGINE.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+    asyncio.run(_create())
+    app.dependency_overrides[get_db] = _override_get_db
+
+    with patch("shomer.middleware.session.async_session", _SESSION_FACTORY):
+        yield
+
+    app.dependency_overrides.clear()
+
+    async def _drop() -> None:
+        async with _ENGINE.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+
+    asyncio.run(_drop())
+
+
+async def _create_user_and_session(
+    db: AsyncSession,
+) -> tuple[uuid.UUID, str]:
+    """Create a user with an active session, return (user_id, raw_token)."""
+    user = User(username="test")
+    db.add(user)
+    await db.flush()
+
+    raw_token = uuid.uuid4().hex
+    token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
+    now = datetime.now(timezone.utc)
+
+    session = Session(
+        user_id=user.id,
+        token_hash=token_hash,
+        csrf_token=uuid.uuid4().hex,
+        last_activity=now - timedelta(minutes=10),
+        expires_at=now + timedelta(hours=23),
+    )
+    db.add(session)
+    await db.commit()
+    return user.id, raw_token
+
+
+class TestSessionMiddleware:
+    """Tests for sliding session expiration middleware."""
+
+    def test_unauthenticated_request_passes_through(self) -> None:
+        async def _run() -> None:
+            transport = ASGITransport(app=app)
+            async with AsyncClient(
+                transport=transport, base_url="http://test"
+            ) as client:
+                resp = await client.get("/liveness")
+                assert resp.status_code == 200
+
+        asyncio.run(_run())
+
+    def test_invalid_cookie_passes_through(self) -> None:
+        async def _run() -> None:
+            transport = ASGITransport(app=app)
+            async with AsyncClient(
+                transport=transport, base_url="http://test"
+            ) as client:
+                resp = await client.get(
+                    "/liveness", cookies={"session_id": "invalid-token"}
+                )
+                assert resp.status_code == 200
+
+        asyncio.run(_run())
+
+    def test_valid_session_gets_renewed(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                user_id, raw_token = await _create_user_and_session(db)
+
+                # Get session before request
+                token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
+                result = await db.execute(
+                    select(Session).where(Session.token_hash == token_hash)
+                )
+                session_before = result.scalar_one()
+                old_last_activity = session_before.last_activity
+
+            transport = ASGITransport(app=app)
+            async with AsyncClient(
+                transport=transport, base_url="http://test"
+            ) as client:
+                resp = await client.get("/liveness", cookies={"session_id": raw_token})
+                assert resp.status_code == 200
+
+            # Check session was renewed
+            async with _SESSION_FACTORY() as db:
+                result = await db.execute(
+                    select(Session).where(Session.token_hash == token_hash)
+                )
+                session_after = result.scalar_one()
+                # last_activity should have been updated
+                assert session_after.last_activity != old_last_activity
+
+        asyncio.run(_run())
+
+    def test_expired_session_not_renewed(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                user = User(username="test")
+                db.add(user)
+                await db.flush()
+
+                raw_token = uuid.uuid4().hex
+                token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
+                now = datetime.now(timezone.utc)
+
+                session = Session(
+                    user_id=user.id,
+                    token_hash=token_hash,
+                    csrf_token=uuid.uuid4().hex,
+                    last_activity=now - timedelta(hours=25),
+                    expires_at=now - timedelta(hours=1),
+                )
+                db.add(session)
+                await db.commit()
+
+            transport = ASGITransport(app=app)
+            async with AsyncClient(
+                transport=transport, base_url="http://test"
+            ) as client:
+                resp = await client.get("/liveness", cookies={"session_id": raw_token})
+                # Should still pass through (middleware doesn't block)
+                assert resp.status_code == 200
+
+        asyncio.run(_run())


### PR DESCRIPTION
## feat(session): sliding session expiration middleware

## Summary

FastAPI middleware for automatic session renewal on each request (sliding expiration). Updates last_activity and extends TTL.

## Changes

- [x] Middleware implementation (BaseHTTPMiddleware)
- [x] Update last_activity timestamp on each authenticated request
- [x] Extend session TTL via sliding window renewal
- [x] Skip silently for unauthenticated/expired requests

## Dependencies

- #20 - session service

## Related Issue

Closes #21

## Test Plan

- [x] `make format` - code formatted
- [x] `make lint` - no linting errors
- [x] `make typecheck` - type checks pass
- [x] `make test` - all unit tests pass (296 passed)
- [x] `make bdd` - all BDD tests pass (19 scenarios, 60 steps)
- [x] `make check-license` - SPDX headers present