### PR TITLE
feat(oauth2): POST /oauth2/token - grant_type=authorization_code

### DIFF
--- a/features/oauth2_token.feature
+++ b/features/oauth2_token.feature
@@ -1,0 +1,38 @@
+Feature: OAuth2 token endpoint
+
+  Scenario: Token endpoint without grant_type returns 422
+    When I send a POST request to "/oauth2/token"
+    Then the response status code should be 422
+
+  Scenario: Unsupported grant_type returns 400
+    When I send a form POST to "/oauth2/token" with
+      """
+      {"grant_type": "implicit"}
+      """
+    Then the response status code should be 400
+    And the response body should contain "unsupported_grant_type"
+
+  Scenario: Missing client credentials returns 401
+    When I send a form POST to "/oauth2/token" with
+      """
+      {"grant_type": "authorization_code", "code": "fake", "redirect_uri": "https://app.example.com/cb"}
+      """
+    Then the response status code should be 401
+    And the response body should contain "invalid_client"
+
+  Scenario: Unknown client_id returns 401
+    When I send a form POST to "/oauth2/token" with
+      """
+      {"grant_type": "authorization_code", "code": "fake", "redirect_uri": "https://app.example.com/cb", "client_id": "unknown-client", "client_secret": "wrong"}
+      """
+    Then the response status code should be 401
+    And the response body should contain "invalid_client"
+
+  Scenario: Token response includes error format per RFC 6749
+    When I send a form POST to "/oauth2/token" with
+      """
+      {"grant_type": "authorization_code", "code": "fake", "redirect_uri": "https://app.example.com/cb", "client_id": "x", "client_secret": "y"}
+      """
+    Then the response status code should be 401
+    And the response should have JSON key "error"
+    And the response should have JSON key "error_description"

--- a/features/steps/http_steps.py
+++ b/features/steps/http_steps.py
@@ -3,6 +3,7 @@
 
 import json
 import urllib.error
+import urllib.parse
 import urllib.request
 
 from behave import given, then, when
@@ -52,6 +53,32 @@ def step_post_request(context, path):
 def step_post_request_with_json(context, path):
     data = json.loads(context.text)
     _send(context, "POST", path, data=data)
+
+
+def _send_form(context, path, form_data):
+    """Send a form-encoded POST request."""
+    url = context.base_url + path
+    body = urllib.parse.urlencode(form_data).encode()
+    headers = {"Content-Type": "application/x-www-form-urlencoded"}
+    req = urllib.request.Request(url, data=body, headers=headers, method="POST")
+    try:
+        context.response = urllib.request.urlopen(req, timeout=10)
+        context.response_status = context.response.status
+        context.response_body = context.response.read().decode()
+    except urllib.error.HTTPError as e:
+        context.response = e
+        context.response_status = e.code
+        context.response_body = e.read().decode()
+    except urllib.error.URLError as e:
+        context.response = None
+        context.response_status = 0
+        context.response_body = str(e)
+
+
+@when('I send a form POST to "{path}" with')
+def step_post_form(context, path):
+    form_data = json.loads(context.text)
+    _send_form(context, path, form_data)
 
 
 @when('I send a DELETE request to "{path}"')

--- a/src/shomer/routes/oauth2.py
+++ b/src/shomer/routes/oauth2.py
@@ -9,12 +9,16 @@ from typing import Any
 from urllib.parse import urlencode
 
 from fastapi import APIRouter, Form, HTTPException, Request, status
-from fastapi.responses import RedirectResponse
+from fastapi.responses import JSONResponse, RedirectResponse
 
 from shomer.deps import DbSession
 from shomer.services.authorize_service import AuthorizeError, AuthorizeService
-from shomer.services.oauth2_client_service import OAuth2ClientService
+from shomer.services.oauth2_client_service import (
+    InvalidClientError,
+    OAuth2ClientService,
+)
 from shomer.services.session_service import SessionService
+from shomer.services.token_service import TokenError, TokenService
 
 router = APIRouter(prefix="/oauth2", tags=["oauth2"])
 
