### PR TITLE
feat(auth): [UI] forgot password and password change pages

### DIFF
--- a/features/ui_password.feature
+++ b/features/ui_password.feature
@@ -1,0 +1,51 @@
+Feature: Password management UI pages
+
+  Scenario: Forgot password page renders correctly
+    When I open the page "/ui/password/reset"
+    Then the page title should be "Forgot Password — Shomer"
+    And the page should contain "Forgot Password"
+    And the page should contain "Send Reset Link"
+    And the page should contain "Back to login"
+    And I take a screenshot named "forgot_password_page"
+
+  Scenario: Forgot password form submits and shows success
+    When I open the page "/ui/password/reset"
+    And I fill "input[name='email']" with "anyone@example.com"
+    And I click the "Send Reset Link" button
+    Then the page should contain "reset link has been sent"
+    And I take a screenshot named "forgot_password_success"
+
+  Scenario: Navigate from forgot password to login via link
+    When I open the page "/ui/password/reset"
+    And I click the "Back to login" link
+    Then the page URL should contain "/ui/login"
+    And the page should contain "Login"
+    And I take a screenshot named "forgot_to_login"
+
+  Scenario: Reset password page renders correctly
+    When I open the page "/ui/password/reset-verify"
+    Then the page title should be "Reset Password — Shomer"
+    And the page should contain "Reset Password"
+    And the page should contain "Set New Password"
+    And I take a screenshot named "reset_password_page"
+
+  Scenario: Reset password with invalid token shows error
+    When I open the page "/ui/password/reset-verify?token=not-a-uuid"
+    And I fill "input[name='new_password']" with "newstrongpassword"
+    And I click the "Set New Password" button
+    Then the page should contain "Invalid reset token"
+    And I take a screenshot named "reset_password_invalid_token"
+
+  Scenario: Change password page renders correctly
+    When I open the page "/ui/password/change"
+    Then the page title should be "Change Password — Shomer"
+    And the page should contain "Change Password"
+    And I take a screenshot named "change_password_page"
+
+  Scenario: Change password without session shows error
+    When I open the page "/ui/password/change"
+    And I fill "input[name='current_password']" with "oldpassword"
+    And I fill "input[name='new_password']" with "newpassword1"
+    And I click the "Change Password" button
+    Then the page should contain "Authentication required"
+    And I take a screenshot named "change_password_no_session"

--- a/src/shomer/app.py
+++ b/src/shomer/app.py
@@ -57,6 +57,7 @@ def create_app() -> FastAPI:
     from shomer.routes.docs import router as docs_router
     from shomer.routes.health import router as health_router
     from shomer.routes.jwks import router as jwks_router
+    from shomer.routes.password_ui import router as password_ui_router
     from shomer.routes.views import router as views_router
 
     setup_cors(application, settings)
@@ -65,6 +66,7 @@ def create_app() -> FastAPI:
     application.include_router(health_router)
     application.include_router(auth_router)
     application.include_router(auth_ui_router)
+    application.include_router(password_ui_router)
     application.include_router(docs_router)
     application.include_router(jwks_router)
     application.include_router(views_router)

