### PR TITLE
feat(pkce): PKCE service (code_challenge S256/plain)

### DIFF
--- a/src/shomer/services/pkce_service.py
+++ b/src/shomer/services/pkce_service.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""PKCE (Proof Key for Code Exchange) service per RFC 7636.
+
+Provides code_verifier generation, code_challenge computation
+(S256 and plain methods), and verification utilities.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import secrets
+
+#: Minimum length for a code_verifier per RFC 7636 §4.1.
+MIN_VERIFIER_LENGTH = 43
+
+#: Maximum length for a code_verifier per RFC 7636 §4.1.
+MAX_VERIFIER_LENGTH = 128
+
+#: Characters allowed in a code_verifier (unreserved URI characters).
+_VERIFIER_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+
+
+def generate_code_verifier(length: int = 128) -> str:
+    """Generate a cryptographically random code_verifier.
+
+    Parameters
+    ----------
+    length : int
+        Length of the verifier (43–128 characters per RFC 7636 §4.1).
+
+    Returns
+    -------
+    str
+        A random string of unreserved URI characters.
+
+    Raises
+    ------
+    ValueError
+        If length is outside the 43–128 range.
+    """
+    if length < MIN_VERIFIER_LENGTH or length > MAX_VERIFIER_LENGTH:
+        raise ValueError(
+            f"code_verifier length must be {MIN_VERIFIER_LENGTH}-{MAX_VERIFIER_LENGTH}, "
+            f"got {length}"
+        )
+    return "".join(secrets.choice(_VERIFIER_CHARS) for _ in range(length))
+
+
+def compute_code_challenge(verifier: str, method: str = "S256") -> str:
+    """Compute a code_challenge from a code_verifier.
+
+    Parameters
+    ----------
+    verifier : str
+        The code_verifier string.
+    method : str
+        Challenge method: ``S256`` (recommended) or ``plain``.
+
+    Returns
+    -------
+    str
+        The code_challenge value.
+
+    Raises
+    ------
+    ValueError
+        If the method is not ``S256`` or ``plain``.
+    """
+    if method == "plain":
+        return verifier
+    if method == "S256":
+        digest = hashlib.sha256(verifier.encode("ascii")).digest()
+        return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    raise ValueError(f"Unsupported code_challenge_method: {method}")
+
+
+def verify_code_challenge(verifier: str, challenge: str, method: str = "S256") -> bool:
+    """Verify a code_verifier against a stored code_challenge.
+
+    Parameters
+    ----------
+    verifier : str
+        The code_verifier from the token request.
+    challenge : str
+        The code_challenge stored during the authorization request.
+    method : str
+        The method used to compute the challenge (``S256`` or ``plain``).
+
+    Returns
+    -------
+    bool
+        ``True`` if the verifier matches the challenge.
+
+    Raises
+    ------
+    ValueError
+        If the method is not ``S256`` or ``plain``.
+    """
+    computed = compute_code_challenge(verifier, method)
+    return computed == challenge

--- a/src/shomer/services/token_service.py
+++ b/src/shomer/services/token_service.py
@@ -458,6 +458,8 @@ class TokenService:
     def _verify_pkce(code_verifier: str, code_challenge: str, method: str) -> bool:
         """Verify PKCE code_verifier against code_challenge.
 
+        Delegates to :func:`shomer.services.pkce_service.verify_code_challenge`.
+
         Parameters
         ----------
         code_verifier : str
@@ -471,12 +473,9 @@ class TokenService:
         -------
         bool
         """
-        import base64
+        from shomer.services.pkce_service import verify_code_challenge
 
-        if method == "plain":
-            return code_verifier == code_challenge
-        if method == "S256":
-            digest = hashlib.sha256(code_verifier.encode("ascii")).digest()
-            computed = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
-            return computed == code_challenge
-        return False
+        try:
+            return verify_code_challenge(code_verifier, code_challenge, method)
+        except ValueError:
+            return False

