### PR TITLE
feat(models): OAuth2Client

### DIFF
--- a/alembic/versions/0008_add_oauth2_clients.py
+++ b/alembic/versions/0008_add_oauth2_clients.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Add oauth2_clients table.
+
+Revision ID: 0008
+Revises: 0007
+Create Date: 2026-03-19
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0008"
+down_revision: Union[str, None] = "0007"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create oauth2_clients table."""
+    op.create_table(
+        "oauth2_clients",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("client_id", sa.String(255), nullable=False),
+        sa.Column("client_secret_hash", sa.Text(), nullable=True),
+        sa.Column("client_name", sa.String(255), nullable=False),
+        sa.Column(
+            "client_type",
+            sa.String(12),
+            nullable=False,
+            server_default="confidential",
+        ),
+        sa.Column("redirect_uris", sa.Text(), nullable=False, server_default="[]"),
+        sa.Column("grant_types", sa.Text(), nullable=False, server_default="[]"),
+        sa.Column("response_types", sa.Text(), nullable=False, server_default="[]"),
+        sa.Column("scopes", sa.Text(), nullable=False, server_default="[]"),
+        sa.Column("logo_uri", sa.String(2048), nullable=True),
+        sa.Column("tos_uri", sa.String(2048), nullable=True),
+        sa.Column("policy_uri", sa.String(2048), nullable=True),
+        sa.Column("contacts", sa.Text(), nullable=False, server_default="[]"),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default="true"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_oauth2_clients")),
+        sa.UniqueConstraint("client_id", name=op.f("uq_oauth2_clients_client_id")),
+    )
+    op.create_index(
+        op.f("ix_oauth2_clients_client_id"), "oauth2_clients", ["client_id"]
+    )
+
+
+def downgrade() -> None:
+    """Drop oauth2_clients table."""
+    op.drop_table("oauth2_clients")

--- a/src/shomer/models/__init__.py
+++ b/src/shomer/models/__init__.py
@@ -9,6 +9,7 @@ can resolve all relationships at configuration time.
 
 from shomer.models.access_token import AccessToken as AccessToken
 from shomer.models.jwk import JWK as JWK
+from shomer.models.oauth2_client import OAuth2Client as OAuth2Client
 from shomer.models.password_reset_token import PasswordResetToken as PasswordResetToken
 from shomer.models.refresh_token import RefreshToken as RefreshToken
 from shomer.models.session import Session as Session

--- a/src/shomer/models/oauth2_client.py
+++ b/src/shomer/models/oauth2_client.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""OAuth2Client model for RFC 6749 client registration."""
+
+from __future__ import annotations
+
+import enum
+
+from sqlalchemy import Boolean, Enum, String, Text
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from shomer.core.database import Base, TimestampMixin, UUIDMixin
+
+
+class ClientType(str, enum.Enum):
+    """OAuth2 client type per RFC 6749 §2.1.
+
+    Attributes
+    ----------
+    CONFIDENTIAL
+        Client capable of maintaining the confidentiality of its credentials.
+    PUBLIC
+        Client incapable of maintaining the confidentiality of its credentials.
+    """
+
+    CONFIDENTIAL = "confidential"
+    PUBLIC = "public"
+
+
+class OAuth2Client(Base, UUIDMixin, TimestampMixin):
+    """OAuth2 client entity.
+
+    Stores client credentials, allowed grant types, redirect URIs,
+    and OIDC metadata per RFC 6749 and OpenID Connect Dynamic Registration.
+
+    Attributes
+    ----------
+    id : uuid.UUID
+        Primary key (from UUIDMixin).
+    client_id : str
+        Unique client identifier (indexed).
+    client_secret_hash : str or None
+        Hashed client secret (None for public clients).
+    client_name : str
+        Human-readable client name.
+    client_type : ClientType
+        Confidential or public.
+    redirect_uris : list
+        Allowed redirect URIs (JSON array).
+    grant_types : list
+        Allowed grant types (JSON array).
+    response_types : list
+        Allowed response types (JSON array).
+    scopes : list
+        Allowed scopes (JSON array).
+    logo_uri : str or None
+        URL of the client logo.
+    tos_uri : str or None
+        URL of the Terms of Service.
+    policy_uri : str or None
+        URL of the privacy policy.
+    contacts : list
+        Contact email addresses (JSON array).
+    is_active : bool
+        Whether the client is active.
+    created_at : datetime
+        Row creation timestamp (from TimestampMixin).
+    updated_at : datetime
+        Last update timestamp (from TimestampMixin).
+    """
+
+    __tablename__ = "oauth2_clients"
+
+    client_id: Mapped[str] = mapped_column(
+        String(255),
+        unique=True,
+        nullable=False,
+        index=True,
+    )
+    client_secret_hash: Mapped[str | None] = mapped_column(
+        Text,
+        nullable=True,
+    )
+    client_name: Mapped[str] = mapped_column(
+        String(255),
+        nullable=False,
+    )
+    client_type: Mapped[ClientType] = mapped_column(
+        Enum(ClientType, name="client_type", native_enum=False),
+        default=ClientType.CONFIDENTIAL,
+        nullable=False,
+    )
+    redirect_uris: Mapped[list[str]] = mapped_column(
+        JSONB().with_variant(Text, "sqlite"),
+        default=list,
+        nullable=False,
+    )
+    grant_types: Mapped[list[str]] = mapped_column(
+        JSONB().with_variant(Text, "sqlite"),
+        default=list,
+        nullable=False,
+    )
+    response_types: Mapped[list[str]] = mapped_column(
+        JSONB().with_variant(Text, "sqlite"),
+        default=list,
+        nullable=False,
+    )
+    scopes: Mapped[list[str]] = mapped_column(
+        JSONB().with_variant(Text, "sqlite"),
+        default=list,
+        nullable=False,
+    )
+
+    # OIDC metadata
+    logo_uri: Mapped[str | None] = mapped_column(
+        String(2048),
+        nullable=True,
+    )
+    tos_uri: Mapped[str | None] = mapped_column(
+        String(2048),
+        nullable=True,
+    )
+    policy_uri: Mapped[str | None] = mapped_column(
+        String(2048),
+        nullable=True,
+    )
+    contacts: Mapped[list[str]] = mapped_column(
+        JSONB().with_variant(Text, "sqlite"),
+        default=list,
+        nullable=False,
+    )
+
+    is_active: Mapped[bool] = mapped_column(
+        Boolean,
+        default=True,
+        nullable=False,
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<OAuth2Client client_id={self.client_id} type={self.client_type.value}>"
+        )

