### PR TITLE
feat(auth): POST /auth/password/change

### DIFF
--- a/features/auth_password_change.feature
+++ b/features/auth_password_change.feature
@@ -1,0 +1,16 @@
+Feature: Password change
+
+  Scenario: Change password without session returns 401
+    When I send a POST request to "/auth/password/change" with JSON
+      """
+      {"current_password": "old", "new_password": "newpassword1"}
+      """
+    Then the response status code should be 401
+    And the response body should contain "Authentication required"
+
+  Scenario: Change password with short new password returns 422
+    When I send a POST request to "/auth/password/change" with JSON
+      """
+      {"current_password": "oldpassword", "new_password": "short"}
+      """
+    Then the response status code should be 422

--- a/src/shomer/routes/auth.py
+++ b/src/shomer/routes/auth.py
@@ -15,6 +15,7 @@ from shomer.schemas.auth import (
     LoginResponse,
     LogoutRequest,
     MessageResponse,
+    PasswordChangeRequest,
     PasswordResetRequest,
     PasswordResetVerifyRequest,
     RegisterRequest,
@@ -369,3 +370,61 @@ async def password_reset_verify(
         )
 
     return MessageResponse(message="Password reset successfully")
+
+
+@router.post("/password/change", response_model=MessageResponse)
+async def password_change(
+    body: PasswordChangeRequest, request: Request, db: DbSession
+) -> MessageResponse:
+    """Change the authenticated user's password.
+
+    Requires a valid session cookie.
+
+    Parameters
+    ----------
+    body : PasswordChangeRequest
+        Current and new passwords.
+    request : Request
+        Incoming request with session cookie.
+    db : DbSession
+        Injected async database session.
+
+    Returns
+    -------
+    MessageResponse
+        Confirmation of password change.
+
+    Raises
+    ------
+    HTTPException
+        401 if not authenticated or current password is wrong.
+    """
+    session_token = request.cookies.get("session_id")
+    if not session_token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authentication required",
+        )
+
+    svc_session = SessionService(db)
+    session = await svc_session.validate(session_token)
+    if session is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired session",
+        )
+
+    svc = AuthService(db)
+    try:
+        await svc.change_password(
+            user_id=session.user_id,
+            current_password=body.current_password,
+            new_password=body.new_password,
+        )
+    except InvalidCredentialsError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Current password is incorrect",
+        )
+
+    return MessageResponse(message="Password changed successfully")

--- a/src/shomer/schemas/auth.py
+++ b/src/shomer/schemas/auth.py
@@ -134,6 +134,21 @@ class PasswordResetVerifyRequest(BaseModel):
     new_password: str = Field(min_length=8, max_length=128)
 
 
+class PasswordChangeRequest(BaseModel):
+    """Password change request body.
+
+    Attributes
+    ----------
+    current_password : str
+        Current plain-text password.
+    new_password : str
+        New password (min 8 characters).
+    """
+
+    current_password: str = Field(min_length=1, max_length=128)
+    new_password: str = Field(min_length=8, max_length=128)
+
+
 class RegisterResponse(BaseModel):
     """Registration success response.
 

--- a/src/shomer/services/auth_service.py
+++ b/src/shomer/services/auth_service.py
@@ -407,6 +407,43 @@ class AuthService:
         self.session.add(new_pw)
         await self.session.flush()
 
+    async def change_password(
+        self,
+        *,
+        user_id: uuid.UUID,
+        current_password: str,
+        new_password: str,
+    ) -> None:
+        """Change a user's password after verifying the current one.
+
+        Parameters
+        ----------
+        user_id : uuid.UUID
+            Authenticated user's ID.
+        current_password : str
+            Current plain-text password.
+        new_password : str
+            New plain-text password.
+
+        Raises
+        ------
+        InvalidCredentialsError
+            If the current password is incorrect.
+        """
+        current_pw = await self._get_current_password(user_id)
+        if current_pw is None or not verify_password(
+            current_password, current_pw.password_hash
+        ):
+            raise InvalidCredentialsError("Current password is incorrect")
+
+        current_pw.is_current = False
+        new_pw = UserPassword(
+            user_id=user_id,
+            password_hash=hash_password(new_password),
+        )
+        self.session.add(new_pw)
+        await self.session.flush()
+
     async def _email_exists(self, email: str) -> bool:
         """Check if an email is already registered.
 