--- a/src/shomer/routes/password_ui.py
+++ b/src/shomer/routes/password_ui.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Browser-facing password management UI routes (Jinja2/HTMX)."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+
+from shomer.deps import DbSession
+from shomer.services.auth_service import (
+    AuthService,
+    InvalidCredentialsError,
+    InvalidResetTokenError,
+)
+from shomer.services.session_service import SessionService
+from shomer.tasks.email import send_email_task
+
+router = APIRouter(prefix="/ui", tags=["ui"], include_in_schema=False)
+
+
+def _templates() -> Jinja2Templates:
+    from shomer.app import templates
+
+    return templates
+
+
+def _render(request: Request, template: str, ctx: dict[str, Any] | None = None) -> Any:
+    return _templates().TemplateResponse(request, template, ctx or {})
+
+
+@router.get("/password/reset", response_class=HTMLResponse)
+async def forgot_password_page(request: Request) -> Any:
+    """Render the forgot password page."""
+    return _render(request, "auth/forgot_password.html")
+
+
+@router.post("/password/reset", response_class=HTMLResponse)
+async def forgot_password_submit(
+    request: Request, db: DbSession, email: str = Form(...)
+) -> Any:
+    """Handle forgot password form submission."""
+    svc = AuthService(db)
+    token = await svc.request_password_reset(email=email)
+
+    # Always dispatch to prevent enumeration
+    send_email_task.delay(
+        to=email,
+        subject="Reset your password",
+        template="password_reset.html",
+        context={"token": str(token) if token else ""},
+    )
+
+    return _render(
+        request,
+        "auth/forgot_password.html",
+        {"success": "If the email is registered, a reset link has been sent."},
+    )
+
+
+@router.get("/password/reset-verify", response_class=HTMLResponse)
+async def reset_password_page(request: Request, token: str = "") -> Any:
+    """Render the reset password page."""
+    return _render(request, "auth/reset_password.html", {"token": token})
+
+
+@router.post("/password/reset-verify", response_class=HTMLResponse)
+async def reset_password_submit(
+    request: Request,
+    db: DbSession,
+    token: str = Form(...),
+    new_password: str = Form(...),
+) -> Any:
+    """Handle reset password form submission."""
+    svc = AuthService(db)
+    try:
+        token_uuid = uuid.UUID(token)
+    except ValueError:
+        return _render(
+            request,
+            "auth/reset_password.html",
+            {"error": "Invalid reset token", "token": token},
+        )
+
+    try:
+        await svc.verify_password_reset(token=token_uuid, new_password=new_password)
+    except InvalidResetTokenError:
+        return _render(
+            request,
+            "auth/reset_password.html",
+            {"error": "Invalid or expired reset token", "token": token},
+        )
+
+    return _render(
+        request,
+        "auth/reset_password.html",
+        {"success": "Password reset successfully. You can now log in."},
+    )
+
+
+@router.get("/password/change", response_class=HTMLResponse)
+async def change_password_page(request: Request) -> Any:
+    """Render the password change page."""
+    return _render(request, "auth/change_password.html")
+
+
+@router.post("/password/change", response_class=HTMLResponse)
+async def change_password_submit(
+    request: Request,
+    db: DbSession,
+    current_password: str = Form(...),
+    new_password: str = Form(...),
+) -> Any:
+    """Handle password change form submission."""
+    session_token = request.cookies.get("session_id")
+    if not session_token:
+        return _render(
+            request, "auth/change_password.html", {"error": "Authentication required"}
+        )
+
+    svc_session = SessionService(db)
+    session = await svc_session.validate(session_token)
+    if session is None:
+        return _render(
+            request, "auth/change_password.html", {"error": "Session expired"}
+        )
+
+    svc = AuthService(db)
+    try:
+        await svc.change_password(
+            user_id=session.user_id,
+            current_password=current_password,
+            new_password=new_password,
+        )
+    except InvalidCredentialsError:
+        return _render(
+            request,
+            "auth/change_password.html",
+            {"error": "Current password is incorrect"},
+        )
+
+    return _render(
+        request,
+        "auth/change_password.html",
+        {"success": "Password changed successfully"},
+    )

--- a/src/shomer/templates/auth/change_password.html
+++ b/src/shomer/templates/auth/change_password.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block title %}Change Password — Shomer{% endblock %}
+{% block content %}
+<h1>Change Password</h1>
+{% if error %}<p class="error">{{ error }}</p>{% endif %}
+{% if success %}<p class="success">{{ success }}</p>{% endif %}
+<form method="post" action="/ui/password/change">
+    <input type="password" name="current_password" placeholder="Current password" required>
+    <input type="password" name="new_password" placeholder="New password (min 8 chars)" required minlength="8">
+    <button type="submit">Change Password</button>
+</form>
+{% endblock %}

