### PR TITLE
feat(oauth2): OAuth2 client management service

### DIFF
--- a/alembic/versions/0009_add_token_endpoint_auth_method.py
+++ b/alembic/versions/0009_add_token_endpoint_auth_method.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Add token_endpoint_auth_method to oauth2_clients.
+
+Revision ID: 0009
+Revises: 0008
+Create Date: 2026-03-19
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0009"
+down_revision: Union[str, None] = "0008"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add token_endpoint_auth_method column."""
+    op.add_column(
+        "oauth2_clients",
+        sa.Column(
+            "token_endpoint_auth_method",
+            sa.String(20),
+            nullable=False,
+            server_default="client_secret_basic",
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Remove token_endpoint_auth_method column."""
+    op.drop_column("oauth2_clients", "token_endpoint_auth_method")

--- a/src/shomer/models/oauth2_client.py
+++ b/src/shomer/models/oauth2_client.py
@@ -7,8 +7,7 @@ from __future__ import annotations
 
 import enum
 
-from sqlalchemy import Boolean, Enum, String, Text
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy import JSON, Boolean, Enum, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from shomer.core.database import Base, TimestampMixin, UUIDMixin
@@ -27,6 +26,24 @@ class ClientType(str, enum.Enum):
 
     CONFIDENTIAL = "confidential"
     PUBLIC = "public"
+
+
+class TokenEndpointAuthMethod(str, enum.Enum):
+    """Token endpoint authentication method per RFC 6749 §2.3 / OIDC Core §9.
+
+    Attributes
+    ----------
+    CLIENT_SECRET_BASIC
+        HTTP Basic authentication with client_id:client_secret.
+    CLIENT_SECRET_POST
+        client_id and client_secret in the POST body.
+    NONE
+        No authentication (public clients).
+    """
+
+    CLIENT_SECRET_BASIC = "client_secret_basic"
+    CLIENT_SECRET_POST = "client_secret_post"
+    NONE = "none"
 
 
 class OAuth2Client(Base, UUIDMixin, TimestampMixin):
@@ -63,6 +80,8 @@ class OAuth2Client(Base, UUIDMixin, TimestampMixin):
         URL of the privacy policy.
     contacts : list
         Contact email addresses (JSON array).
+    token_endpoint_auth_method : TokenEndpointAuthMethod
+        How this client authenticates at the token endpoint.
     is_active : bool
         Whether the client is active.
     created_at : datetime
@@ -93,22 +112,22 @@ class OAuth2Client(Base, UUIDMixin, TimestampMixin):
         nullable=False,
     )
     redirect_uris: Mapped[list[str]] = mapped_column(
-        JSONB().with_variant(Text, "sqlite"),
+        JSON,
         default=list,
         nullable=False,
     )
     grant_types: Mapped[list[str]] = mapped_column(
-        JSONB().with_variant(Text, "sqlite"),
+        JSON,
         default=list,
         nullable=False,
     )
     response_types: Mapped[list[str]] = mapped_column(
-        JSONB().with_variant(Text, "sqlite"),
+        JSON,
         default=list,
         nullable=False,
     )
     scopes: Mapped[list[str]] = mapped_column(
-        JSONB().with_variant(Text, "sqlite"),
+        JSON,
         default=list,
         nullable=False,
     )
@@ -127,8 +146,18 @@ class OAuth2Client(Base, UUIDMixin, TimestampMixin):
         nullable=True,
     )
     contacts: Mapped[list[str]] = mapped_column(
-        JSONB().with_variant(Text, "sqlite"),
+        JSON,
         default=list,
+        nullable=False,
+    )
+
+    token_endpoint_auth_method: Mapped[TokenEndpointAuthMethod] = mapped_column(
+        Enum(
+            TokenEndpointAuthMethod,
+            name="token_endpoint_auth_method",
+            native_enum=False,
+        ),
+        default=TokenEndpointAuthMethod.CLIENT_SECRET_BASIC,
         nullable=False,
     )
 