@@ -271,4 +275,100 @@ async def authorize_consent(
     params = {"code": code, "state": auth_request.state}
     return RedirectResponse(
         url=f"{auth_request.redirect_uri}?{urlencode(params)}", status_code=302
+    )
+
+
+@router.post("/token")
+async def token(
+    request: Request,
+    db: DbSession,
+    grant_type: str = Form(...),
+    code: str = Form(""),
+    redirect_uri: str = Form(""),
+    client_id: str = Form(""),
+    client_secret: str = Form(""),
+    code_verifier: str = Form(""),
+) -> JSONResponse:
+    """OAuth2 token endpoint per RFC 6749 §4.1.3.
+
+    Exchanges an authorization code for access_token, refresh_token,
+    and optionally id_token.
+
+    Parameters
+    ----------
+    request : Request
+        Incoming request (for Authorization header).
+    db : DbSession
+        Injected async database session.
+    grant_type : str
+        Must be ``authorization_code``.
+    code : str
+        The authorization code.
+    redirect_uri : str
+        Must match the original redirect_uri.
+    client_id : str
+        Client identifier (from POST body or Basic auth).
+    client_secret : str
+        Client secret (from POST body or Basic auth).
+    code_verifier : str
+        PKCE code verifier.
+
+    Returns
+    -------
+    JSONResponse
+        Token response per RFC 6749 §5.1 or error per §5.2.
+    """
+    # Only authorization_code grant for now
+    if grant_type != "authorization_code":
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error": "unsupported_grant_type",
+                "error_description": f"Unsupported grant_type: {grant_type}",
+            },
+        )
+
+    # Authenticate client
+    client_svc = OAuth2ClientService(db)
+    auth_header = request.headers.get("authorization")
+    try:
+        authenticated_client = await client_svc.authenticate_client(
+            authorization_header=auth_header,
+            body_client_id=client_id or None,
+            body_client_secret=client_secret or None,
+        )
+    except InvalidClientError as exc:
+        return JSONResponse(
+            status_code=401,
+            content={
+                "error": "invalid_client",
+                "error_description": str(exc),
+            },
+            headers={"WWW-Authenticate": "Basic"},
+        )
+
+    # Exchange code for tokens
+    from shomer.core.settings import get_settings
+
+    settings = get_settings()
+    token_svc = TokenService(db, settings)
+    try:
+        response = await token_svc.exchange_authorization_code(
+            code=code,
+            client_id=authenticated_client.client_id,
+            redirect_uri=redirect_uri,
+            code_verifier=code_verifier or None,
+        )
+    except TokenError as exc:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error": exc.error,
+                "error_description": exc.description,
+            },
+        )
+
+    return JSONResponse(
+        content=response.to_dict(),
+        headers={"Cache-Control": "no-store", "Pragma": "no-cache"},
     )

