### PR TITLE
feat(oauth2): POST /oauth2/token - grant_type=refresh_token with rotation

### DIFF
--- a/features/oauth2_token.feature
+++ b/features/oauth2_token.feature
@@ -142,3 +142,40 @@ Feature: OAuth2 token endpoint
       """
     Then the response status code should be 401
     And the response body should contain "invalid_client"
+
+  # --- refresh_token grant ---
+
+  Scenario: refresh_token without client auth returns 401
+    When I send a form POST to "/oauth2/token" with
+      """
+      {"grant_type": "refresh_token", "refresh_token": "fake"}
+      """
+    Then the response status code should be 401
+    And the response body should contain "invalid_client"
+
+  Scenario: refresh_token with unknown client returns 401
+    When I send a form POST to "/oauth2/token" with
+      """
+      {"grant_type": "refresh_token", "refresh_token": "fake", "client_id": "unknown", "client_secret": "wrong"}
+      """
+    Then the response status code should be 401
+    And the response body should contain "invalid_client"
+
+  Scenario: refresh_token with invalid token returns 400
+    Given a verified user and an OAuth2 client with all grants
+    When I send a form POST to "/oauth2/token" with
+      """
+      {"grant_type": "refresh_token", "refresh_token": "nonexistent", "client_id": "bdd-full-client", "client_secret": "bdd-test-secret-value"}
+      """
+    Then the response status code should be 400
+    And the response body should contain "invalid_grant"
+
+  Scenario: refresh_token error uses RFC 6749 format
+    Given a verified user and an OAuth2 client with all grants
+    When I send a form POST to "/oauth2/token" with
+      """
+      {"grant_type": "refresh_token", "refresh_token": "bad", "client_id": "bdd-full-client", "client_secret": "bdd-test-secret-value"}
+      """
+    Then the response status code should be 400
+    And the response should have JSON key "error"
+    And the response should have JSON key "error_description"

--- a/features/steps/oauth2_steps.py
+++ b/features/steps/oauth2_steps.py
@@ -123,7 +123,7 @@ def step_setup_oauth2_full(context):
         f"'{escaped_hash}', "
         "'BDD Full App', 'CONFIDENTIAL', "
         "'[\"https://app.example.com/callback\"]'::jsonb, "
-        '\'["authorization_code", "client_credentials", "password"]\'::jsonb, '
+        '\'["authorization_code", "client_credentials", "password", "refresh_token"]\'::jsonb, '
         "'[\"code\"]'::jsonb, "
         '\'["openid", "profile", "email"]\'::jsonb, '
         "'[]'::jsonb, "
@@ -131,7 +131,7 @@ def step_setup_oauth2_full(context):
         ") ON CONFLICT (client_id) DO UPDATE SET "
         f"client_secret_hash = '{escaped_hash}', "
         "grant_types = "
-        '\'["authorization_code", "client_credentials", "password"]\'::jsonb;'
+        '\'["authorization_code", "client_credentials", "password", "refresh_token"]\'::jsonb;'
     )
 
     context.oauth2_client_id = "bdd-full-client"

--- a/src/shomer/routes/oauth2.py
+++ b/src/shomer/routes/oauth2.py
@@ -378,11 +378,13 @@ async def token(
     password: str = Form(""),
     client_id: str = Form(""),
     client_secret: str = Form(""),
+    refresh_token: str = Form(""),
     code_verifier: str = Form(""),
 ) -> JSONResponse:
-    """OAuth2 token endpoint per RFC 6749 §4.1.3, §4.3 and §4.4.
+    """OAuth2 token endpoint per RFC 6749 §4.1.3, §4.3, §4.4 and §6.
 
-    Supports ``authorization_code``, ``client_credentials`` and ``password`` grants.
+    Supports ``authorization_code``, ``client_credentials``, ``password``
+    and ``refresh_token`` grants.
 
     Parameters
     ----------
@@ -391,7 +393,8 @@ async def token(
     db : DbSession
         Injected async database session.
     grant_type : str
-        ``authorization_code``, ``client_credentials`` or ``password``.
+        ``authorization_code``, ``client_credentials``, ``password``
+        or ``refresh_token``.
     code : str
         The authorization code (authorization_code grant only).
     redirect_uri : str
@@ -406,6 +409,8 @@ async def token(
         Client identifier (from POST body or Basic auth).
     client_secret : str
         Client secret (from POST body or Basic auth).
+    refresh_token : str
+        The refresh token (refresh_token grant only).
     code_verifier : str
         PKCE code verifier (authorization_code grant only).
 
@@ -414,7 +419,12 @@ async def token(
     JSONResponse
         Token response per RFC 6749 §5.1 or error per §5.2.
     """
