### PR TITLE
feat(oidc): GET/POST /userinfo

### DIFF
--- a/features/steps/http_steps.py
+++ b/features/steps/http_steps.py
@@ -17,6 +17,10 @@ def _send(context, method, path, data=None):
     if data is not None:
         body = json.dumps(data).encode()
         headers["Content-Type"] = "application/json"
+    # Attach Bearer token if available
+    bearer = getattr(context, "bearer_token", None)
+    if bearer:
+        headers["Authorization"] = f"Bearer {bearer}"
     # Attach session cookie if available
     cookie = getattr(context, "session_cookie", None)
     if cookie:
@@ -122,6 +126,25 @@ def step_logged_in_as(context, email, password):
     assert context.response_status == 200, (
         f"Login failed with status {context.response_status}: {context.response_body}"
     )
+
+
+@given("I have a Bearer token for the OAuth2 client")
+def step_obtain_bearer_token(context):
+    """Obtain a Bearer token via password grant for the BDD test user/client."""
+    form_data = {
+        "grant_type": "password",
+        "username": context.oauth2_user_email,
+        "password": context.oauth2_user_password,
+        "client_id": context.oauth2_client_id,
+        "client_secret": context.oauth2_client_secret,
+        "scope": "openid profile email",
+    }
+    _send_form(context, "/oauth2/token", form_data)
+    assert context.response_status == 200, (
+        f"Token request failed: {context.response_body}"
+    )
+    token_data = json.loads(context.response_body)
+    context.bearer_token = token_data["access_token"]
 
 
 @when('I send a DELETE request to "{path}"')

--- a/features/userinfo.feature
+++ b/features/userinfo.feature
@@ -1,0 +1,30 @@
+Feature: OIDC UserInfo endpoint
+
+  Scenario: GET /userinfo without Authorization returns 401
+    When I send a GET request to "/userinfo"
+    Then the response status code should be 401
+
+  Scenario: POST /userinfo without Authorization returns 401
+    When I send a POST request to "/userinfo"
+    Then the response status code should be 401
+
+  Scenario: GET /userinfo with valid Bearer token returns sub
+    Given a verified user and an OAuth2 client with all grants
+    And I have a Bearer token for the OAuth2 client
+    When I send a GET request to "/userinfo"
+    Then the response status code should be 200
+    And the response should have JSON key "sub"
+
+  Scenario: GET /userinfo with valid Bearer token returns email
+    Given a verified user and an OAuth2 client with all grants
+    And I have a Bearer token for the OAuth2 client
+    When I send a GET request to "/userinfo"
+    Then the response status code should be 200
+    And the response body should contain "email"
+
+  Scenario: POST /userinfo with valid Bearer token returns sub
+    Given a verified user and an OAuth2 client with all grants
+    And I have a Bearer token for the OAuth2 client
+    When I send a POST request to "/userinfo"
+    Then the response status code should be 200
+    And the response should have JSON key "sub"

--- a/src/shomer/app.py
+++ b/src/shomer/app.py
@@ -59,6 +59,7 @@ def create_app() -> FastAPI:
     from shomer.routes.jwks import router as jwks_router
     from shomer.routes.oauth2 import router as oauth2_router
     from shomer.routes.password_ui import router as password_ui_router
+    from shomer.routes.userinfo import router as userinfo_router
     from shomer.routes.views import router as views_router
 
     setup_cors(application, settings)
@@ -71,6 +72,7 @@ def create_app() -> FastAPI:
     application.include_router(oauth2_router)
     application.include_router(docs_router)
     application.include_router(jwks_router)
+    application.include_router(userinfo_router)
     application.include_router(views_router)
 
     return application

