### PR TITLE
feat(oauth2): POST /oauth2/token - grant_type=client_credentials

### DIFF
--- a/alembic/versions/0011_make_access_token_user_id_nullable.py
+++ b/alembic/versions/0011_make_access_token_user_id_nullable.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Make access_token.user_id nullable for client_credentials grants.
+
+Revision ID: 0011
+Revises: 0010
+Create Date: 2026-03-19
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0011"
+down_revision: Union[str, None] = "0010"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Allow NULL user_id on access_tokens for M2M tokens."""
+    op.alter_column(
+        "access_tokens",
+        "user_id",
+        existing_type=sa.Uuid(),
+        nullable=True,
+    )
+
+
+def downgrade() -> None:
+    """Restore NOT NULL constraint on access_tokens.user_id."""
+    op.alter_column(
+        "access_tokens",
+        "user_id",
+        existing_type=sa.Uuid(),
+        nullable=False,
+    )

--- a/features/oauth2_token.feature
+++ b/features/oauth2_token.feature
@@ -36,3 +36,30 @@ Feature: OAuth2 token endpoint
     Then the response status code should be 401
     And the response should have JSON key "error"
     And the response should have JSON key "error_description"
+
+  # --- client_credentials grant ---
+
+  Scenario: client_credentials without client auth returns 401
+    When I send a form POST to "/oauth2/token" with
+      """
+      {"grant_type": "client_credentials"}
+      """
+    Then the response status code should be 401
+    And the response body should contain "invalid_client"
+
+  Scenario: client_credentials with unknown client returns 401
+    When I send a form POST to "/oauth2/token" with
+      """
+      {"grant_type": "client_credentials", "client_id": "unknown", "client_secret": "wrong"}
+      """
+    Then the response status code should be 401
+    And the response body should contain "invalid_client"
+
+  Scenario: client_credentials error uses RFC 6749 format
+    When I send a form POST to "/oauth2/token" with
+      """
+      {"grant_type": "client_credentials", "client_id": "no-such-client", "client_secret": "x"}
+      """
+    Then the response status code should be 401
+    And the response should have JSON key "error"
+    And the response should have JSON key "error_description"

--- a/src/shomer/models/access_token.py
+++ b/src/shomer/models/access_token.py
@@ -1,7 +1,11 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2025 Chris <goabonga@pm.me>
 
-"""AccessToken model for token storage and revocation."""
+"""AccessToken model for token storage and revocation.
+
+user_id is nullable to support client_credentials grants (M2M tokens
+that are not associated with any user).
+"""
 
 from __future__ import annotations
 
@@ -27,8 +31,8 @@ class AccessToken(Base, UUIDMixin, TimestampMixin):
         Primary key (from UUIDMixin).
     jti : str
         JWT ID (unique token identifier, indexed).
-    user_id : uuid.UUID
-        Foreign key to the users table.
+    user_id : uuid.UUID or None
+        Foreign key to the users table (None for client_credentials grants).
     client_id : str
         OAuth2 client that requested the token.
     scopes : str
@@ -51,9 +55,9 @@ class AccessToken(Base, UUIDMixin, TimestampMixin):
         nullable=False,
         index=True,
     )
-    user_id: Mapped[uuid.UUID] = mapped_column(
+    user_id: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("users.id", ondelete="CASCADE"),
-        nullable=False,
+        nullable=True,
         index=True,
     )
     client_id: Mapped[str] = mapped_column(
@@ -76,7 +80,7 @@ class AccessToken(Base, UUIDMixin, TimestampMixin):
     )
 
     # Relationships
-    user: Mapped[User] = relationship(back_populates="access_tokens")
+    user: Mapped[User | None] = relationship(back_populates="access_tokens")
 
     def __repr__(self) -> str:
         return f"<AccessToken jti={self.jti} revoked={self.revoked}>"

--- a/src/shomer/routes/oauth2.py
+++ b/src/shomer/routes/oauth2.py
@@ -285,14 +285,14 @@ async def token(
     grant_type: str = Form(...),
     code: str = Form(""),
     redirect_uri: str = Form(""),
+    scope: str = Form(""),
     client_id: str = Form(""),
     client_secret: str = Form(""),
     code_verifier: str = Form(""),
 ) -> JSONResponse:
-    """OAuth2 token endpoint per RFC 6749 §4.1.3.
+    """OAuth2 token endpoint per RFC 6749 §4.1.3 and §4.4.
 
-    Exchanges an authorization code for access_token, refresh_token,
-    and optionally id_token.
+    Supports ``authorization_code`` and ``client_credentials`` grants.
 
     Parameters
     ----------
@@ -301,25 +301,27 @@ async def token(
     db : DbSession
         Injected async database session.
     grant_type : str
-        Must be ``authorization_code``.
+        ``authorization_code`` or ``client_credentials``.
     code : str
-        The authorization code.
+        The authorization code (authorization_code grant only).
     redirect_uri : str
-        Must match the original redirect_uri.
+        Must match the original redirect_uri (authorization_code grant only).
+    scope : str
+        Requested scopes (client_credentials grant).
     client_id : str
         Client identifier (from POST body or Basic auth).
     client_secret : str
         Client secret (from POST body or Basic auth).
     code_verifier : str
-        PKCE code verifier.
+        PKCE code verifier (authorization_code grant only).
 
     Returns
     -------
     JSONResponse
         Token response per RFC 6749 §5.1 or error per §5.2.
     """