-    supported_grants = {"authorization_code", "client_credentials", "password"}
+    supported_grants = {
+        "authorization_code",
+        "client_credentials",
+        "password",
+        "refresh_token",
+    }
     if grant_type not in supported_grants:
         return JSONResponse(
             status_code=400,
@@ -454,6 +464,11 @@ async def token(
     if grant_type == "password":
         return await _handle_password_grant(
             token_svc, authenticated_client, username, password, scope
+        )
+
+    if grant_type == "refresh_token":
+        return await _handle_refresh_token(
+            token_svc, authenticated_client, refresh_token
         )
 
     # authorization_code grant
@@ -599,6 +614,68 @@ async def _handle_password_grant(
             password=password,
             client_id=client.client_id,
             scope=scope or None,
+        )
+    except TokenError as exc:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error": exc.error,
+                "error_description": exc.description,
+            },
+        )
+
+    return JSONResponse(
+        content=response.to_dict(),
+        headers={"Cache-Control": "no-store", "Pragma": "no-cache"},
+    )
+
+
+async def _handle_refresh_token(
+    token_svc: TokenService,
+    client: Any,
+    refresh_token: str,
+) -> JSONResponse:
+    """Handle refresh_token grant per RFC 6749 §6.
+
+    Parameters
+    ----------
+    token_svc : TokenService
+        Token service instance.
+    client : OAuth2Client
+        The authenticated client.
+    refresh_token : str
+        The refresh token value.
+
+    Returns
+    -------
+    JSONResponse
+        Token response or error.
+    """
+    if not refresh_token:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error": "invalid_request",
+                "error_description": "refresh_token is required",
+            },
+        )
+
+    # Check grant_type is allowed for this client
+    if "refresh_token" not in (client.grant_types or []):
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error": "unauthorized_client",
+                "error_description": (
+                    "Client is not authorized for refresh_token grant"
+                ),
+            },
+        )
+
+    try:
+        response = await token_svc.rotate_refresh_token(
+            refresh_token=refresh_token,
+            client_id=client.client_id,
         )
     except TokenError as exc:
         return JSONResponse(

--- a/src/shomer/services/token_service.py
+++ b/src/shomer/services/token_service.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2025 Chris <goabonga@pm.me>
 
-"""OAuth2 token endpoint service (RFC 6749 §4.1.3, §4.3 and §4.4)."""
+"""OAuth2 token endpoint service (RFC 6749 §4.1.3, §4.3, §4.4 and §6)."""
 
 from __future__ import annotations
 
@@ -392,6 +392,115 @@ class TokenService:
             access_token=access_jwt,
             expires_in=self.settings.jwt_access_token_exp,
             refresh_token=raw_refresh,
+            scope=" ".join(scopes),
+        )
+
+    async def rotate_refresh_token(
+        self,
+        *,
+        refresh_token: str,
+        client_id: str,
+    ) -> TokenResponse:
+        """Exchange a refresh token for new tokens (RFC 6749 §6).
+
+        Performs mandatory rotation: the old token is revoked and a new
+        refresh token is issued. If a revoked token is presented (reuse
+        detection), the entire token family is revoked.
+
+        Parameters
+        ----------
+        refresh_token : str
+            The raw refresh token value.
+        client_id : str
+            The authenticated client identifier.
+
+        Returns
+        -------
+        TokenResponse
+            New access_token and refresh_token.
+
+        Raises
+        ------
+        TokenError
+            If the token is invalid, expired, revoked, or client mismatches.
+        """
+        from sqlalchemy import update
+
+        token_hash = hashlib.sha256(refresh_token.encode()).hexdigest()
+        stmt = select(RefreshToken).where(RefreshToken.token_hash == token_hash)
+        result = await self.session.execute(stmt)
+        rt = result.scalar_one_or_none()
+
+        if rt is None:
+            raise TokenError("invalid_grant", "Invalid refresh token")
+
+        # Reuse detection: if token is already revoked, revoke entire family
+        if rt.revoked:
+            revoke_stmt = (
+                update(RefreshToken)
+                .where(RefreshToken.family_id == rt.family_id)
+                .values(revoked=True)
+            )
+            await self.session.execute(revoke_stmt)
+            await self.session.flush()
+            raise TokenError("invalid_grant", "Refresh token reuse detected")
+
+        # Check expiration
+        now = datetime.now(timezone.utc)
+        expires_at = rt.expires_at
+        if expires_at.tzinfo is None:  # pragma: no cover — SQLite compat
+            expires_at = expires_at.replace(tzinfo=timezone.utc)
+        if expires_at < now:
+            raise TokenError("invalid_grant", "Refresh token expired")
+
+        # Check client matches
+        if rt.client_id != client_id:
+            raise TokenError("invalid_grant", "Client mismatch")
+
+        # Revoke old token
+        rt.revoked = True
+
+        # Issue new refresh token (same family)
+        new_raw = uuid.uuid4().hex
+        new_hash = hashlib.sha256(new_raw.encode()).hexdigest()
+        new_rt = RefreshToken(
+            token_hash=new_hash,
+            family_id=rt.family_id,
+            user_id=rt.user_id,
+            client_id=client_id,
+            scopes=rt.scopes,
+            expires_at=now + timedelta(days=30),
+        )
+        self.session.add(new_rt)
+
+        # Point old token to new one
+        rt.replaced_by = new_rt.id
+
+        # Issue new access token
+        scopes = rt.scopes.split() if rt.scopes else []
+        jti = uuid.uuid4().hex
+
+        access_token_record = AccessToken(
+            jti=jti,
+            user_id=rt.user_id,
+            client_id=client_id,
+            scopes=rt.scopes,
+            expires_at=now + timedelta(seconds=self.settings.jwt_access_token_exp),
+        )
+        self.session.add(access_token_record)
+        await self.session.flush()
+
+        access_jwt = self._build_access_jwt(
+            sub=str(rt.user_id),
+            aud=client_id,
+            jti=jti,
+            scopes=scopes,
+        )
+
+        return TokenResponse(
+            access_token=access_jwt,
+            expires_in=self.settings.jwt_access_token_exp,
+            refresh_token=new_raw,
             scope=" ".join(scopes),
         )
 

