### PR TITLE
feat(oidc): GET /.well-known/openid-configuration

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -14,12 +14,16 @@ MAILCATCHER_URL = os.getenv("MAILCATCHER_URL", "http://localhost:1080")
 
 
 def before_scenario(context, scenario):
-    """Clear MailCatcher inbox before each scenario."""
+    """Clear state before each scenario."""
+    # Clear MailCatcher inbox
     try:
         req = urllib.request.Request(MAILCATCHER_URL + "/messages", method="DELETE")
         urllib.request.urlopen(req, timeout=2)
     except Exception:
         pass
+    # Clear auth state from previous scenarios
+    context.bearer_token = None
+    context.session_cookie = None
 
 
 def before_all(context):

--- a/features/openid_configuration.feature
+++ b/features/openid_configuration.feature
@@ -1,0 +1,31 @@
+Feature: OIDC Discovery endpoint
+
+  Scenario: Discovery endpoint returns 200 with issuer
+    When I send a GET request to "/.well-known/openid-configuration"
+    Then the response status code should be 200
+    And the response body should contain "issuer"
+
+  Scenario: Discovery returns authorization and token endpoints
+    When I send a GET request to "/.well-known/openid-configuration"
+    Then the response status code should be 200
+    And the response should have JSON key "authorization_endpoint"
+    And the response should have JSON key "token_endpoint"
+    And the response should have JSON key "userinfo_endpoint"
+    And the response should have JSON key "jwks_uri"
+
+  Scenario: Discovery returns supported scopes and grants
+    When I send a GET request to "/.well-known/openid-configuration"
+    Then the response status code should be 200
+    And the response body should contain "openid"
+    And the response body should contain "authorization_code"
+    And the response body should contain "S256"
+
+  Scenario: Discovery includes Cache-Control header
+    When I send a GET request to "/.well-known/openid-configuration"
+    Then the response status code should be 200
+    And the response should have header "Cache-Control" containing "max-age"
+
+  Scenario: Discovery returns JSON content type
+    When I send a GET request to "/.well-known/openid-configuration"
+    Then the response status code should be 200
+    And the response content type should be json

--- a/src/shomer/app.py
+++ b/src/shomer/app.py
@@ -54,6 +54,7 @@ def create_app() -> FastAPI:
     from shomer.middleware.session import SessionMiddleware
     from shomer.routes.auth import router as auth_router
     from shomer.routes.auth_ui import router as auth_ui_router
+    from shomer.routes.discovery import router as discovery_router
     from shomer.routes.docs import router as docs_router
     from shomer.routes.health import router as health_router
     from shomer.routes.jwks import router as jwks_router
@@ -74,6 +75,7 @@ def create_app() -> FastAPI:
     application.include_router(oauth2_router)
     application.include_router(docs_router)
     application.include_router(jwks_router)
+    application.include_router(discovery_router)
     application.include_router(userinfo_router)
     application.include_router(profile_router)
     application.include_router(settings_ui_router)