--- a/src/shomer/services/oauth2_client_service.py
+++ b/src/shomer/services/oauth2_client_service.py
@@ -1,0 +1,305 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""OAuth2 client management service per RFC 6749 §2.3."""
+
+from __future__ import annotations
+
+import base64
+import secrets
+from urllib.parse import urlparse
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from shomer.core.security import hash_password, verify_password
+from shomer.models.oauth2_client import (
+    ClientType,
+    OAuth2Client,
+    TokenEndpointAuthMethod,
+)
+
+
+class InvalidClientError(Exception):
+    """Raised when client authentication fails."""
+
+
+class InvalidRedirectURIError(Exception):
+    """Raised when a redirect URI is invalid."""
+
+
+class OAuth2ClientService:
+    """Manage OAuth2 clients: creation, authentication, redirect validation.
+
+    Attributes
+    ----------
+    session : AsyncSession
+        Database session.
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def create_client(
+        self,
+        *,
+        client_name: str,
+        client_type: ClientType = ClientType.CONFIDENTIAL,
+        redirect_uris: list[str] | None = None,
+        grant_types: list[str] | None = None,
+        response_types: list[str] | None = None,
+        scopes: list[str] | None = None,
+        token_endpoint_auth_method: TokenEndpointAuthMethod | None = None,
+    ) -> tuple[OAuth2Client, str | None]:
+        """Create a new OAuth2 client.
+
+        Generates a random ``client_id`` and, for confidential clients,
+        a random ``client_secret`` hashed with Argon2id.
+
+        Parameters
+        ----------
+        client_name : str
+            Human-readable client name.
+        client_type : ClientType
+            Confidential or public.
+        redirect_uris : list[str] or None
+            Allowed redirect URIs.
+        grant_types : list[str] or None
+            Allowed grant types.
+        response_types : list[str] or None
+            Allowed response types.
+        scopes : list[str] or None
+            Allowed scopes.
+        token_endpoint_auth_method : TokenEndpointAuthMethod or None
+            Auth method. Defaults to ``client_secret_basic`` for
+            confidential, ``none`` for public.
+
+        Returns
+        -------
+        tuple[OAuth2Client, str | None]
+            The created client and the raw client_secret (None for public).
+        """
+        client_id = secrets.token_urlsafe(24)
+        raw_secret: str | None = None
+        secret_hash: str | None = None
+
+        if client_type == ClientType.CONFIDENTIAL:
+            raw_secret = secrets.token_urlsafe(48)
+            secret_hash = hash_password(raw_secret)
+
+        if token_endpoint_auth_method is None:
+            token_endpoint_auth_method = (
+                TokenEndpointAuthMethod.CLIENT_SECRET_BASIC
+                if client_type == ClientType.CONFIDENTIAL
+                else TokenEndpointAuthMethod.NONE
+            )
+
+        # Validate redirect URIs
+        for uri in redirect_uris or []:
+            self._validate_redirect_uri(uri)
+
+        client = OAuth2Client(
+            client_id=client_id,
+            client_secret_hash=secret_hash,
+            client_name=client_name,
+            client_type=client_type,
+            redirect_uris=redirect_uris or [],
+            grant_types=grant_types or [],
+            response_types=response_types or [],
+            scopes=scopes or [],
+            token_endpoint_auth_method=token_endpoint_auth_method,
+        )
+        self.session.add(client)
+        await self.session.flush()
+        return client, raw_secret
+
+    async def get_by_client_id(self, client_id: str) -> OAuth2Client | None:
+        """Look up a client by its client_id.
+
+        Parameters
+        ----------
+        client_id : str
+            The unique client identifier.
+
+        Returns
+        -------
+        OAuth2Client or None
+            The client if found and active.
+        """
+        stmt = select(OAuth2Client).where(
+            OAuth2Client.client_id == client_id,
+            OAuth2Client.is_active == True,  # noqa: E712
+        )
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def authenticate_client(
+        self,
+        *,
+        authorization_header: str | None = None,
+        body_client_id: str | None = None,
+        body_client_secret: str | None = None,
+    ) -> OAuth2Client:
+        """Authenticate an OAuth2 client per RFC 6749 §2.3.
+
+        Supports ``client_secret_basic`` (HTTP Basic), ``client_secret_post``
+        (POST body), and ``none`` (public client).
+
+        Parameters
+        ----------
+        authorization_header : str or None
+            Value of the ``Authorization`` header (for Basic auth).
+        body_client_id : str or None
+            ``client_id`` from the request body.
+        body_client_secret : str or None
+            ``client_secret`` from the request body.
+
+        Returns
+        -------
+        OAuth2Client
+            The authenticated client.
+
+        Raises
+        ------
+        InvalidClientError
+            If authentication fails.
+        """
+        client_id: str | None = None
+        client_secret: str | None = None
+
+        # Try HTTP Basic first (RFC 6749 §2.3.1)
+        if authorization_header and authorization_header.startswith("Basic "):
+            client_id, client_secret = self._parse_basic_auth(authorization_header)
+        elif body_client_id:
+            client_id = body_client_id
+            client_secret = body_client_secret
+
+        if not client_id:
+            raise InvalidClientError("Missing client credentials")
+
+        client = await self.get_by_client_id(client_id)
+        if client is None:
+            # Dummy hash to prevent timing enumeration
+            hash_password("dummy")
+            raise InvalidClientError("Invalid client credentials")
+
+        method = client.token_endpoint_auth_method
+
+        if method == TokenEndpointAuthMethod.NONE:
+            # Public client — no secret required
+            if client.client_type != ClientType.PUBLIC:
+                raise InvalidClientError(
+                    "auth method 'none' only allowed for public clients"
+                )
+            return client
+
+        if method in (
+            TokenEndpointAuthMethod.CLIENT_SECRET_BASIC,
+            TokenEndpointAuthMethod.CLIENT_SECRET_POST,
+        ):
+            if not client_secret or not client.client_secret_hash:
+                raise InvalidClientError("Client secret required")
+            if not verify_password(client_secret, client.client_secret_hash):
+                raise InvalidClientError("Invalid client credentials")
+            return client
+
+        raise InvalidClientError(f"Unsupported auth method: {method}")
+
+    async def rotate_secret(self, client_id: str) -> tuple[OAuth2Client, str]:
+        """Generate a new secret for a confidential client.
+
+        Parameters
+        ----------
+        client_id : str
+            The client identifier.
+
+        Returns
+        -------
+        tuple[OAuth2Client, str]
+            The updated client and the new raw secret.
+
+        Raises
+        ------
+        InvalidClientError
+            If the client is not found or is public.
+        """
+        client = await self.get_by_client_id(client_id)
+        if client is None:
+            raise InvalidClientError("Client not found")
+        if client.client_type == ClientType.PUBLIC:
+            raise InvalidClientError("Cannot rotate secret for public client")
+
+        new_secret = secrets.token_urlsafe(48)
+        client.client_secret_hash = hash_password(new_secret)
+        await self.session.flush()
+        return client, new_secret
+
+    def validate_redirect_uri(self, client: OAuth2Client, redirect_uri: str) -> None:
+        """Validate a redirect URI against the client's registered URIs.
+
+        Per RFC 6749 §3.1.2.2: exact string match, no fragments.
+
+        Parameters
+        ----------
+        client : OAuth2Client
+            The client to validate against.
+        redirect_uri : str
+            The URI to validate.
+
+        Raises
+        ------
+        InvalidRedirectURIError
+            If the URI is not registered or contains a fragment.
+        """
+        self._validate_redirect_uri(redirect_uri)
+        if redirect_uri not in client.redirect_uris:
+            raise InvalidRedirectURIError(
+                f"Redirect URI not registered: {redirect_uri}"
+            )
+
+    @staticmethod
+    def _validate_redirect_uri(uri: str) -> None:
+        """Validate a redirect URI format.
+
+        Parameters
+        ----------
+        uri : str
+            URI to validate.
+
+        Raises
+        ------
+        InvalidRedirectURIError
+            If the URI has a fragment or is malformed.
+        """
+        parsed = urlparse(uri)
+        if parsed.fragment:
+            raise InvalidRedirectURIError("Redirect URI must not contain a fragment")
+        if not parsed.scheme or not parsed.netloc:
+            raise InvalidRedirectURIError(f"Malformed redirect URI: {uri}")
+
+    @staticmethod
+    def _parse_basic_auth(header: str) -> tuple[str, str]:
+        """Parse an HTTP Basic Authorization header.
+
+        Parameters
+        ----------
+        header : str
+            The full ``Authorization: Basic ...`` header value.
+
+        Returns
+        -------
+        tuple[str, str]
+            ``(client_id, client_secret)``.
+
+        Raises
+        ------
+        InvalidClientError
+            If the header is malformed.
+        """
+        try:
+            encoded = header[len("Basic ") :]
+            decoded = base64.b64decode(encoded).decode("utf-8")
+            client_id, client_secret = decoded.split(":", 1)
+            return client_id, client_secret
+        except Exception as exc:
+            raise InvalidClientError("Malformed Basic Authorization header") from exc