--- a/tests/routes/test_oauth2_unit.py
+++ b/tests/routes/test_oauth2_unit.py
@@ -426,3 +426,61 @@ class TestRenderOAuth2Error:
         assert "server_error" in _FRIENDLY_ERROR_MESSAGES
         for msg in _FRIENDLY_ERROR_MESSAGES.values():
             assert len(msg) > 0
+
+
+class TestHandleRefreshToken:
+    """Unit tests for _handle_refresh_token."""
+
+    def test_missing_refresh_token(self) -> None:
+        async def _run() -> None:
+            from shomer.routes.oauth2 import _handle_refresh_token
+
+            client = _mock_client(grant_types=["refresh_token"])
+            svc = AsyncMock()
+            resp = await _handle_refresh_token(svc, client, "")
+            assert resp.status_code == 400
+            assert b"required" in resp.body
+
+        asyncio.run(_run())
+
+    def test_grant_not_allowed(self) -> None:
+        async def _run() -> None:
+            from shomer.routes.oauth2 import _handle_refresh_token
+
+            client = _mock_client(grant_types=["authorization_code"])
+            svc = AsyncMock()
+            resp = await _handle_refresh_token(svc, client, "tok")
+            assert resp.status_code == 400
+            assert b"not authorized" in resp.body
+
+        asyncio.run(_run())
+
+    def test_success(self) -> None:
+        async def _run() -> None:
+            from shomer.routes.oauth2 import _handle_refresh_token
+
+            client = _mock_client(grant_types=["refresh_token"])
+            svc = AsyncMock()
+            svc.rotate_refresh_token.return_value = TokenResponse(
+                access_token="new-at", refresh_token="new-rt"
+            )
+            resp = await _handle_refresh_token(svc, client, "old-rt")
+            assert resp.status_code == 200
+            assert b"new-at" in resp.body
+
+        asyncio.run(_run())
+
+    def test_token_error(self) -> None:
+        async def _run() -> None:
+            from shomer.routes.oauth2 import _handle_refresh_token
+
+            client = _mock_client(grant_types=["refresh_token"])
+            svc = AsyncMock()
+            svc.rotate_refresh_token.side_effect = TokenError(
+                "invalid_grant", "expired"
+            )
+            resp = await _handle_refresh_token(svc, client, "tok")
+            assert resp.status_code == 400
+            assert b"invalid_grant" in resp.body
+
+        asyncio.run(_run())