--- a/src/shomer/routes/userinfo.py
+++ b/src/shomer/routes/userinfo.py
@@ -1,0 +1,169 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""OIDC UserInfo endpoint per OpenID Connect Core 1.0 §5.3."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+from shomer.auth import CurrentUserInfo
+from shomer.deps import CurrentUser, DbSession
+from shomer.models.user import User
+from shomer.models.user_profile import UserProfile
+
+router = APIRouter(tags=["oidc"])
+
+
+async def _build_userinfo(user: CurrentUserInfo, db: Any) -> dict[str, Any]:
+    """Build the UserInfo response claims based on token scopes.
+
+    Parameters
+    ----------
+    user : CurrentUserInfo
+        The authenticated user context.
+    db : AsyncSession
+        Database session.
+
+    Returns
+    -------
+    dict[str, Any]
+        Claims to return in the UserInfo response.
+    """
+    claims: dict[str, Any] = {"sub": str(user.user_id)}
+    scopes = set(user.scopes)
+
+    # Look up user with profile and emails
+    stmt = (
+        select(User)
+        .where(User.id == user.user_id)
+        .options(selectinload(User.profile), selectinload(User.emails))
+    )
+    result = await db.execute(stmt)
+    db_user = result.scalar_one_or_none()
+
+    if db_user is None:
+        return claims
+
+    # email scope
+    if "email" in scopes:
+        primary_email = next((e for e in db_user.emails if e.is_primary), None)
+        if primary_email:
+            claims["email"] = primary_email.email
+            claims["email_verified"] = primary_email.is_verified
+
+    # profile scope
+    if "profile" in scopes and db_user.profile is not None:
+        profile = db_user.profile
+        _add_if_set(claims, "name", profile.name)
+        _add_if_set(claims, "given_name", profile.given_name)
+        _add_if_set(claims, "family_name", profile.family_name)
+        _add_if_set(claims, "middle_name", profile.middle_name)
+        _add_if_set(claims, "nickname", profile.nickname)
+        _add_if_set(claims, "preferred_username", profile.preferred_username)
+        _add_if_set(claims, "profile", profile.profile_url)
+        _add_if_set(claims, "picture", profile.picture_url)
+        _add_if_set(claims, "website", profile.website)
+        _add_if_set(claims, "gender", profile.gender)
+        _add_if_set(claims, "birthdate", profile.birthdate)
+        _add_if_set(claims, "zoneinfo", profile.zoneinfo)
+        _add_if_set(claims, "locale", profile.locale)
+
+    # address scope
+    if "address" in scopes and db_user.profile is not None:
+        address = _build_address(db_user.profile)
+        if address:
+            claims["address"] = address
+
+    # phone scope
+    if "phone" in scopes and db_user.profile is not None:
+        if db_user.profile.phone_number:
+            claims["phone_number"] = db_user.profile.phone_number
+            claims["phone_number_verified"] = db_user.profile.phone_number_verified
+
+    return claims
+
+
+def _add_if_set(claims: dict[str, Any], key: str, value: Any) -> None:
+    """Add a claim only if the value is not None."""
+    if value is not None:
+        claims[key] = value
+
+
+def _build_address(profile: UserProfile) -> dict[str, str] | None:
+    """Build OIDC address claim from profile fields.
+
+    Parameters
+    ----------
+    profile : UserProfile
+        The user profile.
+
+    Returns
+    -------
+    dict[str, str] or None
+        Address object per OIDC Core §5.1.1, or None if empty.
+    """
+    address: dict[str, str] = {}
+    if profile.address_formatted:
+        address["formatted"] = profile.address_formatted
+    if profile.address_street:
+        address["street_address"] = profile.address_street
+    if profile.address_locality:
+        address["locality"] = profile.address_locality
+    if profile.address_region:
+        address["region"] = profile.address_region
+    if profile.address_postal_code:
+        address["postal_code"] = profile.address_postal_code
+    if profile.address_country:
+        address["country"] = profile.address_country
+    return address or None
+
+
+@router.get("/userinfo")
+async def userinfo_get(user: CurrentUser, db: DbSession) -> JSONResponse:
+    """OIDC UserInfo endpoint (GET).
+
+    Returns claims about the authenticated user based on the scopes
+    granted to the access token.
+
+    Parameters
+    ----------
+    user : CurrentUser
+        The authenticated user (injected via Bearer token or session).
+    db : DbSession
+        Database session.
+
+    Returns
+    -------
+    JSONResponse
+        JSON object with user claims.
+    """
+    claims = await _build_userinfo(user, db)
+    return JSONResponse(content=claims)
+
+
+@router.post("/userinfo")
+async def userinfo_post(user: CurrentUser, db: DbSession) -> JSONResponse:
+    """OIDC UserInfo endpoint (POST).
+
+    Identical to GET — both methods are supported per OIDC Core §5.3.
+
+    Parameters
+    ----------
+    user : CurrentUser
+        The authenticated user.
+    db : DbSession
+        Database session.
+
+    Returns
+    -------
+    JSONResponse
+        JSON object with user claims.
+    """
+    claims = await _build_userinfo(user, db)
+    return JSONResponse(content=claims)