-    # Only authorization_code grant for now
-    if grant_type != "authorization_code":
+    supported_grants = {"authorization_code", "client_credentials"}
+    if grant_type not in supported_grants:
         return JSONResponse(
             status_code=400,
             content={
@@ -347,17 +349,89 @@ async def token(
             headers={"WWW-Authenticate": "Basic"},
         )
 
-    # Exchange code for tokens
     from shomer.core.settings import get_settings
 
     settings = get_settings()
     token_svc = TokenService(db, settings)
+
+    if grant_type == "client_credentials":
+        return await _handle_client_credentials(token_svc, authenticated_client, scope)
+
+    # authorization_code grant
     try:
         response = await token_svc.exchange_authorization_code(
             code=code,
             client_id=authenticated_client.client_id,
             redirect_uri=redirect_uri,
             code_verifier=code_verifier or None,
+        )
+    except TokenError as exc:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error": exc.error,
+                "error_description": exc.description,
+            },
+        )
+
+    return JSONResponse(
+        content=response.to_dict(),
+        headers={"Cache-Control": "no-store", "Pragma": "no-cache"},
+    )
+
+
+async def _handle_client_credentials(
+    token_svc: TokenService,
+    client: Any,
+    scope: str,
+) -> JSONResponse:
+    """Handle client_credentials grant per RFC 6749 §4.4.
+
+    Parameters
+    ----------
+    token_svc : TokenService
+        Token service instance.
+    client : OAuth2Client
+        The authenticated client.
+    scope : str
+        Requested scopes (space-separated).
+
+    Returns
+    -------
+    JSONResponse
+        Token response or error.
+    """
+    from shomer.models.oauth2_client import ClientType
+
+    # Only confidential clients may use client_credentials
+    if client.client_type != ClientType.CONFIDENTIAL:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error": "unauthorized_client",
+                "error_description": (
+                    "Public clients cannot use client_credentials grant"
+                ),
+            },
+        )
+
+    # Check grant_type is allowed for this client
+    if "client_credentials" not in (client.grant_types or []):
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error": "unauthorized_client",
+                "error_description": (
+                    "Client is not authorized for client_credentials grant"
+                ),
+            },
+        )
+
+    try:
+        response = await token_svc.issue_client_credentials(
+            client_id=client.client_id,
+            client_scopes=client.scopes or [],
+            requested_scope=scope or None,
         )
     except TokenError as exc:
         return JSONResponse(

--- a/src/shomer/services/token_service.py
+++ b/src/shomer/services/token_service.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2025 Chris <goabonga@pm.me>
 
-"""OAuth2 token endpoint service for authorization_code grant (RFC 6749 §4.1.3)."""
+"""OAuth2 token endpoint service (RFC 6749 §4.1.3 and §4.4)."""
 
 from __future__ import annotations
 
@@ -81,7 +81,7 @@ class TokenResponse:
 
 
 class TokenService:
-    """Exchange authorization codes for tokens.
+    """Exchange authorization codes or client credentials for tokens.
 
     Attributes
     ----------
@@ -219,6 +219,75 @@ class TokenService:
             refresh_token=raw_refresh,
             scope=" ".join(scopes),
             id_token=id_token,
+        )
+
+    async def issue_client_credentials(
+        self,
+        *,
+        client_id: str,
+        client_scopes: list[str],
+        requested_scope: str | None = None,
+    ) -> TokenResponse:
+        """Issue tokens for a client_credentials grant (RFC 6749 §4.4).
+
+        Parameters
+        ----------
+        client_id : str
+            The authenticated client identifier.
+        client_scopes : list[str]
+            Scopes the client is allowed to request.
+        requested_scope : str or None
+            Space-separated scopes requested by the client.
+            If None, all allowed scopes are granted.
+
+        Returns
+        -------
+        TokenResponse
+            The token response (access_token only, no refresh_token or id_token).
+
+        Raises
+        ------
+        TokenError
+            If the requested scope is not allowed.
+        """
+        # Determine granted scopes
+        if requested_scope:
+            requested = requested_scope.split()
+            invalid = [s for s in requested if s not in client_scopes]
+            if invalid:
+                raise TokenError(
+                    "invalid_scope",
+                    f"Scope not allowed: {' '.join(invalid)}",
+                )
+            granted_scopes = requested
+        else:
+            granted_scopes = list(client_scopes)
+
+        # Generate access token
+        now = datetime.now(timezone.utc)
+        jti = uuid.uuid4().hex
+
+        access_token_record = AccessToken(
+            jti=jti,
+            user_id=None,
+            client_id=client_id,
+            scopes=" ".join(granted_scopes),
+            expires_at=now + timedelta(seconds=self.settings.jwt_access_token_exp),
+        )
+        self.session.add(access_token_record)
+        await self.session.flush()
+
+        access_jwt = self._build_access_jwt(
+            sub=client_id,
+            aud=client_id,
+            jti=jti,
+            scopes=granted_scopes,
+        )
+
+        return TokenResponse(
+            access_token=access_jwt,
+            expires_in=self.settings.jwt_access_token_exp,
+            scope=" ".join(granted_scopes),
         )
 
     async def _get_authorization_code(self, code: str) -> AuthorizationCode | None:

--- a/tests/models/test_access_token.py
+++ b/tests/models/test_access_token.py
@@ -50,9 +50,10 @@ class TestAccessTokenModel:
         col = AccessToken.__table__.c.user_id
         assert col.index is True
 
-    def test_user_id_not_nullable(self) -> None:
+    def test_user_id_nullable(self) -> None:
+        """user_id is nullable for client_credentials grants."""
         col = AccessToken.__table__.c.user_id
-        assert col.nullable is False
+        assert col.nullable is True
 
     def test_user_id_foreign_key(self) -> None:
         col = AccessToken.__table__.c.user_id

--- a/tests/services/test_token_service.py
+++ b/tests/services/test_token_service.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2025 Chris <goabonga@pm.me>
 
-"""Unit tests for TokenService (authorization_code grant)."""
+"""Unit tests for TokenService (authorization_code and client_credentials grants)."""
 
 from __future__ import annotations
 
@@ -299,5 +299,145 @@ class TestPKCE:
                         redirect_uri="https://app.example.com/cb",
                         code_verifier="wrong-verifier",
                     )
+
+        asyncio.run(_run())
+
+
+class TestClientCredentials:
+    """Tests for TokenService.issue_client_credentials()."""
+
+    def test_successful_issue(self) -> None:
+        """Issue access_token with all allowed scopes."""
+
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                svc = TokenService(db, _settings())
+                resp = await svc.issue_client_credentials(
+                    client_id="m2m-client",
+                    client_scopes=["read", "write"],
+                )
+                assert resp.access_token is not None
+                assert resp.token_type == "Bearer"
+                assert resp.refresh_token is None
+                assert resp.id_token is None
+                assert resp.scope == "read write"
+
+        asyncio.run(_run())
+
+    def test_grants_requested_scope_subset(self) -> None:
+        """Only requested scopes are granted."""
+
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                svc = TokenService(db, _settings())
+                resp = await svc.issue_client_credentials(
+                    client_id="m2m-client",
+                    client_scopes=["read", "write", "admin"],
+                    requested_scope="read",
+                )
+                assert resp.scope == "read"
+
+        asyncio.run(_run())
+
+    def test_grants_all_scopes_when_none_requested(self) -> None:
+        """All allowed scopes are granted when no scope is requested."""
+
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                svc = TokenService(db, _settings())
+                resp = await svc.issue_client_credentials(
+                    client_id="m2m-client",
+                    client_scopes=["read", "write"],
+                )
+                assert resp.scope == "read write"
+
+        asyncio.run(_run())
+
+    def test_invalid_scope_raises(self) -> None:
+        """Requesting a scope not allowed by the client raises TokenError."""
+
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                svc = TokenService(db, _settings())
+                with pytest.raises(TokenError, match="Scope not allowed"):
+                    await svc.issue_client_credentials(
+                        client_id="m2m-client",
+                        client_scopes=["read"],
+                        requested_scope="read admin",
+                    )
+
+        asyncio.run(_run())
+
+    def test_no_refresh_token(self) -> None:
+        """client_credentials grant must NOT issue a refresh_token."""
+
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                svc = TokenService(db, _settings())
+                resp = await svc.issue_client_credentials(
+                    client_id="m2m-client",
+                    client_scopes=["read"],
+                )
+                assert resp.refresh_token is None
+
+        asyncio.run(_run())
+
+    def test_no_id_token(self) -> None:
+        """client_credentials grant must NOT issue an id_token."""
+
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                svc = TokenService(db, _settings())
+                resp = await svc.issue_client_credentials(
+                    client_id="m2m-client",
+                    client_scopes=["openid"],
+                    requested_scope="openid",
+                )
+                assert resp.id_token is None
+
+        asyncio.run(_run())
+
+    def test_access_token_record_has_null_user_id(self) -> None:
+        """AccessToken record should have user_id=None for M2M tokens."""
+
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                svc = TokenService(db, _settings())
+                await svc.issue_client_credentials(
+                    client_id="m2m-client",
+                    client_scopes=["read"],
+                )
+                from sqlalchemy import select
+
+                from shomer.models.access_token import AccessToken
+
+                stmt = select(AccessToken).where(AccessToken.client_id == "m2m-client")
+                result = await db.execute(stmt)
+                record = result.scalar_one()
+                assert record.user_id is None
+                assert record.client_id == "m2m-client"
+
+        asyncio.run(_run())
+
+    def test_subject_is_client_id(self) -> None:
+        """JWT subject claim should be the client_id."""
+        import jwt as pyjwt
+
+        async def _run() -> None:
+            async with _SESSION_FACTORY() as db:
+                settings = _settings()
+                svc = TokenService(db, settings)
+                resp = await svc.issue_client_credentials(
+                    client_id="m2m-client",
+                    client_scopes=["read"],
+                )
+                payload = pyjwt.decode(
+                    resp.access_token,
+                    settings.jwk_encryption_key,
+                    algorithms=["HS256"],
+                    audience="m2m-client",
+                )
+                assert payload["sub"] == "m2m-client"
+                assert payload["aud"] == "m2m-client"
 
         asyncio.run(_run())


### PR DESCRIPTION
## feat(oauth2): POST /oauth2/token - grant_type=client_credentials

## Summary

Client credentials grant for machine-to-machine calls per RFC 6749 §4.4. Mandatory client authentication, issues access_token only (no refresh_token, no id_token).

## Changes

- [x] grant_type=client_credentials handler in token endpoint
- [x] Client authentication required (confidential clients only)
- [x] Scope validation against client allowed scopes
- [x] Issue access_token with client_id as subject
- [x] No refresh_token or id_token
- [x] Integration test (8 unit + 3 BDD scenarios)
- [x] AccessToken.user_id nullable for M2M tokens (migration 0011)

## Dependencies

- #33 - token endpoint base

## Related Issue

Closes #34

## Test Plan

- [x] `make format` - code formatted
- [x] `make lint` - no linting errors
- [x] `make typecheck` - type checks pass
- [x] `make test` - 430 passed
- [x] `make bdd` - 55 scenarios passed
- [x] `make check-license` - SPDX headers present