--- a/src/shomer/routes/discovery.py
+++ b/src/shomer/routes/discovery.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""OIDC Discovery endpoint per OpenID Connect Discovery 1.0.
+
+Returns the server configuration document at
+``/.well-known/openid-configuration``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+
+from shomer.core.settings import get_settings
+
+router = APIRouter()
+
+#: Cache-Control max-age for the discovery document (seconds).
+DISCOVERY_CACHE_MAX_AGE = 3600
+
+
+@router.get("/.well-known/openid-configuration")
+async def openid_configuration() -> JSONResponse:
+    """Return the OIDC Discovery document.
+
+    Provides client auto-discovery of the server's capabilities
+    per OpenID Connect Discovery 1.0 §3.
+
+    Returns
+    -------
+    JSONResponse
+        JSON discovery document with Cache-Control header.
+    """
+    settings = get_settings()
+    issuer = settings.jwt_issuer
+
+    config: dict[str, Any] = {
+        # Required
+        "issuer": issuer,
+        "authorization_endpoint": f"{issuer}/oauth2/authorize",
+        "token_endpoint": f"{issuer}/oauth2/token",
+        "userinfo_endpoint": f"{issuer}/userinfo",
+        "jwks_uri": f"{issuer}/.well-known/jwks.json",
+        # Recommended
+        "registration_endpoint": None,
+        "scopes_supported": [
+            "openid",
+            "profile",
+            "email",
+            "address",
+            "phone",
+            "offline_access",
+        ],
+        "response_types_supported": ["code"],
+        "response_modes_supported": ["query"],
+        "grant_types_supported": [
+            "authorization_code",
+            "client_credentials",
+            "password",
+            "refresh_token",
+        ],
+        "subject_types_supported": ["public"],
+        "id_token_signing_alg_values_supported": ["HS256", "RS256"],
+        "token_endpoint_auth_methods_supported": [
+            "client_secret_basic",
+            "client_secret_post",
+            "none",
+        ],
+        "claims_supported": [
+            "sub",
+            "iss",
+            "aud",
+            "exp",
+            "iat",
+            "nonce",
+            "auth_time",
+            "name",
+            "given_name",
+            "family_name",
+            "nickname",
+            "preferred_username",
+            "profile",
+            "picture",
+            "website",
+            "email",
+            "email_verified",
+            "gender",
+            "birthdate",
+            "zoneinfo",
+            "locale",
+            "phone_number",
+            "phone_number_verified",
+            "address",
+        ],
+        "code_challenge_methods_supported": ["S256", "plain"],
+        # Additional endpoints
+        "revocation_endpoint": f"{issuer}/oauth2/revoke",
+        "introspection_endpoint": f"{issuer}/oauth2/introspect",
+        "end_session_endpoint": f"{issuer}/auth/logout",
+    }
+
+    return JSONResponse(
+        content=config,
+        headers={"Cache-Control": f"public, max-age={DISCOVERY_CACHE_MAX_AGE}"},
+    )

