### PR TITLE
feat(oauth2): dynamic issuer resolver service

### DIFF
--- a/src/shomer/services/issuer_resolver.py
+++ b/src/shomer/services/issuer_resolver.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Dynamic issuer resolver for multi-tenant OAuth2/OIDC."""
+
+from __future__ import annotations
+
+import uuid
+
+from shomer.core.settings import Settings
+
+
+class IssuerResolver:
+    """Resolve the issuer URL based on the current tenant context.
+
+    In a multi-tenant setup, each tenant may have its own issuer URL
+    (e.g. ``https://tenant1.auth.example.com``). This service provides
+    the correct issuer for JWT ``iss`` claims, OIDC discovery, and
+    token responses.
+
+    Attributes
+    ----------
+    settings : Settings
+        Application configuration with the default issuer.
+    """
+
+    def __init__(self, settings: Settings) -> None:
+        self.settings = settings
+
+    def resolve(self, tenant_id: uuid.UUID | None = None) -> str:
+        """Resolve the issuer URL for the given tenant.
+
+        Parameters
+        ----------
+        tenant_id : uuid.UUID or None
+            The current tenant ID. ``None`` means no tenant context
+            (single-tenant mode).
+
+        Returns
+        -------
+        str
+            The issuer URL. Falls back to the default ``jwt_issuer``
+            setting when no tenant-specific issuer is configured.
+        """
+        if tenant_id is not None:
+            tenant_issuer = self._lookup_tenant_issuer(tenant_id)
+            if tenant_issuer is not None:
+                return tenant_issuer
+
+        return self.settings.jwt_issuer
+
+    def get_token_endpoint(self, tenant_id: uuid.UUID | None = None) -> str:
+        """Return the token endpoint URL for the given tenant.
+
+        Parameters
+        ----------
+        tenant_id : uuid.UUID or None
+            The current tenant ID.
+
+        Returns
+        -------
+        str
+            The token endpoint URL.
+        """
+        return f"{self.resolve(tenant_id)}/auth/token"
+
+    def get_authorization_endpoint(self, tenant_id: uuid.UUID | None = None) -> str:
+        """Return the authorization endpoint URL for the given tenant.
+
+        Parameters
+        ----------
+        tenant_id : uuid.UUID or None
+            The current tenant ID.
+
+        Returns
+        -------
+        str
+            The authorization endpoint URL.
+        """
+        return f"{self.resolve(tenant_id)}/auth/authorize"
+
+    def get_jwks_uri(self, tenant_id: uuid.UUID | None = None) -> str:
+        """Return the JWKS URI for the given tenant.
+
+        Parameters
+        ----------
+        tenant_id : uuid.UUID or None
+            The current tenant ID.
+
+        Returns
+        -------
+        str
+            The JWKS endpoint URL.
+        """
+        return f"{self.resolve(tenant_id)}/.well-known/jwks.json"
+
+    def get_userinfo_endpoint(self, tenant_id: uuid.UUID | None = None) -> str:
+        """Return the userinfo endpoint URL for the given tenant.
+
+        Parameters
+        ----------
+        tenant_id : uuid.UUID or None
+            The current tenant ID.
+
+        Returns
+        -------
+        str
+            The userinfo endpoint URL.
+        """
+        return f"{self.resolve(tenant_id)}/userinfo"
+
+    @staticmethod
+    def _lookup_tenant_issuer(tenant_id: uuid.UUID) -> str | None:
+        """Look up a tenant-specific issuer URL.
+
+        This is a placeholder. The real implementation will query the
+        tenant table (M18) to resolve custom domains and issuers.
+
+        Parameters
+        ----------
+        tenant_id : uuid.UUID
+            Tenant to look up.
+
+        Returns
+        -------
+        str or None
+            The tenant issuer URL, or ``None`` if not configured.
+        """
+        # Placeholder — will be wired in M18 (multi-tenancy)
+        return None

--- a/tests/services/test_issuer_resolver.py
+++ b/tests/services/test_issuer_resolver.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Unit tests for IssuerResolver."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import patch
+
+from shomer.core.settings import Settings
+from shomer.services.issuer_resolver import IssuerResolver
+
+_ISSUER = "https://auth.shomer.local"
+
+
+def _settings(**overrides: str) -> Settings:
+    defaults: dict[str, str] = {"jwt_issuer": _ISSUER}
+    defaults.update(overrides)
+    return Settings(**defaults)  # type: ignore[arg-type]
+
+
+class TestResolve:
+    """Tests for IssuerResolver.resolve()."""
+
+    def test_default_issuer_when_no_tenant(self) -> None:
+        resolver = IssuerResolver(_settings())
+        assert resolver.resolve() == _ISSUER
+
+    def test_default_issuer_when_tenant_has_no_custom(self) -> None:
+        resolver = IssuerResolver(_settings())
+        assert resolver.resolve(uuid.uuid4()) == _ISSUER
+
+    def test_tenant_specific_issuer(self) -> None:
+        resolver = IssuerResolver(_settings())
+        tenant_id = uuid.uuid4()
+        with patch.object(
+            IssuerResolver,
+            "_lookup_tenant_issuer",
+            return_value="https://tenant1.auth.example.com",
+        ):
+            assert resolver.resolve(tenant_id) == "https://tenant1.auth.example.com"
+
+    def test_custom_default_issuer(self) -> None:
+        resolver = IssuerResolver(_settings(jwt_issuer="https://custom.example.com"))
+        assert resolver.resolve() == "https://custom.example.com"
+
+
+class TestEndpoints:
+    """Tests for endpoint URL builders."""
+
+    def test_token_endpoint(self) -> None:
+        resolver = IssuerResolver(_settings())
+        assert resolver.get_token_endpoint() == f"{_ISSUER}/auth/token"
+
+    def test_authorization_endpoint(self) -> None:
+        resolver = IssuerResolver(_settings())
+        assert resolver.get_authorization_endpoint() == f"{_ISSUER}/auth/authorize"
+
+    def test_jwks_uri(self) -> None:
+        resolver = IssuerResolver(_settings())
+        assert resolver.get_jwks_uri() == f"{_ISSUER}/.well-known/jwks.json"
+
+    def test_userinfo_endpoint(self) -> None:
+        resolver = IssuerResolver(_settings())
+        assert resolver.get_userinfo_endpoint() == f"{_ISSUER}/userinfo"
+
+    def test_endpoints_with_tenant(self) -> None:
+        resolver = IssuerResolver(_settings())
+        tenant_id = uuid.uuid4()
+        with patch.object(
+            IssuerResolver,
+            "_lookup_tenant_issuer",
+            return_value="https://t1.example.com",
+        ):
+            assert (
+                resolver.get_token_endpoint(tenant_id)
+                == "https://t1.example.com/auth/token"
+            )
+            assert (
+                resolver.get_jwks_uri(tenant_id)
+                == "https://t1.example.com/.well-known/jwks.json"
+            )
+
+
+class TestLookupPlaceholder:
+    """Tests for the placeholder tenant lookup."""
+
+    def test_placeholder_returns_none(self) -> None:
+        assert IssuerResolver._lookup_tenant_issuer(uuid.uuid4()) is None


### PR DESCRIPTION
## feat(oauth2): dynamic issuer resolver service

## Summary

Service for resolving the issuer URL based on the current tenant. Provides dynamic base URL for tokens and OIDC discovery.

## Changes

- [x] IssuerResolver with tenant-aware `resolve()` method
- [x] Fallback to default `jwt_issuer` setting when no tenant context
- [x] Endpoint URL builders: token, authorization, JWKS, userinfo
- [x] Placeholder `_lookup_tenant_issuer()` for M18 multi-tenancy
- [x] Unit tests (10 tests: default/custom/tenant issuer, all endpoints, placeholder)

Closes #30

## Test Plan

- [x] `make format` - code formatted
- [x] `make lint` - no linting errors
- [x] `make typecheck` - type checks pass
- [x] `make test` - all unit tests pass (355 passed)
- [x] `make bdd` - all BDD tests pass (43 scenarios, 170 steps)
- [x] `make check-license` - SPDX headers present