--- a/tests/services/test_oauth2_client_service.py
+++ b/tests/services/test_oauth2_client_service.py
@@ -1,0 +1,336 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Unit tests for OAuth2ClientService."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+from collections.abc import Iterator
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from shomer.core.database import Base
+from shomer.models.access_token import AccessToken  # noqa: F401
+from shomer.models.jwk import JWK  # noqa: F401
+from shomer.models.oauth2_client import (
+    ClientType,
+    TokenEndpointAuthMethod,
+)
+from shomer.models.password_reset_token import PasswordResetToken  # noqa: F401
+from shomer.models.refresh_token import RefreshToken  # noqa: F401
+from shomer.models.session import Session  # noqa: F401
+from shomer.models.user import User  # noqa: F401
+from shomer.models.user_email import UserEmail  # noqa: F401
+from shomer.models.user_password import UserPassword  # noqa: F401
+from shomer.models.user_profile import UserProfile  # noqa: F401
+from shomer.models.verification_code import VerificationCode  # noqa: F401
+from shomer.services.oauth2_client_service import (
+    InvalidClientError,
+    InvalidRedirectURIError,
+    OAuth2ClientService,
+)
+
+_ENGINE = create_async_engine(
+    "sqlite+aiosqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+_SESSION_FACTORY = async_sessionmaker(_ENGINE, expire_on_commit=False)
+
+
+@pytest.fixture(autouse=True)
+def _setup_db() -> Iterator[None]:
+    async def _create() -> None:
+        async with _ENGINE.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+    asyncio.run(_create())
+    yield
+
+    async def _drop() -> None:
+        async with _ENGINE.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+
+    asyncio.run(_drop())
+
+
+class TestCreateClient:
+    """Tests for OAuth2ClientService.create_client()."""
+
+    def test_creates_confidential_client(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                svc = OAuth2ClientService(db)
+                client, secret = await svc.create_client(
+                    client_name="My App",
+                    redirect_uris=["https://app.example.com/callback"],
+                )
+                assert client.client_id is not None
+                assert secret is not None
+                assert client.client_secret_hash is not None
+                assert client.client_type == ClientType.CONFIDENTIAL
+                assert (
+                    client.token_endpoint_auth_method
+                    == TokenEndpointAuthMethod.CLIENT_SECRET_BASIC
+                )
+
+        asyncio.run(_run())
+
+    def test_creates_public_client(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                svc = OAuth2ClientService(db)
+                client, secret = await svc.create_client(
+                    client_name="SPA",
+                    client_type=ClientType.PUBLIC,
+                    redirect_uris=["https://spa.example.com/callback"],
+                )
+                assert secret is None
+                assert client.client_secret_hash is None
+                assert client.client_type == ClientType.PUBLIC
+                assert client.token_endpoint_auth_method == TokenEndpointAuthMethod.NONE
+
+        asyncio.run(_run())
+
+    def test_rejects_redirect_uri_with_fragment(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                svc = OAuth2ClientService(db)
+                with pytest.raises(InvalidRedirectURIError, match="fragment"):
+                    await svc.create_client(
+                        client_name="Bad",
+                        redirect_uris=["https://app.example.com/cb#frag"],
+                    )
+
+        asyncio.run(_run())
+
+    def test_rejects_malformed_redirect_uri(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                svc = OAuth2ClientService(db)
+                with pytest.raises(InvalidRedirectURIError, match="Malformed"):
+                    await svc.create_client(
+                        client_name="Bad",
+                        redirect_uris=["not-a-uri"],
+                    )
+
+        asyncio.run(_run())
+
+
+class TestGetByClientId:
+    """Tests for OAuth2ClientService.get_by_client_id()."""
+
+    def test_finds_client(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                svc = OAuth2ClientService(db)
+                client, _ = await svc.create_client(client_name="App")
+                found = await svc.get_by_client_id(client.client_id)
+                assert found is not None
+                assert found.client_id == client.client_id
+
+        asyncio.run(_run())
+
+    def test_returns_none_for_unknown(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                svc = OAuth2ClientService(db)
+                assert await svc.get_by_client_id("nonexistent") is None
+
+        asyncio.run(_run())
+
+
+class TestAuthenticateClient:
+    """Tests for OAuth2ClientService.authenticate_client()."""
+
+    def test_basic_auth_success(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                svc = OAuth2ClientService(db)
+                client, secret = await svc.create_client(client_name="App")
+                assert secret is not None
+                header = (
+                    "Basic "
+                    + base64.b64encode(f"{client.client_id}:{secret}".encode()).decode()
+                )
+                authed = await svc.authenticate_client(authorization_header=header)
+                assert authed.client_id == client.client_id
+
+        asyncio.run(_run())
+
+    def test_post_body_auth_success(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                svc = OAuth2ClientService(db)
+                client, secret = await svc.create_client(
+                    client_name="App",
+                    token_endpoint_auth_method=TokenEndpointAuthMethod.CLIENT_SECRET_POST,
+                )
+                assert secret is not None
+                authed = await svc.authenticate_client(
+                    body_client_id=client.client_id,
+                    body_client_secret=secret,
+                )
+                assert authed.client_id == client.client_id
+
+        asyncio.run(_run())
+
+    def test_none_auth_public_client(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                svc = OAuth2ClientService(db)
+                client, _ = await svc.create_client(
+                    client_name="SPA",
+                    client_type=ClientType.PUBLIC,
+                )
+                authed = await svc.authenticate_client(
+                    body_client_id=client.client_id,
+                )
+                assert authed.client_id == client.client_id
+
+        asyncio.run(_run())
+
+    def test_wrong_secret_raises(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                svc = OAuth2ClientService(db)
+                client, _ = await svc.create_client(client_name="App")
+                header = (
+                    "Basic "
+                    + base64.b64encode(f"{client.client_id}:wrong".encode()).decode()
+                )
+                with pytest.raises(InvalidClientError):
+                    await svc.authenticate_client(authorization_header=header)
+
+        asyncio.run(_run())
+
+    def test_unknown_client_raises(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                svc = OAuth2ClientService(db)
+                header = "Basic " + base64.b64encode(b"unknown:secret").decode()
+                with pytest.raises(InvalidClientError):
+                    await svc.authenticate_client(authorization_header=header)
+
+        asyncio.run(_run())
+
+    def test_missing_credentials_raises(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                svc = OAuth2ClientService(db)
+                with pytest.raises(InvalidClientError, match="Missing"):
+                    await svc.authenticate_client()
+
+        asyncio.run(_run())
+
+    def test_malformed_basic_header_raises(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                svc = OAuth2ClientService(db)
+                with pytest.raises(InvalidClientError, match="Malformed"):
+                    await svc.authenticate_client(
+                        authorization_header="Basic !!!invalid!!!"
+                    )
+
+        asyncio.run(_run())
+
+
+class TestRotateSecret:
+    """Tests for OAuth2ClientService.rotate_secret()."""
+
+    def test_rotates_secret(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                svc = OAuth2ClientService(db)
+                client, old_secret = await svc.create_client(client_name="App")
+                assert old_secret is not None
+                _, new_secret = await svc.rotate_secret(client.client_id)
+                assert new_secret != old_secret
+                # Old secret should no longer work
+                header = (
+                    "Basic "
+                    + base64.b64encode(
+                        f"{client.client_id}:{old_secret}".encode()
+                    ).decode()
+                )
+                with pytest.raises(InvalidClientError):
+                    await svc.authenticate_client(authorization_header=header)
+
+        asyncio.run(_run())
+
+    def test_new_secret_works(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                svc = OAuth2ClientService(db)
+                client, _ = await svc.create_client(client_name="App")
+                _, new_secret = await svc.rotate_secret(client.client_id)
+                header = (
+                    "Basic "
+                    + base64.b64encode(
+                        f"{client.client_id}:{new_secret}".encode()
+                    ).decode()
+                )
+                authed = await svc.authenticate_client(authorization_header=header)
+                assert authed.client_id == client.client_id
+
+        asyncio.run(_run())
+
+    def test_public_client_raises(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                svc = OAuth2ClientService(db)
+                client, _ = await svc.create_client(
+                    client_name="SPA", client_type=ClientType.PUBLIC
+                )
+                with pytest.raises(InvalidClientError, match="public"):
+                    await svc.rotate_secret(client.client_id)
+
+        asyncio.run(_run())
+
+
+class TestValidateRedirectUri:
+    """Tests for OAuth2ClientService.validate_redirect_uri()."""
+
+    def test_valid_uri(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                svc = OAuth2ClientService(db)
+                client, _ = await svc.create_client(
+                    client_name="App",
+                    redirect_uris=["https://app.example.com/callback"],
+                )
+                svc.validate_redirect_uri(client, "https://app.example.com/callback")
+
+        asyncio.run(_run())
+
+    def test_unregistered_uri_raises(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                svc = OAuth2ClientService(db)
+                client, _ = await svc.create_client(
+                    client_name="App",
+                    redirect_uris=["https://app.example.com/callback"],
+                )
+                with pytest.raises(InvalidRedirectURIError, match="not registered"):
+                    svc.validate_redirect_uri(client, "https://evil.com/callback")
+
+        asyncio.run(_run())
+
+    def test_fragment_uri_raises(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                svc = OAuth2ClientService(db)
+                client, _ = await svc.create_client(
+                    client_name="App",
+                    redirect_uris=["https://app.example.com/callback"],
+                )
+                with pytest.raises(InvalidRedirectURIError, match="fragment"):
+                    svc.validate_redirect_uri(
+                        client, "https://app.example.com/callback#bad"
+                    )
+
+        asyncio.run(_run())


### PR DESCRIPTION
## feat(oauth2): OAuth2 client management service

## Summary

CRUD service for OAuth2 clients per RFC 6749 §2.3: creation with client_id/secret generation, client authentication (Basic, POST body, none), redirect URI validation, secret rotation.

## Changes

- [x] Client creation with random client_id + Argon2id hashed secret
- [x] Client lookup by client_id
- [x] `client_secret_basic` authentication (RFC 6749 §2.3.1 — HTTP Basic)
- [x] `client_secret_post` authentication (RFC 6749 §2.3.1 — POST body)
- [x] `none` authentication (public clients — client_id only)
- [x] `TokenEndpointAuthMethod` enum + field on OAuth2Client model
- [x] Alembic migration (0009) for new column
- [x] Redirect URI validation (exact match, no fragments per §3.1.2.2)
- [x] Secret rotation (generate new, old invalidated)
- [x] Anti-enumeration: dummy hash on unknown client_id
- [x] JSON columns fixed (JSONB → JSON for SQLite compat)
- [x] Unit tests (19 tests with aiosqlite)

Closes #28

## Test Plan

- [x] `make format` - code formatted
- [x] `make lint` - no linting errors
- [x] `make typecheck` - type checks pass
- [x] `make test` - all unit tests pass (364 passed)
- [x] `make bdd` - all BDD tests pass (43 scenarios, 170 steps)
- [x] `make check-license` - SPDX headers present