--- a/tests/routes/test_auth_password_change.py
+++ b/tests/routes/test_auth_password_change.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Integration tests for POST /auth/password/change."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from shomer.app import app
+from shomer.core.database import Base
+from shomer.core.security import hash_password
+from shomer.deps import get_db
+from shomer.models.access_token import AccessToken  # noqa: F401
+from shomer.models.jwk import JWK  # noqa: F401
+from shomer.models.password_reset_token import PasswordResetToken  # noqa: F401
+from shomer.models.refresh_token import RefreshToken  # noqa: F401
+from shomer.models.session import Session
+from shomer.models.user import User
+from shomer.models.user_email import UserEmail
+from shomer.models.user_password import UserPassword
+from shomer.models.user_profile import UserProfile  # noqa: F401
+from shomer.models.verification_code import VerificationCode  # noqa: F401
+
+_ENGINE = create_async_engine(
+    "sqlite+aiosqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+_SESSION_FACTORY = async_sessionmaker(_ENGINE, expire_on_commit=False)
+
+
+async def _override_get_db() -> AsyncIterator[AsyncSession]:
+    async with _SESSION_FACTORY() as session:
+        try:
+            yield session
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise
+
+
+@pytest.fixture(autouse=True)
+def _setup() -> Iterator[None]:
+    async def _create() -> None:
+        async with _ENGINE.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+    asyncio.run(_create())
+    app.dependency_overrides[get_db] = _override_get_db
+
+    with patch("shomer.middleware.session.async_session", _SESSION_FACTORY):
+        yield
+
+    app.dependency_overrides.clear()
+
+    async def _drop() -> None:
+        async with _ENGINE.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+
+    asyncio.run(_drop())
+
+
+async def _create_authed_user(db: AsyncSession) -> tuple[str, uuid.UUID]:
+    """Create a user with a verified email, password, and session."""
+    user = User(username="test")
+    db.add(user)
+    await db.flush()
+
+    email = UserEmail(
+        user_id=user.id, email="user@example.com", is_primary=True, is_verified=True
+    )
+    pw = UserPassword(user_id=user.id, password_hash=hash_password("oldpassword1"))
+    db.add_all([email, pw])
+    await db.flush()
+
+    raw_token = uuid.uuid4().hex
+    token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
+    now = datetime.now(timezone.utc)
+    session = Session(
+        user_id=user.id,
+        token_hash=token_hash,
+        csrf_token=uuid.uuid4().hex,
+        last_activity=now,
+        expires_at=now + timedelta(hours=24),
+    )
+    db.add(session)
+    await db.commit()
+    return raw_token, user.id
+
+
+class TestPasswordChangeEndpoint:
+    """Integration tests for POST /auth/password/change."""
+
+    def test_no_session_returns_401(self) -> None:
+        async def _run() -> None:
+            transport = ASGITransport(app=app)
+            async with AsyncClient(
+                transport=transport, base_url="http://test"
+            ) as client:
+                resp = await client.post(
+                    "/auth/password/change",
+                    json={"current_password": "x", "new_password": "newpassword1"},
+                )
+                assert resp.status_code == 401
+
+        asyncio.run(_run())
+
+    def test_wrong_current_password_returns_401(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                raw_token, _ = await _create_authed_user(db)
+
+            transport = ASGITransport(app=app)
+            async with AsyncClient(
+                transport=transport, base_url="http://test"
+            ) as client:
+                client.cookies.set("session_id", raw_token)
+                resp = await client.post(
+                    "/auth/password/change",
+                    json={
+                        "current_password": "wrongpassword",
+                        "new_password": "newpassword1",
+                    },
+                )
+                assert resp.status_code == 401
+                assert "incorrect" in resp.json()["detail"]
+
+        asyncio.run(_run())
+
+    def test_change_password_success(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                raw_token, user_id = await _create_authed_user(db)
+
+            transport = ASGITransport(app=app)
+            async with AsyncClient(
+                transport=transport, base_url="http://test"
+            ) as client:
+                client.cookies.set("session_id", raw_token)
+                resp = await client.post(
+                    "/auth/password/change",
+                    json={
+                        "current_password": "oldpassword1",
+                        "new_password": "newpassword1",
+                    },
+                )
+                assert resp.status_code == 200
+                assert "changed" in resp.json()["message"]
+
+        asyncio.run(_run())


### PR DESCRIPTION
## feat(auth): POST /auth/password/change

## Summary

Password change for authenticated users. Verifies current password, sets new Argon2id hash.

## Changes

- [x] POST `/auth/password/change` route (requires session cookie)
- [x] Current password verification via Argon2id
- [x] New password hashing + old password deactivation
- [x] Integration tests + BDD features

## Dependencies

- #19 - login endpoint
- #20 - session service

## Related Issue

Closes #24

## Test Plan

- [x] `make format` - code formatted
- [x] `make lint` - no linting errors
- [x] `make typecheck` - type checks pass
- [x] `make test` - all unit tests pass (303 passed)
- [x] `make bdd` - all BDD tests pass (23 scenarios, 71 steps)
- [x] `make check-license` - SPDX headers present