--- a/tests/services/test_token_service.py
+++ b/tests/services/test_token_service.py
@@ -834,3 +834,164 @@ class TestVerifyPKCEPlain:
     def test_unknown_method(self) -> None:
         """Unknown PKCE method returns False."""
         assert TokenService._verify_pkce("v", "c", "unknown") is False
+
+
+class TestRotateRefreshToken:
+    """Tests for TokenService.rotate_refresh_token()."""
+
+    def test_successful_rotation(self) -> None:
+        """Valid refresh token returns new access_token + refresh_token."""
+
+        async def _run() -> None:
+            db = AsyncMock()
+            db.add = MagicMock()
+            db.flush = AsyncMock()
+
+            mock_rt = MagicMock()
+            mock_rt.token_hash = hashlib.sha256(b"raw-token").hexdigest()
+            mock_rt.family_id = uuid.uuid4()
+            mock_rt.user_id = uuid.uuid4()
+            mock_rt.client_id = "test-client"
+            mock_rt.scopes = "openid profile"
+            mock_rt.revoked = False
+            mock_rt.expires_at = datetime.now(timezone.utc) + timedelta(days=30)
+
+            rt_result = MagicMock()
+            rt_result.scalar_one_or_none.return_value = mock_rt
+            db.execute.return_value = rt_result
+
+            svc = TokenService(db, _settings())
+            resp = await svc.rotate_refresh_token(
+                refresh_token="raw-token",
+                client_id="test-client",
+            )
+            assert resp.access_token is not None
+            assert resp.refresh_token is not None
+            assert resp.refresh_token != "raw-token"
+            assert mock_rt.revoked is True
+
+        asyncio.run(_run())
+
+    def test_invalid_token_raises(self) -> None:
+        """Unknown refresh token raises TokenError."""
+
+        async def _run() -> None:
+            db = AsyncMock()
+            rt_result = MagicMock()
+            rt_result.scalar_one_or_none.return_value = None
+            db.execute.return_value = rt_result
+
+            svc = TokenService(db, _settings())
+            with pytest.raises(TokenError, match="Invalid refresh token"):
+                await svc.rotate_refresh_token(
+                    refresh_token="nonexistent",
+                    client_id="c",
+                )
+
+        asyncio.run(_run())
+
+    def test_reuse_detection_revokes_family(self) -> None:
+        """Already-revoked token triggers family-wide revocation."""
+
+        async def _run() -> None:
+            db = AsyncMock()
+            db.flush = AsyncMock()
+
+            mock_rt = MagicMock()
+            mock_rt.revoked = True
+            mock_rt.family_id = uuid.uuid4()
+
+            rt_result = MagicMock()
+            rt_result.scalar_one_or_none.return_value = mock_rt
+            db.execute.return_value = rt_result
+
+            svc = TokenService(db, _settings())
+            with pytest.raises(TokenError, match="reuse detected"):
+                await svc.rotate_refresh_token(
+                    refresh_token="reused-token",
+                    client_id="c",
+                )
+            # execute called twice: SELECT + UPDATE (family revocation)
+            assert db.execute.call_count == 2
+
+        asyncio.run(_run())
+
+    def test_expired_token_raises(self) -> None:
+        """Expired refresh token raises TokenError."""
+
+        async def _run() -> None:
+            db = AsyncMock()
+
+            mock_rt = MagicMock()
+            mock_rt.revoked = False
+            mock_rt.expires_at = datetime.now(timezone.utc) - timedelta(hours=1)
+
+            rt_result = MagicMock()
+            rt_result.scalar_one_or_none.return_value = mock_rt
+            db.execute.return_value = rt_result
+
+            svc = TokenService(db, _settings())
+            with pytest.raises(TokenError, match="expired"):
+                await svc.rotate_refresh_token(
+                    refresh_token="expired-token",
+                    client_id="c",
+                )
+
+        asyncio.run(_run())
+
+    def test_client_mismatch_raises(self) -> None:
+        """Token for a different client raises TokenError."""
+
+        async def _run() -> None:
+            db = AsyncMock()
+
+            mock_rt = MagicMock()
+            mock_rt.revoked = False
+            mock_rt.client_id = "original-client"
+            mock_rt.expires_at = datetime.now(timezone.utc) + timedelta(days=30)
+
+            rt_result = MagicMock()
+            rt_result.scalar_one_or_none.return_value = mock_rt
+            db.execute.return_value = rt_result
+
+            svc = TokenService(db, _settings())
+            with pytest.raises(TokenError, match="Client mismatch"):
+                await svc.rotate_refresh_token(
+                    refresh_token="tok",
+                    client_id="wrong-client",
+                )
+
+        asyncio.run(_run())
+
+    def test_old_token_gets_replaced_by(self) -> None:
+        """After rotation, old token's replaced_by is set."""
+
+        async def _run() -> None:
+            db = AsyncMock()
+            db.add = MagicMock()
+            db.flush = AsyncMock()
+
+            mock_rt = MagicMock()
+            mock_rt.revoked = False
+            mock_rt.family_id = uuid.uuid4()
+            mock_rt.user_id = uuid.uuid4()
+            mock_rt.client_id = "test-client"
+            mock_rt.scopes = "openid"
+            mock_rt.expires_at = datetime.now(timezone.utc) + timedelta(days=30)
+            mock_rt.replaced_by = None
+
+            rt_result = MagicMock()
+            rt_result.scalar_one_or_none.return_value = mock_rt
+            db.execute.return_value = rt_result
+
+            svc = TokenService(db, _settings())
+            await svc.rotate_refresh_token(
+                refresh_token="tok",
+                client_id="test-client",
+            )
+            # Old token revoked and new token added
+            assert mock_rt.revoked is True
+            # db.add called for new RefreshToken + AccessToken
+            assert db.add.call_count >= 2
+
+        asyncio.run(_run())


