### PR TITLE
feat(oauth2): GET /oauth2/authorize - request validation

### DIFF
--- a/alembic/versions/0010_add_authorization_codes.py
+++ b/alembic/versions/0010_add_authorization_codes.py
@@ -3,8 +3,8 @@
 
 """Add authorization_codes table.
 
-Revision ID: 0009
-Revises: 0008
+Revision ID: 0010
+Revises: 0009
 Create Date: 2026-03-19
 
 """
@@ -14,8 +14,8 @@ from typing import Sequence, Union
 import sqlalchemy as sa
 from alembic import op
 
-revision: str = "0009"
-down_revision: Union[str, None] = "0008"
+revision: str = "0010"
+down_revision: Union[str, None] = "0009"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/features/oauth2_authorize.feature
+++ b/features/oauth2_authorize.feature
@@ -1,0 +1,10 @@
+Feature: OAuth2 authorization endpoint
+
+  Scenario: Missing client_id without redirect_uri returns 400
+    When I send a GET request to "/oauth2/authorize?response_type=code"
+    Then the response status code should be 400
+    And the response body should contain "client_id"
+
+  Scenario: Missing state without redirect_uri returns 400
+    When I send a GET request to "/oauth2/authorize?client_id=unknown&response_type=code"
+    Then the response status code should be 400

--- a/src/shomer/app.py
+++ b/src/shomer/app.py
@@ -57,6 +57,7 @@ def create_app() -> FastAPI:
     from shomer.routes.docs import router as docs_router
     from shomer.routes.health import router as health_router
     from shomer.routes.jwks import router as jwks_router
+    from shomer.routes.oauth2 import router as oauth2_router
     from shomer.routes.password_ui import router as password_ui_router
     from shomer.routes.views import router as views_router
 
@@ -67,6 +68,7 @@ def create_app() -> FastAPI:
     application.include_router(auth_router)
     application.include_router(auth_ui_router)
     application.include_router(password_ui_router)
+    application.include_router(oauth2_router)
     application.include_router(docs_router)
     application.include_router(jwks_router)
     application.include_router(views_router)