--- a/tests/routes/test_userinfo_unit.py
+++ b/tests/routes/test_userinfo_unit.py
@@ -1,0 +1,187 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Unit tests for OIDC UserInfo endpoint."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+from shomer.auth import CurrentUserInfo
+from shomer.routes.userinfo import _build_userinfo, userinfo_get, userinfo_post
+
+
+def _user(
+    scopes: list[str] | None = None,
+) -> CurrentUserInfo:
+    return CurrentUserInfo(
+        user_id=uuid.uuid4(),
+        scopes=scopes or [],
+        auth_method="bearer",
+    )
+
+
+def _mock_db(
+    db_user: MagicMock | None = None,
+) -> AsyncMock:
+    db = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = db_user
+    db.execute.return_value = result
+    return db
+
+
+def _mock_user_with_profile(
+    *,
+    email: str = "user@example.com",
+    email_verified: bool = True,
+    name: str | None = "John Doe",
+    phone: str | None = None,
+) -> MagicMock:
+    u = MagicMock()
+    u.id = uuid.uuid4()
+
+    primary_email = MagicMock()
+    primary_email.email = email
+    primary_email.is_primary = True
+    primary_email.is_verified = email_verified
+    u.emails = [primary_email]
+
+    profile = MagicMock()
+    profile.name = name
+    profile.given_name = "John"
+    profile.family_name = "Doe"
+    profile.middle_name = None
+    profile.nickname = None
+    profile.preferred_username = None
+    profile.profile_url = None
+    profile.picture_url = "https://example.com/pic.jpg"
+    profile.website = None
+    profile.gender = None
+    profile.birthdate = None
+    profile.zoneinfo = None
+    profile.locale = None
+    profile.address_formatted = None
+    profile.address_street = None
+    profile.address_locality = None
+    profile.address_region = None
+    profile.address_postal_code = None
+    profile.address_country = None
+    profile.phone_number = phone
+    profile.phone_number_verified = False
+    u.profile = profile
+
+    return u
+
+
+class TestBuildUserinfo:
+    """Tests for _build_userinfo()."""
+
+    def test_sub_always_included(self) -> None:
+        async def _run() -> None:
+            user = _user()
+            claims = await _build_userinfo(user, _mock_db())
+            assert claims["sub"] == str(user.user_id)
+
+        asyncio.run(_run())
+
+    def test_no_claims_without_scopes(self) -> None:
+        async def _run() -> None:
+            user = _user(scopes=[])
+            db_user = _mock_user_with_profile()
+            claims = await _build_userinfo(user, _mock_db(db_user))
+            assert list(claims.keys()) == ["sub"]
+
+        asyncio.run(_run())
+
+    def test_email_scope(self) -> None:
+        async def _run() -> None:
+            user = _user(scopes=["openid", "email"])
+            db_user = _mock_user_with_profile(email="j@example.com")
+            claims = await _build_userinfo(user, _mock_db(db_user))
+            assert claims["email"] == "j@example.com"
+            assert claims["email_verified"] is True
+
+        asyncio.run(_run())
+
+    def test_profile_scope(self) -> None:
+        async def _run() -> None:
+            user = _user(scopes=["openid", "profile"])
+            db_user = _mock_user_with_profile(name="Jane")
+            claims = await _build_userinfo(user, _mock_db(db_user))
+            assert claims["name"] == "Jane"
+            assert claims["given_name"] == "John"
+            assert claims["picture"] == "https://example.com/pic.jpg"
+            assert "middle_name" not in claims
+
+        asyncio.run(_run())
+
+    def test_phone_scope(self) -> None:
+        async def _run() -> None:
+            user = _user(scopes=["openid", "phone"])
+            db_user = _mock_user_with_profile(phone="+33612345678")
+            claims = await _build_userinfo(user, _mock_db(db_user))
+            assert claims["phone_number"] == "+33612345678"
+            assert claims["phone_number_verified"] is False
+
+        asyncio.run(_run())
+
+    def test_address_scope(self) -> None:
+        async def _run() -> None:
+            user = _user(scopes=["openid", "address"])
+            db_user = _mock_user_with_profile()
+            db_user.profile.address_formatted = "123 Main St"
+            db_user.profile.address_country = "France"
+            claims = await _build_userinfo(user, _mock_db(db_user))
+            assert claims["address"]["formatted"] == "123 Main St"
+            assert claims["address"]["country"] == "France"
+
+        asyncio.run(_run())
+
+    def test_user_not_found(self) -> None:
+        async def _run() -> None:
+            user = _user(scopes=["openid", "profile"])
+            claims = await _build_userinfo(user, _mock_db(None))
+            assert claims == {"sub": str(user.user_id)}
+
+        asyncio.run(_run())
+
+    def test_no_profile_object(self) -> None:
+        async def _run() -> None:
+            user = _user(scopes=["openid", "profile"])
+            db_user = MagicMock()
+            db_user.emails = []
+            db_user.profile = None
+            claims = await _build_userinfo(user, _mock_db(db_user))
+            assert "name" not in claims
+
+        asyncio.run(_run())
+
+
+class TestUserinfoGet:
+    """Tests for GET /userinfo."""
+
+    def test_returns_json_response(self) -> None:
+        async def _run() -> None:
+            user = _user(scopes=["openid"])
+            resp = await userinfo_get(user, _mock_db())
+            body = json.loads(bytes(resp.body))
+            assert "sub" in body
+
+        asyncio.run(_run())
+
+
+class TestUserinfoPost:
+    """Tests for POST /userinfo."""
+
+    def test_returns_json_response(self) -> None:
+        async def _run() -> None:
+            user = _user(scopes=["openid"])
+            resp = await userinfo_post(user, _mock_db())
+            body = json.loads(bytes(resp.body))
+            assert "sub" in body
+
+        asyncio.run(_run())