--- a/src/shomer/templates/auth/forgot_password.html
+++ b/src/shomer/templates/auth/forgot_password.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block title %}Forgot Password — Shomer{% endblock %}
+{% block content %}
+<h1>Forgot Password</h1>
+{% if error %}<p class="error">{{ error }}</p>{% endif %}
+{% if success %}<p class="success">{{ success }}</p>{% endif %}
+<form method="post" action="/ui/password/reset">
+    <input type="email" name="email" placeholder="Email" required>
+    <button type="submit">Send Reset Link</button>
+</form>
+<p><a href="/ui/login">Back to login</a></p>
+{% endblock %}

--- a/src/shomer/templates/auth/reset_password.html
+++ b/src/shomer/templates/auth/reset_password.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block title %}Reset Password — Shomer{% endblock %}
+{% block content %}
+<h1>Reset Password</h1>
+{% if error %}<p class="error">{{ error }}</p>{% endif %}
+{% if success %}<p class="success">{{ success }}</p>{% endif %}
+<form method="post" action="/ui/password/reset-verify">
+    <input type="hidden" name="token" value="{{ token or '' }}">
+    <input type="password" name="new_password" placeholder="New password (min 8 chars)" required minlength="8">
+    <button type="submit">Set New Password</button>
+</form>
+{% endblock %}

--- a/tests/routes/test_password_ui.py
+++ b/tests/routes/test_password_ui.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Integration tests for password management UI pages."""
+
+from __future__ import annotations
+
+import asyncio
+
+from httpx import ASGITransport, AsyncClient
+
+from shomer.app import app
+
+
+class TestPasswordUIPages:
+    """Tests for GET /ui/password/reset, /ui/password/reset-verify, /ui/password/change."""
+
+    def test_forgot_password_page(self) -> None:
+        async def _run() -> None:
+            transport = ASGITransport(app=app)
+            async with AsyncClient(
+                transport=transport, base_url="http://test"
+            ) as client:
+                resp = await client.get("/ui/password/reset")
+                assert resp.status_code == 200
+                assert "Forgot Password" in resp.text
+
+        asyncio.run(_run())
+
+    def test_reset_password_page(self) -> None:
+        async def _run() -> None:
+            transport = ASGITransport(app=app)
+            async with AsyncClient(
+                transport=transport, base_url="http://test"
+            ) as client:
+                resp = await client.get("/ui/password/reset-verify")
+                assert resp.status_code == 200
+                assert "Reset Password" in resp.text
+
+        asyncio.run(_run())
+
+    def test_reset_password_page_with_token(self) -> None:
+        async def _run() -> None:
+            transport = ASGITransport(app=app)
+            async with AsyncClient(
+                transport=transport, base_url="http://test"
+            ) as client:
+                resp = await client.get("/ui/password/reset-verify?token=abc123")
+                assert resp.status_code == 200
+                assert "abc123" in resp.text
+
+        asyncio.run(_run())
+
+    def test_change_password_page(self) -> None:
+        async def _run() -> None:
+            transport = ASGITransport(app=app)
+            async with AsyncClient(
+                transport=transport, base_url="http://test"
+            ) as client:
+                resp = await client.get("/ui/password/change")
+                assert resp.status_code == 200
+                assert "Change Password" in resp.text
+
+        asyncio.run(_run())


### PR DESCRIPTION
## feat(auth): [UI] forgot password and password change pages

## Summary
Jinja2/HTMX pages for forgot password, reset password (with token), and password change (authenticated).

## Changes
- [x] Forgot password page (`/ui/password/reset`)
- [x] Reset password page (`/ui/password/reset-verify?token=...`)
- [x] Password change page (`/ui/password/change`, requires session)
- [x] Success and error state display
- [x] `change_password` service method + `python-multipart` dependency
- [x] BDD features (3 scenarios) + integration tests (4 tests)

Closes #26

## Test Plan
- [x] `make format` - code formatted
- [x] `make lint` - no linting errors
- [x] `make typecheck` - type checks pass
- [x] `make test` - all unit tests pass (317 passed)
- [x] `make bdd` - all BDD tests pass (28 scenarios, 88 steps)
- [x] `make check-license` - SPDX headers present