--- a/src/shomer/services/token_service.py
+++ b/src/shomer/services/token_service.py
@@ -1,0 +1,308 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""OAuth2 token endpoint service for authorization_code grant (RFC 6749 §4.1.3)."""
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from shomer.core.settings import Settings
+from shomer.models.access_token import AccessToken
+from shomer.models.authorization_code import AuthorizationCode
+from shomer.models.refresh_token import RefreshToken
+
+
+class TokenError(Exception):
+    """OAuth2 token error per RFC 6749 §5.2.
+
+    Attributes
+    ----------
+    error : str
+        Error code.
+    description : str
+        Human-readable description.
+    """
+
+    def __init__(self, error: str, description: str) -> None:
+        self.error = error
+        self.description = description
+        super().__init__(description)
+
+
+@dataclass
+class TokenResponse:
+    """OAuth2 token response per RFC 6749 §5.1.
+
+    Attributes
+    ----------
+    access_token : str
+        The access token (JWT).
+    token_type : str
+        Always ``Bearer``.
+    expires_in : int
+        Token lifetime in seconds.
+    refresh_token : str or None
+        The refresh token (opaque).
+    scope : str
+        Granted scopes.
+    id_token : str or None
+        OIDC ID token (JWT) if ``openid`` scope was requested.
+    """
+
+    access_token: str
+    token_type: str = "Bearer"
+    expires_in: int = 3600
+    refresh_token: str | None = None
+    scope: str = ""
+    id_token: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to RFC 6749 §5.1 response dict."""
+        result: dict[str, Any] = {
+            "access_token": self.access_token,
+            "token_type": self.token_type,
+            "expires_in": self.expires_in,
+        }
+        if self.refresh_token:
+            result["refresh_token"] = self.refresh_token
+        if self.scope:
+            result["scope"] = self.scope
+        if self.id_token:
+            result["id_token"] = self.id_token
+        return result
+
+
+class TokenService:
+    """Exchange authorization codes for tokens.
+
+    Attributes
+    ----------
+    session : AsyncSession
+        Database session.
+    settings : Settings
+        Application settings.
+    """
+
+    def __init__(self, session: AsyncSession, settings: Settings) -> None:
+        self.session = session
+        self.settings = settings
+
+    async def exchange_authorization_code(
+        self,
+        *,
+        code: str,
+        client_id: str,
+        redirect_uri: str,
+        code_verifier: str | None = None,
+    ) -> TokenResponse:
+        """Exchange an authorization code for tokens.
+
+        Parameters
+        ----------
+        code : str
+            The authorization code.
+        client_id : str
+            The client that obtained the code.
+        redirect_uri : str
+            Must match the redirect_uri used in the authorization request.
+        code_verifier : str | None
+            PKCE code verifier (required if code_challenge was used).
+
+        Returns
+        -------
+        TokenResponse
+            The token response.
+
+        Raises
+        ------
+        TokenError
+            If the code is invalid, expired, or parameters don't match.
+        """
+        # Look up the authorization code
+        auth_code = await self._get_authorization_code(code)
+        if auth_code is None:
+            raise TokenError("invalid_grant", "Invalid authorization code")
+
+        # Check not expired
+        now = datetime.now(timezone.utc)
+        expires_at = auth_code.expires_at
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=timezone.utc)
+        if expires_at < now:
+            raise TokenError("invalid_grant", "Authorization code expired")
+
+        # Check not already used
+        if auth_code.is_used:
+            raise TokenError("invalid_grant", "Authorization code already used")
+
+        # Check client matches
+        if auth_code.client_id != client_id:
+            raise TokenError("invalid_grant", "Client mismatch")
+
+        # Check redirect_uri matches
+        if auth_code.redirect_uri != redirect_uri:
+            raise TokenError("invalid_grant", "Redirect URI mismatch")
+
+        # PKCE verification
+        if auth_code.code_challenge:
+            if not code_verifier:
+                raise TokenError("invalid_grant", "code_verifier required")
+            if not self._verify_pkce(
+                code_verifier,
+                auth_code.code_challenge,
+                auth_code.code_challenge_method or "S256",
+            ):
+                raise TokenError("invalid_grant", "PKCE verification failed")
+
+        # Mark code as used
+        auth_code.is_used = True
+        auth_code.used_at = now
+        await self.session.flush()
+
+        # Generate tokens
+        scopes = auth_code.scopes.split() if auth_code.scopes else []
+        jti = uuid.uuid4().hex
+
+        # Create access token record
+        access_token_record = AccessToken(
+            jti=jti,
+            user_id=auth_code.user_id,
+            client_id=client_id,
+            scopes=auth_code.scopes,
+            expires_at=now + timedelta(seconds=self.settings.jwt_access_token_exp),
+        )
+        self.session.add(access_token_record)
+
+        # Create refresh token
+        raw_refresh = uuid.uuid4().hex
+        refresh_hash = hashlib.sha256(raw_refresh.encode()).hexdigest()
+        family_id = uuid.uuid4()
+        refresh_record = RefreshToken(
+            token_hash=refresh_hash,
+            family_id=family_id,
+            user_id=auth_code.user_id,
+            client_id=client_id,
+            scopes=auth_code.scopes,
+            expires_at=now + timedelta(days=30),
+        )
+        self.session.add(refresh_record)
+        await self.session.flush()
+
+        # Build JWT access token
+        access_jwt = self._build_access_jwt(
+            sub=str(auth_code.user_id),
+            aud=client_id,
+            jti=jti,
+            scopes=scopes,
+        )
+
+        # Build ID token if openid scope
+        id_token: str | None = None
+        if "openid" in scopes:
+            id_token = self._build_id_token(
+                sub=str(auth_code.user_id),
+                aud=client_id,
+                nonce=auth_code.nonce,
+            )
+
+        return TokenResponse(
+            access_token=access_jwt,
+            expires_in=self.settings.jwt_access_token_exp,
+            refresh_token=raw_refresh,
+            scope=" ".join(scopes),
+            id_token=id_token,
+        )
+
+    async def _get_authorization_code(self, code: str) -> AuthorizationCode | None:
+        """Look up an authorization code.
+
+        Parameters
+        ----------
+        code : str
+            The code value.
+
+        Returns
+        -------
+        AuthorizationCode or None
+        """
+        stmt = select(AuthorizationCode).where(AuthorizationCode.code == code)
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    def _build_access_jwt(
+        self, *, sub: str, aud: str, jti: str, scopes: list[str]
+    ) -> str:
+        """Build a signed JWT access token (simplified — no JWK lookup).
+
+        For now returns a simple opaque-style token. Full JWT signing
+        via JWKService will be integrated when the JWK is seeded.
+        """
+        import jwt as pyjwt
+
+        now = datetime.now(timezone.utc)
+        payload = {
+            "iss": self.settings.jwt_issuer,
+            "sub": sub,
+            "aud": aud,
+            "exp": now + timedelta(seconds=self.settings.jwt_access_token_exp),
+            "iat": now,
+            "jti": jti,
+            "scope": " ".join(scopes),
+        }
+        # Use HS256 with a secret as fallback (no RSA key required)
+        return pyjwt.encode(
+            payload, self.settings.jwk_encryption_key or "dev-secret", algorithm="HS256"
+        )
+
+    def _build_id_token(self, *, sub: str, aud: str, nonce: str | None) -> str:
+        """Build a signed OIDC ID token (simplified)."""
+        import jwt as pyjwt
+
+        now = datetime.now(timezone.utc)
+        payload: dict[str, Any] = {
+            "iss": self.settings.jwt_issuer,
+            "sub": sub,
+            "aud": aud,
+            "exp": now + timedelta(seconds=self.settings.jwt_id_token_exp),
+            "iat": now,
+        }
+        if nonce:
+            payload["nonce"] = nonce
+        return pyjwt.encode(
+            payload, self.settings.jwk_encryption_key or "dev-secret", algorithm="HS256"
+        )
+
+    @staticmethod
+    def _verify_pkce(code_verifier: str, code_challenge: str, method: str) -> bool:
+        """Verify PKCE code_verifier against code_challenge.
+
+        Parameters
+        ----------
+        code_verifier : str
+            The verifier from the token request.
+        code_challenge : str
+            The challenge from the authorization request.
+        method : str
+            ``S256`` or ``plain``.
+
+        Returns
+        -------
+        bool
+        """
+        import base64
+
+        if method == "plain":
+            return code_verifier == code_challenge
+        if method == "S256":
+            digest = hashlib.sha256(code_verifier.encode("ascii")).digest()
+            computed = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+            return computed == code_challenge
+        return False