--- a/tests/services/test_pkce_service.py
+++ b/tests/services/test_pkce_service.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Unit tests for PKCE service (RFC 7636)."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+
+import pytest
+
+from shomer.services.pkce_service import (
+    MAX_VERIFIER_LENGTH,
+    MIN_VERIFIER_LENGTH,
+    compute_code_challenge,
+    generate_code_verifier,
+    verify_code_challenge,
+)
+
+
+class TestGenerateCodeVerifier:
+    """Tests for generate_code_verifier()."""
+
+    def test_default_length(self) -> None:
+        """Default verifier is 128 characters."""
+        v = generate_code_verifier()
+        assert len(v) == 128
+
+    def test_custom_length(self) -> None:
+        """Custom length is respected."""
+        v = generate_code_verifier(64)
+        assert len(v) == 64
+
+    def test_min_length(self) -> None:
+        """Minimum allowed length (43)."""
+        v = generate_code_verifier(MIN_VERIFIER_LENGTH)
+        assert len(v) == 43
+
+    def test_max_length(self) -> None:
+        """Maximum allowed length (128)."""
+        v = generate_code_verifier(MAX_VERIFIER_LENGTH)
+        assert len(v) == 128
+
+    def test_too_short_raises(self) -> None:
+        """Length below 43 raises ValueError."""
+        with pytest.raises(ValueError, match="43-128"):
+            generate_code_verifier(42)
+
+    def test_too_long_raises(self) -> None:
+        """Length above 128 raises ValueError."""
+        with pytest.raises(ValueError, match="43-128"):
+            generate_code_verifier(129)
+
+    def test_uses_unreserved_chars(self) -> None:
+        """Generated verifier only contains unreserved URI characters."""
+        allowed = set(
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+        )
+        v = generate_code_verifier()
+        assert set(v).issubset(allowed)
+
+    def test_randomness(self) -> None:
+        """Multiple verifiers are different."""
+        verifiers = {generate_code_verifier() for _ in range(10)}
+        assert len(verifiers) == 10
+
+
+class TestComputeCodeChallenge:
+    """Tests for compute_code_challenge()."""
+
+    def test_s256(self) -> None:
+        """S256 computes SHA-256 + base64url-no-pad."""
+        verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+        expected_digest = hashlib.sha256(verifier.encode("ascii")).digest()
+        expected = (
+            base64.urlsafe_b64encode(expected_digest).rstrip(b"=").decode("ascii")
+        )
+        assert compute_code_challenge(verifier, "S256") == expected
+
+    def test_plain(self) -> None:
+        """Plain returns the verifier as-is."""
+        verifier = "my-plain-verifier"
+        assert compute_code_challenge(verifier, "plain") == verifier
+
+    def test_unsupported_method_raises(self) -> None:
+        """Unsupported method raises ValueError."""
+        with pytest.raises(ValueError, match="Unsupported"):
+            compute_code_challenge("verifier", "RS256")
+
+
+class TestVerifyCodeChallenge:
+    """Tests for verify_code_challenge()."""
+
+    def test_s256_valid(self) -> None:
+        """Correct S256 verifier returns True."""
+        verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+        challenge = compute_code_challenge(verifier, "S256")
+        assert verify_code_challenge(verifier, challenge, "S256") is True
+
+    def test_s256_invalid(self) -> None:
+        """Wrong S256 verifier returns False."""
+        challenge = compute_code_challenge("correct-verifier", "S256")
+        assert verify_code_challenge("wrong-verifier", challenge, "S256") is False
+
+    def test_plain_valid(self) -> None:
+        """Correct plain verifier returns True."""
+        assert verify_code_challenge("verifier", "verifier", "plain") is True
+
+    def test_plain_invalid(self) -> None:
+        """Wrong plain verifier returns False."""
+        assert verify_code_challenge("verifier", "wrong", "plain") is False
+
+    def test_unsupported_method_raises(self) -> None:
+        """Unsupported method raises ValueError."""
+        with pytest.raises(ValueError, match="Unsupported"):
+            verify_code_challenge("v", "c", "unknown")
+
+    def test_roundtrip_s256(self) -> None:
+        """Generate → compute → verify roundtrip works."""
+        verifier = generate_code_verifier()
+        challenge = compute_code_challenge(verifier, "S256")
+        assert verify_code_challenge(verifier, challenge, "S256") is True
+
+    def test_roundtrip_plain(self) -> None:
+        """Generate → compute → verify roundtrip works for plain."""
+        verifier = generate_code_verifier()
+        challenge = compute_code_challenge(verifier, "plain")
+        assert verify_code_challenge(verifier, challenge, "plain") is True


### PR DESCRIPTION
## feat(pkce): PKCE service (code_challenge S256/plain)

## Summary

PKCE service per RFC 7636: code_verifier generation, code_challenge computation (S256 and plain), verification. TokenService._verify_pkce refactored to delegate to the new service.

## Changes

- [x] `generate_code_verifier()` - random 43-128 char unreserved URI string
- [x] `compute_code_challenge(verifier, method)` - S256 (SHA-256 + base64url) and plain
- [x] `verify_code_challenge(verifier, challenge, method)` - verification
- [x] Unit tests (18 tests: generation, computation, verification, roundtrips, edge cases)
- [x] Refactor TokenService._verify_pkce to delegate to pkce_service

## Dependencies

None.

## Related Issue

Closes #38

## Test Plan

- [x] `make format` - code formatted
- [x] `make lint` - no linting errors
- [x] `make typecheck` - type checks pass
- [x] `make test` - 515 passed, 100% coverage
- [x] `make bdd` - 81 scenarios passed
- [x] `make check-license` - SPDX headers present