--- a/tests/models/test_oauth2_client.py
+++ b/tests/models/test_oauth2_client.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Unit tests for OAuth2Client model."""
+
+from shomer.models.oauth2_client import ClientType, OAuth2Client
+
+
+class TestClientType:
+    """Tests for ClientType enum."""
+
+    def test_confidential_value(self) -> None:
+        assert ClientType.CONFIDENTIAL.value == "confidential"
+
+    def test_public_value(self) -> None:
+        assert ClientType.PUBLIC.value == "public"
+
+    def test_is_str_enum(self) -> None:
+        assert isinstance(ClientType.CONFIDENTIAL, str)
+
+
+class TestOAuth2ClientModel:
+    """Tests for OAuth2Client SQLAlchemy model definition."""
+
+    def test_tablename(self) -> None:
+        assert OAuth2Client.__tablename__ == "oauth2_clients"
+
+    def test_required_fields(self) -> None:
+        client = OAuth2Client(
+            client_id="my-app",
+            client_name="My App",
+        )
+        assert client.client_id == "my-app"
+        assert client.client_name == "My App"
+
+    def test_client_id_unique(self) -> None:
+        col = OAuth2Client.__table__.c.client_id
+        assert col.unique is True
+
+    def test_client_id_indexed(self) -> None:
+        col = OAuth2Client.__table__.c.client_id
+        assert col.index is True
+
+    def test_client_id_not_nullable(self) -> None:
+        col = OAuth2Client.__table__.c.client_id
+        assert col.nullable is False
+
+    def test_client_secret_hash_nullable(self) -> None:
+        col = OAuth2Client.__table__.c.client_secret_hash
+        assert col.nullable is True
+
+    def test_client_type_default(self) -> None:
+        col = OAuth2Client.__table__.c.client_type
+        assert col.default.arg is ClientType.CONFIDENTIAL
+
+    def test_client_type_not_nullable(self) -> None:
+        col = OAuth2Client.__table__.c.client_type
+        assert col.nullable is False
+
+    def test_is_active_default(self) -> None:
+        col = OAuth2Client.__table__.c.is_active
+        assert col.default.arg is True
+
+    def test_redirect_uris_not_nullable(self) -> None:
+        col = OAuth2Client.__table__.c.redirect_uris
+        assert col.nullable is False
+
+    def test_grant_types_not_nullable(self) -> None:
+        col = OAuth2Client.__table__.c.grant_types
+        assert col.nullable is False
+
+    def test_response_types_not_nullable(self) -> None:
+        col = OAuth2Client.__table__.c.response_types
+        assert col.nullable is False
+
+    def test_scopes_not_nullable(self) -> None:
+        col = OAuth2Client.__table__.c.scopes
+        assert col.nullable is False
+
+    def test_oidc_metadata_nullable(self) -> None:
+        assert OAuth2Client.__table__.c.logo_uri.nullable is True
+        assert OAuth2Client.__table__.c.tos_uri.nullable is True
+        assert OAuth2Client.__table__.c.policy_uri.nullable is True
+
+    def test_contacts_not_nullable(self) -> None:
+        col = OAuth2Client.__table__.c.contacts
+        assert col.nullable is False
+
+    def test_repr_confidential(self) -> None:
+        client = OAuth2Client(
+            client_id="test-app",
+            client_name="Test",
+            client_type=ClientType.CONFIDENTIAL,
+        )
+        r = repr(client)
+        assert "client_id=test-app" in r
+        assert "type=confidential" in r
+
+    def test_repr_public(self) -> None:
+        client = OAuth2Client(
+            client_id="spa",
+            client_name="SPA",
+            client_type=ClientType.PUBLIC,
+        )
+        assert "type=public" in repr(client)
+
+    def test_all_fields(self) -> None:
+        client = OAuth2Client(
+            client_id="full-app",
+            client_name="Full App",
+            client_secret_hash="hashed",
+            client_type=ClientType.CONFIDENTIAL,
+            redirect_uris=["https://app.example.com/callback"],
+            grant_types=["authorization_code", "refresh_token"],
+            response_types=["code"],
+            scopes=["openid", "profile", "email"],
+            logo_uri="https://app.example.com/logo.png",
+            tos_uri="https://app.example.com/tos",
+            policy_uri="https://app.example.com/privacy",
+            contacts=["admin@example.com"],
+        )
+        assert client.client_secret_hash == "hashed"
+        assert client.redirect_uris == ["https://app.example.com/callback"]
+        assert client.grant_types == ["authorization_code", "refresh_token"]
+        assert client.response_types == ["code"]
+        assert client.scopes == ["openid", "profile", "email"]
+        assert client.logo_uri == "https://app.example.com/logo.png"
+        assert client.contacts == ["admin@example.com"]


### PR DESCRIPTION
## feat(models): OAuth2Client

## Summary

OAuth2Client model with client credentials, allowed grant types, redirect URIs, and OIDC metadata per RFC 6749.

## Changes

- [x] OAuth2Client model (client_id, client_secret_hash, client_name, client_type, redirect_uris, grant_types, response_types, scopes)
- [x] ClientType enum (confidential, public)
- [x] JSON columns (JSONB with SQLite Text variant) for arrays
- [x] OIDC metadata fields (logo_uri, tos_uri, policy_uri, contacts)
- [x] Alembic migration (0008)
- [x] Unit tests (21 tests)

Closes #27

## Test Plan

- [x] `make format` - code formatted
- [x] `make lint` - no linting errors
- [x] `make typecheck` - type checks pass
- [x] `make test` - all unit tests pass (345 passed)
- [x] `make bdd` - all BDD tests pass (43 scenarios, 170 steps)
- [x] `make check-license` - SPDX headers present