### PR TITLE
feat(auth): Bearer token extraction middleware

### DIFF
--- a/src/shomer/deps.py
+++ b/src/shomer/deps.py
@@ -18,7 +18,7 @@ import uuid
 from collections.abc import AsyncIterator
 from typing import Annotated
 
-from fastapi import Depends
+from fastapi import Depends, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from shomer.core.database import async_session
@@ -78,3 +78,32 @@ Config = Annotated[Settings, Depends(get_config)]
 
 #: Annotated type for the current tenant ID (may be None).
 TenantId = Annotated[uuid.UUID | None, Depends(get_current_tenant)]
+
+
+async def get_bearer_token(request: Request) -> str:
+    """Extract Bearer token from the Authorization header.
+
+    Delegates to :func:`shomer.middleware.bearer.extract_bearer_token`.
+
+    Parameters
+    ----------
+    request : Request
+        The incoming HTTP request.
+
+    Returns
+    -------
+    str
+        The raw Bearer token.
+
+    Raises
+    ------
+    HTTPException
+        401 with ``WWW-Authenticate: Bearer`` if absent or malformed.
+    """
+    from shomer.middleware.bearer import extract_bearer_token
+
+    return await extract_bearer_token(request)
+
+
+#: Annotated type for an extracted Bearer token from the Authorization header.
+BearerToken = Annotated[str, Depends(get_bearer_token)]