--- a/tests/routes/test_discovery_unit.py
+++ b/tests/routes/test_discovery_unit.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Unit tests for OIDC Discovery endpoint."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import MagicMock, patch
+
+from shomer.routes.discovery import DISCOVERY_CACHE_MAX_AGE, openid_configuration
+
+
+class TestOpenIDConfiguration:
+    """Tests for GET /.well-known/openid-configuration."""
+
+    @patch("shomer.routes.discovery.get_settings")
+    def test_returns_issuer(self, mock_settings: MagicMock) -> None:
+        settings = MagicMock()
+        settings.jwt_issuer = "https://auth.shomer.local"
+        mock_settings.return_value = settings
+
+        async def _run() -> None:
+            resp = await openid_configuration()
+            body = json.loads(bytes(resp.body))
+            assert body["issuer"] == "https://auth.shomer.local"
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.discovery.get_settings")
+    def test_contains_required_endpoints(self, mock_settings: MagicMock) -> None:
+        settings = MagicMock()
+        settings.jwt_issuer = "https://auth.example.com"
+        mock_settings.return_value = settings
+
+        async def _run() -> None:
+            resp = await openid_configuration()
+            body = json.loads(bytes(resp.body))
+            assert (
+                body["authorization_endpoint"]
+                == "https://auth.example.com/oauth2/authorize"
+            )
+            assert body["token_endpoint"] == "https://auth.example.com/oauth2/token"
+            assert body["userinfo_endpoint"] == "https://auth.example.com/userinfo"
+            assert body["jwks_uri"] == "https://auth.example.com/.well-known/jwks.json"
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.discovery.get_settings")
+    def test_scopes_supported(self, mock_settings: MagicMock) -> None:
+        mock_settings.return_value = MagicMock(jwt_issuer="https://x")
+
+        async def _run() -> None:
+            resp = await openid_configuration()
+            body = json.loads(bytes(resp.body))
+            assert "openid" in body["scopes_supported"]
+            assert "profile" in body["scopes_supported"]
+            assert "email" in body["scopes_supported"]
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.discovery.get_settings")
+    def test_grant_types_supported(self, mock_settings: MagicMock) -> None:
+        mock_settings.return_value = MagicMock(jwt_issuer="https://x")
+
+        async def _run() -> None:
+            resp = await openid_configuration()
+            body = json.loads(bytes(resp.body))
+            grants = body["grant_types_supported"]
+            assert "authorization_code" in grants
+            assert "client_credentials" in grants
+            assert "password" in grants
+            assert "refresh_token" in grants
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.discovery.get_settings")
+    def test_response_types_supported(self, mock_settings: MagicMock) -> None:
+        mock_settings.return_value = MagicMock(jwt_issuer="https://x")
+
+        async def _run() -> None:
+            resp = await openid_configuration()
+            body = json.loads(bytes(resp.body))
+            assert "code" in body["response_types_supported"]
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.discovery.get_settings")
+    def test_token_endpoint_auth_methods(self, mock_settings: MagicMock) -> None:
+        mock_settings.return_value = MagicMock(jwt_issuer="https://x")
+
+        async def _run() -> None:
+            resp = await openid_configuration()
+            body = json.loads(bytes(resp.body))
+            methods = body["token_endpoint_auth_methods_supported"]
+            assert "client_secret_basic" in methods
+            assert "client_secret_post" in methods
+            assert "none" in methods
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.discovery.get_settings")
+    def test_code_challenge_methods(self, mock_settings: MagicMock) -> None:
+        mock_settings.return_value = MagicMock(jwt_issuer="https://x")
+
+        async def _run() -> None:
+            resp = await openid_configuration()
+            body = json.loads(bytes(resp.body))
+            assert "S256" in body["code_challenge_methods_supported"]
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.discovery.get_settings")
+    def test_claims_supported(self, mock_settings: MagicMock) -> None:
+        mock_settings.return_value = MagicMock(jwt_issuer="https://x")
+
+        async def _run() -> None:
+            resp = await openid_configuration()
+            body = json.loads(bytes(resp.body))
+            claims = body["claims_supported"]
+            for claim in ["sub", "iss", "email", "name", "address"]:
+                assert claim in claims
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.discovery.get_settings")
+    def test_cache_control_header(self, mock_settings: MagicMock) -> None:
+        mock_settings.return_value = MagicMock(jwt_issuer="https://x")
+
+        async def _run() -> None:
+            resp = await openid_configuration()
+            cc = resp.headers.get("cache-control", "")
+            assert f"max-age={DISCOVERY_CACHE_MAX_AGE}" in cc
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.discovery.get_settings")
+    def test_additional_endpoints(self, mock_settings: MagicMock) -> None:
+        settings = MagicMock()
+        settings.jwt_issuer = "https://auth.example.com"
+        mock_settings.return_value = settings
+
+        async def _run() -> None:
+            resp = await openid_configuration()
+            body = json.loads(bytes(resp.body))
+            assert (
+                body["revocation_endpoint"] == "https://auth.example.com/oauth2/revoke"
+            )
+            assert (
+                body["introspection_endpoint"]
+                == "https://auth.example.com/oauth2/introspect"
+            )
+            assert (
+                body["end_session_endpoint"] == "https://auth.example.com/auth/logout"
+            )
+
+        asyncio.run(_run())


### PR DESCRIPTION
## feat(oidc): GET /.well-known/openid-configuration

## Summary

OIDC Discovery endpoint per OpenID Connect Discovery 1.0 §3. Returns issuer, all endpoint URLs, supported scopes/grants/auth methods/claims/PKCE methods with Cache-Control header.

## Changes

- [x] GET /.well-known/openid-configuration route
- [x] Dynamic issuer from settings (tenant context placeholder for M18)
- [x] All endpoint URLs (authorize, token, userinfo, jwks, revoke, introspect, logout)
- [x] Supported scopes (openid, profile, email, address, phone, offline_access)
- [x] Supported grant_types (authorization_code, client_credentials, password, refresh_token)
- [x] Supported token_endpoint_auth_methods (basic, post, none)
- [x] Supported code_challenge_methods (S256, plain)
- [x] Cache-Control: public, max-age=3600
- [x] Fix BDD auth state leaking between scenarios
- [x] Unit: 10 tests
- [x] BDD: 5 scenarios

## Related Issue

Closes #49

## Test Plan

- [x] \`make format\` - code formatted
- [x] \`make lint\` - no linting errors
- [x] \`make typecheck\` - type checks pass
- [x] \`make test\` - 626 passed, 100% coverage
- [x] \`make bdd\` - 111 scenarios passed
- [x] \`make check-license\` - SPDX headers present