--- a/tests/services/test_token_service.py
+++ b/tests/services/test_token_service.py
@@ -1,0 +1,303 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Unit tests for TokenService (authorization_code grant)."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import secrets
+import uuid
+from collections.abc import Iterator
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from shomer.core.database import Base
+from shomer.core.settings import Settings
+from shomer.models.access_token import AccessToken  # noqa: F401
+from shomer.models.authorization_code import AuthorizationCode
+from shomer.models.jwk import JWK  # noqa: F401
+from shomer.models.oauth2_client import OAuth2Client  # noqa: F401
+from shomer.models.password_reset_token import PasswordResetToken  # noqa: F401
+from shomer.models.refresh_token import RefreshToken  # noqa: F401
+from shomer.models.session import Session  # noqa: F401
+from shomer.models.user import User
+from shomer.models.user_email import UserEmail  # noqa: F401
+from shomer.models.user_password import UserPassword  # noqa: F401
+from shomer.models.user_profile import UserProfile  # noqa: F401
+from shomer.models.verification_code import VerificationCode  # noqa: F401
+from shomer.services.token_service import TokenError, TokenService
+
+_ENGINE = create_async_engine(
+    "sqlite+aiosqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+_SESSION_FACTORY = async_sessionmaker(_ENGINE, expire_on_commit=False)
+
+
+def _settings() -> Settings:
+    return Settings(
+        jwt_issuer="https://test.shomer.local",
+        jwt_access_token_exp=3600,
+        jwt_id_token_exp=3600,
+        jwk_encryption_key="test-secret-key",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _setup_db() -> Iterator[None]:
+    async def _create() -> None:
+        async with _ENGINE.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+    asyncio.run(_create())
+    yield
+
+    async def _drop() -> None:
+        async with _ENGINE.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+
+    asyncio.run(_drop())
+
+
+async def _create_auth_code(
+    db: Any,
+    *,
+    client_id: str = "test-client",
+    redirect_uri: str = "https://app.example.com/cb",
+    scopes: str = "openid profile",
+    nonce: str | None = None,
+    code_challenge: str | None = None,
+    code_challenge_method: str | None = None,
+    expired: bool = False,
+    used: bool = False,
+) -> tuple[str, uuid.UUID]:
+    """Create a user + auth code. Returns (code, user_id)."""
+    user = User(username="test")
+    db.add(user)
+    await db.flush()
+
+    code = secrets.token_urlsafe(32)
+    now = datetime.now(timezone.utc)
+    ac = AuthorizationCode(
+        code=code,
+        user_id=user.id,
+        client_id=client_id,
+        redirect_uri=redirect_uri,
+        scopes=scopes,
+        nonce=nonce,
+        code_challenge=code_challenge,
+        code_challenge_method=code_challenge_method,
+        expires_at=now - timedelta(hours=1) if expired else now + timedelta(minutes=10),
+        is_used=used,
+        used_at=now if used else None,
+    )
+    db.add(ac)
+    await db.flush()
+    return code, user.id
+
+
+class TestExchangeAuthorizationCode:
+    """Tests for TokenService.exchange_authorization_code()."""
+
+    def test_successful_exchange(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                code, _ = await _create_auth_code(db)
+                svc = TokenService(db, _settings())
+                resp = await svc.exchange_authorization_code(
+                    code=code,
+                    client_id="test-client",
+                    redirect_uri="https://app.example.com/cb",
+                )
+                assert resp.access_token is not None
+                assert resp.refresh_token is not None
+                assert resp.token_type == "Bearer"
+                assert resp.scope == "openid profile"
+
+        asyncio.run(_run())
+
+    def test_issues_id_token_with_openid_scope(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                code, _ = await _create_auth_code(
+                    db, scopes="openid profile", nonce="abc"
+                )
+                svc = TokenService(db, _settings())
+                resp = await svc.exchange_authorization_code(
+                    code=code,
+                    client_id="test-client",
+                    redirect_uri="https://app.example.com/cb",
+                )
+                assert resp.id_token is not None
+
+        asyncio.run(_run())
+
+    def test_no_id_token_without_openid(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                code, _ = await _create_auth_code(db, scopes="profile")
+                svc = TokenService(db, _settings())
+                resp = await svc.exchange_authorization_code(
+                    code=code,
+                    client_id="test-client",
+                    redirect_uri="https://app.example.com/cb",
+                )
+                assert resp.id_token is None
+
+        asyncio.run(_run())
+
+    def test_invalid_code_raises(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                svc = TokenService(db, _settings())
+                with pytest.raises(TokenError, match="Invalid"):
+                    await svc.exchange_authorization_code(
+                        code="nonexistent",
+                        client_id="test-client",
+                        redirect_uri="https://app.example.com/cb",
+                    )
+
+        asyncio.run(_run())
+
+    def test_expired_code_raises(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                code, _ = await _create_auth_code(db, expired=True)
+                svc = TokenService(db, _settings())
+                with pytest.raises(TokenError, match="expired"):
+                    await svc.exchange_authorization_code(
+                        code=code,
+                        client_id="test-client",
+                        redirect_uri="https://app.example.com/cb",
+                    )
+
+        asyncio.run(_run())
+
+    def test_used_code_raises(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                code, _ = await _create_auth_code(db, used=True)
+                svc = TokenService(db, _settings())
+                with pytest.raises(TokenError, match="already used"):
+                    await svc.exchange_authorization_code(
+                        code=code,
+                        client_id="test-client",
+                        redirect_uri="https://app.example.com/cb",
+                    )
+
+        asyncio.run(_run())
+
+    def test_client_mismatch_raises(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                code, _ = await _create_auth_code(db)
+                svc = TokenService(db, _settings())
+                with pytest.raises(TokenError, match="Client mismatch"):
+                    await svc.exchange_authorization_code(
+                        code=code,
+                        client_id="wrong-client",
+                        redirect_uri="https://app.example.com/cb",
+                    )
+
+        asyncio.run(_run())
+
+    def test_redirect_uri_mismatch_raises(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                code, _ = await _create_auth_code(db)
+                svc = TokenService(db, _settings())
+                with pytest.raises(TokenError, match="Redirect URI"):
+                    await svc.exchange_authorization_code(
+                        code=code,
+                        client_id="test-client",
+                        redirect_uri="https://evil.com/cb",
+                    )
+
+        asyncio.run(_run())
+
+    def test_marks_code_as_used(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                code, _ = await _create_auth_code(db)
+                svc = TokenService(db, _settings())
+                await svc.exchange_authorization_code(
+                    code=code,
+                    client_id="test-client",
+                    redirect_uri="https://app.example.com/cb",
+                )
+                # Second use should fail
+                with pytest.raises(TokenError, match="already used"):
+                    await svc.exchange_authorization_code(
+                        code=code,
+                        client_id="test-client",
+                        redirect_uri="https://app.example.com/cb",
+                    )
+
+        asyncio.run(_run())
+
+
+class TestPKCE:
+    """Tests for PKCE verification."""
+
+    def test_pkce_s256_success(self) -> None:
+        import base64
+
+        verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+        digest = hashlib.sha256(verifier.encode("ascii")).digest()
+        challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                code, _ = await _create_auth_code(
+                    db, code_challenge=challenge, code_challenge_method="S256"
+                )
+                svc = TokenService(db, _settings())
+                resp = await svc.exchange_authorization_code(
+                    code=code,
+                    client_id="test-client",
+                    redirect_uri="https://app.example.com/cb",
+                    code_verifier=verifier,
+                )
+                assert resp.access_token is not None
+
+        asyncio.run(_run())
+
+    def test_pkce_missing_verifier_raises(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                code, _ = await _create_auth_code(
+                    db, code_challenge="challenge", code_challenge_method="S256"
+                )
+                svc = TokenService(db, _settings())
+                with pytest.raises(TokenError, match="code_verifier required"):
+                    await svc.exchange_authorization_code(
+                        code=code,
+                        client_id="test-client",
+                        redirect_uri="https://app.example.com/cb",
+                    )
+
+        asyncio.run(_run())
+
+    def test_pkce_wrong_verifier_raises(self) -> None:
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                code, _ = await _create_auth_code(
+                    db, code_challenge="correct-challenge", code_challenge_method="S256"
+                )
+                svc = TokenService(db, _settings())
+                with pytest.raises(TokenError, match="PKCE verification failed"):
+                    await svc.exchange_authorization_code(
+                        code=code,
+                        client_id="test-client",
+                        redirect_uri="https://app.example.com/cb",
+                        code_verifier="wrong-verifier",
+                    )
+
+        asyncio.run(_run())


### PR DESCRIPTION
## feat(oauth2): POST /oauth2/token — grant_type=authorization_code

## Summary

Token endpoint for exchanging authorization codes for tokens per RFC 6749 §4.1.3.

## Changes

- [x] POST `/oauth2/token` with grant_type dispatch
- [x] Client authentication via `OAuth2ClientService.authenticate_client()` (Basic + POST body)
- [x] `TokenService.exchange_authorization_code()` with full validation
- [x] PKCE `code_verifier` verification (S256 + plain)
- [x] Access token JWT issuance (HS256 fallback, jti stored in DB)
- [x] Refresh token generation (SHA256 hashed, family_id for rotation tracking)
- [x] ID token issuance when `openid` scope present (with nonce)
- [x] RFC 6749 §5.1 response format + `Cache-Control: no-store`
- [x] RFC 6749 §5.2 error responses
- [x] BDD feature (1 scenario) + unit tests (12 tests: exchange, id_token, no id_token, invalid/expired/used code, client mismatch, redirect mismatch, marks used, PKCE S256/missing/wrong verifier)

Closes #33

## Test Plan

- [x] `make format` - code formatted
- [x] `make lint` - no linting errors
- [x] `make typecheck` - type checks pass
- [x] `make test` - all unit tests pass (422 passed)
- [x] `make bdd` - all BDD tests pass (48 scenarios, 188 steps)
- [x] `make check-license` - SPDX headers present