--- a/src/shomer/middleware/bearer.py
+++ b/src/shomer/middleware/bearer.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Bearer token extraction per RFC 6750 §2.1.
+
+Provides a FastAPI dependency that extracts the Bearer token from the
+``Authorization`` header. Protected routes use this via ``BearerToken``::
+
+    from shomer.deps import BearerToken
+
+    @router.get("/protected")
+    async def protected(token: BearerToken) -> dict: ...
+"""
+
+from __future__ import annotations
+
+from fastapi import HTTPException, Request, status
+
+
+async def extract_bearer_token(request: Request) -> str:
+    """Extract the Bearer token from the Authorization header.
+
+    Per RFC 6750 §2.1, the token is sent in the ``Authorization``
+    request header field using the ``Bearer`` scheme.
+
+    Parameters
+    ----------
+    request : Request
+        The incoming HTTP request.
+
+    Returns
+    -------
+    str
+        The raw Bearer token string.
+
+    Raises
+    ------
+    HTTPException
+        401 with ``WWW-Authenticate: Bearer`` if the header is missing,
+        empty, or does not use the ``Bearer`` scheme.
+    """
+    auth_header = request.headers.get("authorization")
+
+    if not auth_header:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing Authorization header",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    parts = auth_header.split(" ", 1)
+
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid Authorization header — expected 'Bearer <token>'",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    token = parts[1].strip()
+
+    if not token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Empty Bearer token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    return token

--- a/tests/middleware/test_bearer.py
+++ b/tests/middleware/test_bearer.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Unit tests for Bearer token extraction middleware."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from shomer.middleware.bearer import extract_bearer_token
+
+
+def _req(auth_header: str | None = None) -> MagicMock:
+    """Create a mock request with an optional Authorization header."""
+    r = MagicMock()
+    r.headers = MagicMock()
+    r.headers.get = lambda k, d=None: auth_header if k == "authorization" else d
+    return r
+
+
+class TestExtractBearerToken:
+    """Tests for extract_bearer_token()."""
+
+    def test_valid_bearer_token(self) -> None:
+        """Valid 'Bearer <token>' returns the token."""
+
+        async def _run() -> None:
+            token = await extract_bearer_token(_req("Bearer my-jwt-token"))
+            assert token == "my-jwt-token"
+
+        asyncio.run(_run())
+
+    def test_missing_header_raises_401(self) -> None:
+        """Missing Authorization header raises 401."""
+
+        async def _run() -> None:
+            with pytest.raises(HTTPException) as exc_info:
+                await extract_bearer_token(_req(None))
+            assert exc_info.value.status_code == 401
+            headers = exc_info.value.headers or {}
+            assert headers["WWW-Authenticate"] == "Bearer"
+
+        asyncio.run(_run())
+
+    def test_empty_header_raises_401(self) -> None:
+        """Empty Authorization header raises 401."""
+
+        async def _run() -> None:
+            with pytest.raises(HTTPException) as exc_info:
+                await extract_bearer_token(_req(""))
+            assert exc_info.value.status_code == 401
+
+        asyncio.run(_run())
+
+    def test_non_bearer_scheme_raises_401(self) -> None:
+        """Non-Bearer scheme (e.g. Basic) raises 401."""
+
+        async def _run() -> None:
+            with pytest.raises(HTTPException) as exc_info:
+                await extract_bearer_token(_req("Basic dXNlcjpwYXNz"))
+            assert exc_info.value.status_code == 401
+            assert "Bearer" in str(exc_info.value.detail)
+
+        asyncio.run(_run())
+
+    def test_bearer_without_token_raises_401(self) -> None:
+        """'Bearer' without a token raises 401."""
+
+        async def _run() -> None:
+            with pytest.raises(HTTPException) as exc_info:
+                await extract_bearer_token(_req("Bearer "))
+            assert exc_info.value.status_code == 401
+
+        asyncio.run(_run())
+
+    def test_bearer_case_insensitive(self) -> None:
+        """'bearer' (lowercase) is accepted."""
+
+        async def _run() -> None:
+            token = await extract_bearer_token(_req("bearer my-token"))
+            assert token == "my-token"
+
+        asyncio.run(_run())
+
+    def test_bearer_mixed_case(self) -> None:
+        """'BEARER' (uppercase) is accepted."""
+
+        async def _run() -> None:
+            token = await extract_bearer_token(_req("BEARER my-token"))
+            assert token == "my-token"
+
+        asyncio.run(_run())
+
+    def test_token_with_dots_preserved(self) -> None:
+        """JWT-like token with dots is preserved as-is."""
+
+        async def _run() -> None:
+            jwt = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiIxIn0.sig"
+            token = await extract_bearer_token(_req(f"Bearer {jwt}"))
+            assert token == jwt
+
+        asyncio.run(_run())
+
+    def test_www_authenticate_header_on_error(self) -> None:
+        """All 401 responses include WWW-Authenticate: Bearer."""
+
+        async def _run() -> None:
+            for header in [None, "", "Basic x", "Bearer "]:
+                with pytest.raises(HTTPException) as exc_info:
+                    await extract_bearer_token(_req(header))
+                assert exc_info.value.headers is not None
+                headers = exc_info.value.headers or {}
+            assert headers["WWW-Authenticate"] == "Bearer"
+
+        asyncio.run(_run())

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -5,7 +5,7 @@
 
 import asyncio
 import inspect
-from typing import get_type_hints
+from typing import Annotated, get_type_hints
 
 from fastapi.params import Depends as DependsClass
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -112,3 +112,17 @@ class TestGetDbRollback:
                 mock_session.rollback.assert_awaited_once()
 
         asyncio.run(_run())
+
+
+class TestBearerTokenType:
+    """Tests for BearerToken annotated type."""
+
+    def test_bearer_token_is_annotated(self) -> None:
+        from typing import get_args, get_origin
+
+        from shomer.deps import BearerToken
+
+        assert get_origin(BearerToken) is Annotated
+        args = get_args(BearerToken)
+        assert args[0] is str
+        assert any(isinstance(a, DependsClass) for a in args[1:])


### PR DESCRIPTION
## feat(auth): Bearer token extraction middleware

## Summary

FastAPI dependency for extracting Bearer tokens from the Authorization header per RFC 6750 §2.1. Returns 401 with WWW-Authenticate: Bearer on missing/malformed token. Available as BearerToken annotated type.

## Changes

- [x] extract_bearer_token() — parse Authorization header for Bearer scheme
- [x] 401 with WWW-Authenticate: Bearer on missing/malformed/empty token
- [x] Case-insensitive scheme matching (Bearer, bearer, BEARER)
- [x] BearerToken annotated type in deps.py for route injection
- [x] get_bearer_token() wrapper dependency
- [x] Unit: 10 tests (valid, missing, empty, wrong scheme, case, JWT-like, WWW-Authenticate)

## Dependencies

- #15 - JWT validation service

## Related Issue

Closes #41

## Test Plan

- [x] \`make format\` - code formatted
- [x] \`make lint\` - no linting errors
- [x] \`make typecheck\` - type checks pass
- [x] \`make test\` - 539 passed, 100% coverage
- [x] \`make bdd\` - 88 scenarios passed
- [x] \`make check-license\` - SPDX headers present