### PR DESCRIPTION
## feat(oauth2): POST /oauth2/token - grant_type=refresh_token with rotation

## Summary

Refresh token grant with mandatory rotation per RFC 6749 §6. Each use revokes the old refresh_token and issues a new one in the same family. Reuse detection via family_id triggers revocation of the entire token family.

## Changes

- [x] grant_type=refresh_token handler in token endpoint
- [x] Client authentication required
- [x] Refresh token lookup and validation (not expired, not revoked)
- [x] Mandatory rotation: revoke old, issue new refresh_token (same family_id)
- [x] Reuse detection: revoked token revokes entire family
- [x] Issue new access_token on rotation
- [x] _handle_refresh_token route helper
- [x] Add refresh_token to bdd-full-client grant_types
- [x] Unit: 10 tests (rotation, reuse, expired, mismatch, route)
- [x] BDD: 4 scenarios (missing creds, unknown client, invalid token, error format)

## Dependencies

- #33 - token endpoint base
- #16 - RefreshToken model (family_id)

## Related Issue

Closes #40

## Test Plan

- [x] `make format` - code formatted
- [x] `make lint` - no linting errors
- [x] `make typecheck` - type checks pass
- [x] `make test` - 529 passed, 100% coverage
- [x] `make bdd` - 88 scenarios passed
- [x] `make check-license` - SPDX headers present