--- a/src/shomer/routes/oauth2.py
+++ b/src/shomer/routes/oauth2.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""OAuth2 endpoints."""
+
+from __future__ import annotations
+
+from urllib.parse import urlencode
+
+from fastapi import APIRouter, Request
+from fastapi.responses import RedirectResponse
+
+from shomer.deps import DbSession
+from shomer.services.authorize_service import AuthorizeError, AuthorizeService
+from shomer.services.session_service import SessionService
+
+router = APIRouter(prefix="/oauth2", tags=["oauth2"])
+
+
+@router.get("/authorize")
+async def authorize(
+    request: Request,
+    db: DbSession,
+    client_id: str | None = None,
+    redirect_uri: str | None = None,
+    response_type: str | None = None,
+    scope: str | None = None,
+    state: str | None = None,
+    nonce: str | None = None,
+    prompt: str | None = None,
+    login_hint: str | None = None,
+    code_challenge: str | None = None,
+    code_challenge_method: str | None = None,
+) -> RedirectResponse:
+    """OAuth2 authorization endpoint per RFC 6749 §4.1.1.
+
+    Validates the request, checks authentication, and either redirects
+    to login, shows consent, or issues an authorization code.
+
+    Parameters
+    ----------
+    request : Request
+        The incoming HTTP request.
+    db : DbSession
+        Injected async database session.
+    client_id : str or None
+        OAuth2 client identifier.
+    redirect_uri : str or None
+        Requested redirect URI.
+    response_type : str or None
+        Must be ``code``.
+    scope : str or None
+        Requested scopes.
+    state : str or None
+        CSRF state parameter.
+    nonce : str or None
+        OIDC nonce.
+    prompt : str or None
+        OIDC prompt parameter.
+    login_hint : str or None
+        OIDC login hint.
+    code_challenge : str or None
+        PKCE code challenge.
+    code_challenge_method : str or None
+        PKCE challenge method.
+
+    Returns
+    -------
+    RedirectResponse
+        Redirect to login, consent, or callback with code.
+    """
+    svc = AuthorizeService(db)
+
+    # Validate request parameters
+    try:
+        auth_request = await svc.validate_request(
+            client_id=client_id,
+            redirect_uri=redirect_uri,
+            response_type=response_type,
+            scope=scope,
+            state=state,
+            nonce=nonce,
+            prompt=prompt,
+            login_hint=login_hint,
+            code_challenge=code_challenge,
+            code_challenge_method=code_challenge_method,
+        )
+    except AuthorizeError as exc:
+        # OWASP: NEVER redirect to an unvalidated redirect_uri.
+        # Only redirect with error if the redirect_uri was already
+        # verified against the client's registered URIs. Since
+        # validate_request() raises before we reach that point for
+        # client_id/redirect_uri errors, we always return 400 here.
+        # The only errors that could occur AFTER redirect_uri validation
+        # (response_type, scope, state) are safe to redirect.
+        safe_redirect = exc.error in (
+            "unsupported_response_type",
+            "unauthorized_client",
+        )
+        if safe_redirect and redirect_uri and state:
+            params = {
+                "error": exc.error,
+                "error_description": exc.description,
+                "state": state,
+            }
+            return RedirectResponse(
+                url=f"{redirect_uri}?{urlencode(params)}", status_code=302
+            )
+        from fastapi import HTTPException, status
+
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"error": exc.error, "error_description": exc.description},
+        )
+
+    # Check if user is authenticated
+    session_token = request.cookies.get("session_id")
+    session_svc = SessionService(db)
+    session = None
+    if session_token:
+        session = await session_svc.validate(session_token)
+
+    if session is None or prompt == "login":
+        # Redirect to login with return URL (URL-encoded to prevent injection)
+        from urllib.parse import quote
+
+        authorize_url = quote(str(request.url), safe="")
+        return RedirectResponse(url=f"/ui/login?next={authorize_url}", status_code=302)
+
+    # For now, auto-approve (consent screen is issue #32)
+    code = await svc.create_authorization_code(
+        request=auth_request, user_id=session.user_id
+    )
+
+    params = {"code": code, "state": auth_request.state}
+    return RedirectResponse(
+        url=f"{auth_request.redirect_uri}?{urlencode(params)}", status_code=302
+    )

--- a/src/shomer/services/authorize_service.py
+++ b/src/shomer/services/authorize_service.py
@@ -1,0 +1,247 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""OAuth2 authorization request validation service per RFC 6749 §4.1."""
+
+from __future__ import annotations
+
+import secrets
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from shomer.models.authorization_code import AuthorizationCode
+from shomer.services.oauth2_client_service import (
+    InvalidRedirectURIError,
+    OAuth2ClientService,
+)
+
+#: Default authorization code lifetime.
+AUTH_CODE_TTL = timedelta(minutes=10)
+
+
+class AuthorizeError(Exception):
+    """Base error for authorization request failures.
+
+    Attributes
+    ----------
+    error : str
+        OAuth2 error code per RFC 6749 §4.1.2.1.
+    description : str
+        Human-readable error description.
+    """
+
+    def __init__(self, error: str, description: str) -> None:
+        self.error = error
+        self.description = description
+        super().__init__(description)
+
+
+@dataclass
+class AuthorizeRequest:
+    """Parsed and validated authorization request parameters.
+
+    Attributes
+    ----------
+    client_id : str
+        The OAuth2 client identifier.
+    redirect_uri : str
+        The validated redirect URI.
+    response_type : str
+        Requested response type (``code``).
+    scope : str
+        Space-separated requested scopes.
+    state : str
+        Opaque state parameter for CSRF protection.
+    nonce : str or None
+        OIDC nonce for ID token binding.
+    prompt : str or None
+        OIDC prompt parameter (login, consent, none).
+    login_hint : str or None
+        OIDC login hint.
+    code_challenge : str or None
+        PKCE code challenge.
+    code_challenge_method : str or None
+        PKCE challenge method (S256 or plain).
+    validated_scopes : list[str]
+        Scopes validated against client allowed scopes.
+    """
+
+    client_id: str
+    redirect_uri: str
+    response_type: str
+    scope: str = ""
+    state: str = ""
+    nonce: str | None = None
+    prompt: str | None = None
+    login_hint: str | None = None
+    code_challenge: str | None = None
+    code_challenge_method: str | None = None
+    validated_scopes: list[str] = field(default_factory=list)
+
+
+class AuthorizeService:
+    """Validate OAuth2 authorization requests and issue authorization codes.
+
+    Attributes
+    ----------
+    session : AsyncSession
+        Database session.
+    client_service : OAuth2ClientService
+        Client management service.
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+        self.client_service = OAuth2ClientService(session)
+
+    async def validate_request(
+        self,
+        *,
+        client_id: str | None,
+        redirect_uri: str | None,
+        response_type: str | None,
+        scope: str | None,
+        state: str | None,
+        nonce: str | None = None,
+        prompt: str | None = None,
+        login_hint: str | None = None,
+        code_challenge: str | None = None,
+        code_challenge_method: str | None = None,
+    ) -> AuthorizeRequest:
+        """Validate all authorization request parameters.
+
+        Parameters
+        ----------
+        client_id : str or None
+            OAuth2 client identifier.
+        redirect_uri : str or None
+            Requested redirect URI.
+        response_type : str or None
+            Requested response type.
+        scope : str or None
+            Requested scopes.
+        state : str or None
+            CSRF state parameter.
+        nonce : str or None
+            OIDC nonce.
+        prompt : str or None
+            OIDC prompt.
+        login_hint : str or None
+            OIDC login hint.
+        code_challenge : str or None
+            PKCE code challenge.
+        code_challenge_method : str or None
+            PKCE challenge method.
+
+        Returns
+        -------
+        AuthorizeRequest
+            The validated request.
+
+        Raises
+        ------
+        AuthorizeError
+            If any parameter is invalid.
+        """
+        # client_id is required
+        if not client_id:
+            raise AuthorizeError("invalid_request", "client_id is required")
+
+        # Look up client
+        client = await self.client_service.get_by_client_id(client_id)
+        if client is None:
+            raise AuthorizeError("invalid_request", "Unknown client_id")
+
+        # redirect_uri is required
+        if not redirect_uri:
+            raise AuthorizeError("invalid_request", "redirect_uri is required")
+
+        # Validate redirect_uri against client
+        try:
+            self.client_service.validate_redirect_uri(client, redirect_uri)
+        except InvalidRedirectURIError as exc:
+            raise AuthorizeError("invalid_request", str(exc)) from exc
+
+        # response_type is required and must be "code"
+        if not response_type:
+            raise AuthorizeError("invalid_request", "response_type is required")
+        if response_type != "code":
+            raise AuthorizeError(
+                "unsupported_response_type",
+                f"Unsupported response_type: {response_type}",
+            )
+        if "code" not in client.response_types:
+            raise AuthorizeError(
+                "unauthorized_client",
+                "Client not authorized for response_type=code",
+            )
+
+        # Validate scopes
+        requested_scopes = (scope or "").split()
+        client_scopes = set(client.scopes)
+        validated_scopes = [s for s in requested_scopes if s in client_scopes]
+
+        # state is recommended (we require it for CSRF protection)
+        if not state:
+            raise AuthorizeError("invalid_request", "state is required")
+
+        # PKCE validation (enforcement for public clients is in #38/#39)
+        if code_challenge and code_challenge_method not in ("S256", "plain", None):
+            raise AuthorizeError(
+                "invalid_request",
+                f"Unsupported code_challenge_method: {code_challenge_method}",
+            )
+
+        return AuthorizeRequest(
+            client_id=client_id,
+            redirect_uri=redirect_uri,
+            response_type=response_type,
+            scope=scope or "",
+            state=state,
+            nonce=nonce,
+            prompt=prompt,
+            login_hint=login_hint,
+            code_challenge=code_challenge,
+            code_challenge_method=code_challenge_method
+            or ("S256" if code_challenge else None),
+            validated_scopes=validated_scopes,
+        )
+
+    async def create_authorization_code(
+        self,
+        *,
+        request: AuthorizeRequest,
+        user_id: uuid.UUID,
+    ) -> str:
+        """Issue an authorization code after user consent.
+
+        Parameters
+        ----------
+        request : AuthorizeRequest
+            The validated authorization request.
+        user_id : uuid.UUID
+            The authenticated user's ID.
+
+        Returns
+        -------
+        str
+            The authorization code value.
+        """
+        code = secrets.token_urlsafe(32)
+        auth_code = AuthorizationCode(
+            code=code,
+            user_id=user_id,
+            client_id=request.client_id,
+            redirect_uri=request.redirect_uri,
+            scopes=" ".join(request.validated_scopes),
+            nonce=request.nonce,
+            code_challenge=request.code_challenge,
+            code_challenge_method=request.code_challenge_method,
+            expires_at=datetime.now(timezone.utc) + AUTH_CODE_TTL,
+        )
+        self.session.add(auth_code)
+        await self.session.flush()
+        return code

--- a/tests/routes/test_oauth2_authorize.py
+++ b/tests/routes/test_oauth2_authorize.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Integration tests for GET /oauth2/authorize."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Iterator
+from unittest.mock import patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from shomer.app import app
+from shomer.core.database import Base
+from shomer.deps import get_db
+from shomer.models.access_token import AccessToken  # noqa: F401
+from shomer.models.authorization_code import AuthorizationCode  # noqa: F401
+from shomer.models.jwk import JWK  # noqa: F401
+from shomer.models.oauth2_client import OAuth2Client  # noqa: F401
+from shomer.models.password_reset_token import PasswordResetToken  # noqa: F401
+from shomer.models.refresh_token import RefreshToken  # noqa: F401
+from shomer.models.session import Session  # noqa: F401
+from shomer.models.user import User  # noqa: F401
+from shomer.models.user_email import UserEmail  # noqa: F401
+from shomer.models.user_password import UserPassword  # noqa: F401
+from shomer.models.user_profile import UserProfile  # noqa: F401
+from shomer.models.verification_code import VerificationCode  # noqa: F401
+
+_ENGINE = create_async_engine(
+    "sqlite+aiosqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+_SESSION_FACTORY = async_sessionmaker(_ENGINE, expire_on_commit=False)
+
+
+async def _override_get_db() -> AsyncIterator[AsyncSession]:
+    async with _SESSION_FACTORY() as session:
+        try:
+            yield session
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise
+
+
+@pytest.fixture(autouse=True)
+def _setup() -> Iterator[None]:
+    async def _create() -> None:
+        async with _ENGINE.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+    asyncio.run(_create())
+    app.dependency_overrides[get_db] = _override_get_db
+
+    with patch("shomer.middleware.session.async_session", _SESSION_FACTORY):
+        yield
+
+    app.dependency_overrides.clear()
+
+    async def _drop() -> None:
+        async with _ENGINE.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+
+    asyncio.run(_drop())
+
+
+class TestAuthorizeEndpoint:
+    """Integration tests for GET /oauth2/authorize."""
+
+    def test_missing_client_id_returns_400(self) -> None:
+        async def _run() -> None:
+            transport = ASGITransport(app=app)
+            async with AsyncClient(
+                transport=transport, base_url="http://test"
+            ) as client:
+                resp = await client.get(
+                    "/oauth2/authorize",
+                    params={"response_type": "code", "state": "abc"},
+                    follow_redirects=False,
+                )
+                assert resp.status_code == 400
+
+        asyncio.run(_run())
+
+    def test_unknown_client_returns_400_not_redirect(self) -> None:
+        async def _run() -> None:
+            transport = ASGITransport(app=app)
+            async with AsyncClient(
+                transport=transport, base_url="http://test"
+            ) as client:
+                resp = await client.get(
+                    "/oauth2/authorize",
+                    params={
+                        "client_id": "nonexistent",
+                        "redirect_uri": "https://app.example.com/cb",
+                        "response_type": "code",
+                        "state": "abc",
+                    },
+                    follow_redirects=False,
+                )
+                # OWASP: never redirect to unvalidated redirect_uri
+                assert resp.status_code == 400
+
+        asyncio.run(_run())
+
+    def test_unauthenticated_redirects_to_login(self) -> None:
+        async def _run() -> None:
+            # Create a client first
+            from shomer.services.oauth2_client_service import OAuth2ClientService
+
+            async with _SESSION_FACTORY() as db:
+                svc = OAuth2ClientService(db)
+                client, _ = await svc.create_client(
+                    client_name="App",
+                    redirect_uris=["https://app.example.com/cb"],
+                    response_types=["code"],
+                    grant_types=["authorization_code"],
+                    scopes=["openid"],
+                )
+                await db.commit()
+                cid = client.client_id
+
+            transport = ASGITransport(app=app)
+            async with AsyncClient(
+                transport=transport, base_url="http://test"
+            ) as http_client:
+                resp = await http_client.get(
+                    "/oauth2/authorize",
+                    params={
+                        "client_id": cid,
+                        "redirect_uri": "https://app.example.com/cb",
+                        "response_type": "code",
+                        "scope": "openid",
+                        "state": "abc123",
+                    },
+                    follow_redirects=False,
+                )
+                assert resp.status_code == 302
+                assert "/ui/login" in resp.headers["location"]
+
+        asyncio.run(_run())

--- a/tests/services/test_authorize_service.py
+++ b/tests/services/test_authorize_service.py
@@ -1,0 +1,263 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Unit tests for AuthorizeService."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from shomer.core.database import Base
+from shomer.models.access_token import AccessToken  # noqa: F401
+from shomer.models.authorization_code import AuthorizationCode  # noqa: F401
+from shomer.models.jwk import JWK  # noqa: F401
+from shomer.models.oauth2_client import ClientType, OAuth2Client  # noqa: F401
+from shomer.models.password_reset_token import PasswordResetToken  # noqa: F401
+from shomer.models.refresh_token import RefreshToken  # noqa: F401
+from shomer.models.session import Session  # noqa: F401
+from shomer.models.user import User  # noqa: F401
+from shomer.models.user_email import UserEmail  # noqa: F401
+from shomer.models.user_password import UserPassword  # noqa: F401
+from shomer.models.user_profile import UserProfile  # noqa: F401
+from shomer.models.verification_code import VerificationCode  # noqa: F401
+from shomer.services.authorize_service import AuthorizeError, AuthorizeService
+from shomer.services.oauth2_client_service import OAuth2ClientService
+
+_ENGINE = create_async_engine(
+    "sqlite+aiosqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+_SESSION_FACTORY = async_sessionmaker(_ENGINE, expire_on_commit=False)
+
+
+@pytest.fixture(autouse=True)
+def _setup_db() -> Iterator[None]:
+    async def _create() -> None:
+        async with _ENGINE.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+    asyncio.run(_create())
+    yield
+
+    async def _drop() -> None:
+        async with _ENGINE.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+
+    asyncio.run(_drop())
+
+
+async def _create_client(
+    db: object,
+    redirect_uris: list[str] | None = None,
+    response_types: list[str] | None = None,
+    scopes: list[str] | None = None,
+) -> str:
+    """Create a test OAuth2 client and return its client_id."""
+    svc = OAuth2ClientService(db)  # type: ignore[arg-type]
+    client, _ = await svc.create_client(
+        client_name="Test App",
+        redirect_uris=redirect_uris or ["https://app.example.com/callback"],
+        response_types=response_types or ["code"],
+        grant_types=["authorization_code"],
+        scopes=scopes or ["openid", "profile"],
+    )
+    return client.client_id
+
+
+class TestValidateRequest:
+    """Tests for AuthorizeService.validate_request()."""
+
+    def test_valid_request(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                cid = await _create_client(db)
+                svc = AuthorizeService(db)
+                req = await svc.validate_request(
+                    client_id=cid,
+                    redirect_uri="https://app.example.com/callback",
+                    response_type="code",
+                    scope="openid profile",
+                    state="xyz",
+                )
+                assert req.client_id == cid
+                assert req.validated_scopes == ["openid", "profile"]
+
+        asyncio.run(_run())
+
+    def test_missing_client_id(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                svc = AuthorizeService(db)
+                with pytest.raises(AuthorizeError, match="client_id"):
+                    await svc.validate_request(
+                        client_id=None,
+                        redirect_uri="https://app.example.com/cb",
+                        response_type="code",
+                        scope="openid",
+                        state="xyz",
+                    )
+
+        asyncio.run(_run())
+
+    def test_unknown_client(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                svc = AuthorizeService(db)
+                with pytest.raises(AuthorizeError, match="Unknown"):
+                    await svc.validate_request(
+                        client_id="nonexistent",
+                        redirect_uri="https://app.example.com/cb",
+                        response_type="code",
+                        scope="openid",
+                        state="xyz",
+                    )
+
+        asyncio.run(_run())
+
+    def test_invalid_redirect_uri(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                cid = await _create_client(db)
+                svc = AuthorizeService(db)
+                with pytest.raises(AuthorizeError, match="not registered"):
+                    await svc.validate_request(
+                        client_id=cid,
+                        redirect_uri="https://evil.com/cb",
+                        response_type="code",
+                        scope="openid",
+                        state="xyz",
+                    )
+
+        asyncio.run(_run())
+
+    def test_missing_redirect_uri(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                cid = await _create_client(db)
+                svc = AuthorizeService(db)
+                with pytest.raises(AuthorizeError, match="redirect_uri"):
+                    await svc.validate_request(
+                        client_id=cid,
+                        redirect_uri=None,
+                        response_type="code",
+                        scope="openid",
+                        state="xyz",
+                    )
+
+        asyncio.run(_run())
+
+    def test_unsupported_response_type(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                cid = await _create_client(db)
+                svc = AuthorizeService(db)
+                with pytest.raises(AuthorizeError, match="Unsupported response_type"):
+                    await svc.validate_request(
+                        client_id=cid,
+                        redirect_uri="https://app.example.com/callback",
+                        response_type="token",
+                        scope="openid",
+                        state="xyz",
+                    )
+
+        asyncio.run(_run())
+
+    def test_missing_state(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                cid = await _create_client(db)
+                svc = AuthorizeService(db)
+                with pytest.raises(AuthorizeError, match="state"):
+                    await svc.validate_request(
+                        client_id=cid,
+                        redirect_uri="https://app.example.com/callback",
+                        response_type="code",
+                        scope="openid",
+                        state=None,
+                    )
+
+        asyncio.run(_run())
+
+    def test_scope_validation_filters(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                cid = await _create_client(db, scopes=["openid", "profile"])
+                svc = AuthorizeService(db)
+                req = await svc.validate_request(
+                    client_id=cid,
+                    redirect_uri="https://app.example.com/callback",
+                    response_type="code",
+                    scope="openid profile email",
+                    state="xyz",
+                )
+                assert "email" not in req.validated_scopes
+                assert "openid" in req.validated_scopes
+
+        asyncio.run(_run())
+
+    def test_pkce_parameters(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                cid = await _create_client(db)
+                svc = AuthorizeService(db)
+                req = await svc.validate_request(
+                    client_id=cid,
+                    redirect_uri="https://app.example.com/callback",
+                    response_type="code",
+                    scope="openid",
+                    state="xyz",
+                    code_challenge="challenge123",
+                    code_challenge_method="S256",
+                )
+                assert req.code_challenge == "challenge123"
+                assert req.code_challenge_method == "S256"
+
+        asyncio.run(_run())
+
+    def test_nonce_parameter(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                cid = await _create_client(db)
+                svc = AuthorizeService(db)
+                req = await svc.validate_request(
+                    client_id=cid,
+                    redirect_uri="https://app.example.com/callback",
+                    response_type="code",
+                    scope="openid",
+                    state="xyz",
+                    nonce="my-nonce",
+                )
+                assert req.nonce == "my-nonce"
+
+        asyncio.run(_run())
+
+
+class TestCreateAuthorizationCode:
+    """Tests for AuthorizeService.create_authorization_code()."""
+
+    def test_creates_code(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                cid = await _create_client(db)
+                svc = AuthorizeService(db)
+                req = await svc.validate_request(
+                    client_id=cid,
+                    redirect_uri="https://app.example.com/callback",
+                    response_type="code",
+                    scope="openid",
+                    state="xyz",
+                )
+                user = User(username="test")
+                db.add(user)
+                await db.flush()
+                code = await svc.create_authorization_code(request=req, user_id=user.id)
+                assert code is not None
+                assert len(code) > 10
+
+        asyncio.run(_run())


### PR DESCRIPTION
## feat(oauth2): GET /oauth2/authorize — request validation

## Summary

OAuth2 authorization endpoint per RFC 6749 §4.1.1. Validates all parameters, checks authentication, and issues authorization codes.

## Changes

- [x] GET `/oauth2/authorize` route with full parameter validation
- [x] AuthorizeService with `validate_request()` and `create_authorization_code()`
- [x] Client lookup + redirect URI exact match (§3.1.2.2)
- [x] Scope filtering against client allowed scopes
- [x] PKCE support (code_challenge, code_challenge_method)
- [x] OIDC params (nonce, prompt, login_hint)
- [x] Authentication check → redirect to `/ui/login?next=...`
- [x] Auto-approve (consent screen deferred to #32)
- [x] Error responses per §4.1.2.1 (redirect with error params or 400)
- [x] Migration 0010 (fixed chain from duplicate 0009)
- [x] BDD features (2 scenarios) + unit tests (11) + integration tests (3)

Closes #31

## Test Plan

- [x] `make format` - code formatted
- [x] `make lint` - no linting errors
- [x] `make typecheck` - type checks pass
- [x] `make test` - all unit tests pass (406 passed)
- [x] `make bdd` - all BDD tests pass (45 scenarios, 175 steps)
- [x] `make check-license` - SPDX headers present