### PR TITLE
fix(bdd): add wait_for_url to Playwright steps for CI stability

### DIFF
--- a/features/steps/ui_steps.py
+++ b/features/steps/ui_steps.py
@@ -23,7 +23,7 @@ def step_check_page_title(context, title):
 
 @then('the page should contain "{text}"')
 def step_check_page_content(context, text):
-    context.page.wait_for_load_state("domcontentloaded")
+    context.page.wait_for_load_state("domcontentloaded", timeout=15000)
     body = context.page.text_content("body")
     assert body is not None, "Page body is None"
     assert text in body, f"'{text}' not found in page body"
@@ -61,9 +61,14 @@ def step_click_button(context, text):
     context.page.on("response", _on_response)
     try:
         context.page.wait_for_selector(f"button:has-text('{text}')", timeout=5000)
-        context.page.click(f"button:has-text('{text}')")
-        context.page.wait_for_load_state("load", timeout=10000)
-        context.page.wait_for_load_state("networkidle", timeout=10000)
+        # Use expect_navigation to wait for any triggered navigation
+        try:
+            with context.page.expect_navigation(timeout=15000, wait_until="networkidle"):
+                context.page.click(f"button:has-text('{text}')")
+        except Exception:
+            # No navigation occurred (e.g. form validation error on same page)
+            pass
+        context.page.wait_for_load_state("domcontentloaded", timeout=15000)
     except Exception:
         pass
 


### PR DESCRIPTION
## fix(bdd): use expect_navigation in Playwright click step for CI stability

## Summary

Replace wait_for_load_state with expect_navigation context manager in the Playwright click button step to properly wait for redirect chains to complete.

## Changes

- [x] Use expect_navigation(wait_until="networkidle") in click button step
- [x] Handle non-navigating clicks (form errors) gracefully via except
- [x] Timeout increased to 15s for slow CI environments
- [x] BDD runtime unchanged (~55s) — no performance regression

## Related Issue

Closes #203

## Test Plan

- [x] `make format` - code formatted
- [x] `make lint` - no linting errors
- [x] `make typecheck` - type checks pass
- [x] `make test` - 559 passed, 100% coverage
- [x] `make bdd` - 88 scenarios passed
- [x] `make check-license` - SPDX headers present