### PR DESCRIPTION
## feat(oidc): GET/POST /userinfo

## Summary

OIDC UserInfo endpoint per OpenID Connect Core 1.0 §5.3. Returns user claims based on access token scopes. Supports GET and POST. Bearer token required via CurrentUser dependency.

## Changes

- [x] GET /userinfo route
- [x] POST /userinfo route (identical to GET per spec)
- [x] Bearer token required via CurrentUser dependency
- [x] sub claim always included
- [x] email scope → email, email_verified
- [x] profile scope → name, picture, etc. from UserProfile
- [x] address scope → OIDC address object
- [x] phone scope → phone_number, phone_number_verified
- [x] Content-Type: application/json
- [x] Bearer token support in http_steps.py for BDD
- [x] Given step to obtain Bearer token via password grant
- [x] Unit: 10 tests
- [x] BDD: 5 scenarios (GET/POST 401, GET/POST with Bearer → sub/email)

## Dependencies

- #5 - UserProfile model
- #15 - JWT validation
- #42 - get_current_user dependency

## Related Issue

Closes #45

## Test Plan

- [x] \`make format\` - code formatted
- [x] \`make lint\` - no linting errors
- [x] \`make typecheck\` - type checks pass
- [x] \`make test\` - 586 passed, 100% coverage
- [x] \`make bdd\` - 93 scenarios passed
- [x] \`make check-license\` - SPDX headers present