### PR TITLE
feat(models): DeviceCode

### DIFF
--- a/alembic/versions/0013_add_device_codes.py
+++ b/alembic/versions/0013_add_device_codes.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Add device_codes table for RFC 8628.
+
+Revision ID: 0013
+Revises: 0012
+Create Date: 2026-03-21
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0013"
+down_revision: Union[str, None] = "0012"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create device_codes table."""
+    op.create_table(
+        "device_codes",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("device_code", sa.String(255), nullable=False),
+        sa.Column("user_code", sa.String(16), nullable=False),
+        sa.Column("client_id", sa.String(255), nullable=False),
+        sa.Column("scopes", sa.Text(), nullable=False, server_default=""),
+        sa.Column("verification_uri", sa.String(2048), nullable=False),
+        sa.Column("verification_uri_complete", sa.String(2048), nullable=True),
+        sa.Column("interval", sa.Integer(), nullable=False, server_default="5"),
+        sa.Column(
+            "status",
+            sa.String(10),
+            nullable=False,
+            server_default="pending",
+        ),
+        sa.Column("user_id", sa.Uuid(), nullable=True),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_device_codes")),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            name=op.f("fk_device_codes_user_id_users"),
+            ondelete="SET NULL",
+        ),
+        sa.UniqueConstraint("device_code", name=op.f("uq_device_codes_device_code")),
+        sa.UniqueConstraint("user_code", name=op.f("uq_device_codes_user_code")),
+    )
+    op.create_index(
+        op.f("ix_device_codes_device_code"), "device_codes", ["device_code"]
+    )
+    op.create_index(op.f("ix_device_codes_user_code"), "device_codes", ["user_code"])
+
+
+def downgrade() -> None:
+    """Drop device_codes table."""
+    op.drop_table("device_codes")

--- a/src/shomer/models/__init__.py
+++ b/src/shomer/models/__init__.py
@@ -9,6 +9,7 @@ can resolve all relationships at configuration time.
 
 from shomer.models.access_token import AccessToken as AccessToken
 from shomer.models.authorization_code import AuthorizationCode as AuthorizationCode
+from shomer.models.device_code import DeviceCode as DeviceCode
 from shomer.models.jwk import JWK as JWK
 from shomer.models.oauth2_client import OAuth2Client as OAuth2Client
 from shomer.models.password_reset_token import PasswordResetToken as PasswordResetToken

--- a/src/shomer/models/device_code.py
+++ b/src/shomer/models/device_code.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""DeviceCode model for RFC 8628 device authorization grant."""
+
+from __future__ import annotations
+
+import enum
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import DateTime, Enum, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+if TYPE_CHECKING:
+    from shomer.models.user import User
+
+from shomer.core.database import Base, TimestampMixin, UUIDMixin
+
+
+class DeviceCodeStatus(str, enum.Enum):
+    """Status of a device authorization request.
+
+    Attributes
+    ----------
+    PENDING
+        Waiting for user to authorize.
+    APPROVED
+        User approved the request.
+    DENIED
+        User denied the request.
+    EXPIRED
+        Request expired before user acted.
+    """
+
+    PENDING = "pending"
+    APPROVED = "approved"
+    DENIED = "denied"
+    EXPIRED = "expired"
+
+
+class DeviceCode(Base, UUIDMixin, TimestampMixin):
+    """Device authorization request per RFC 8628.
+
+    Stores the device_code (for polling), user_code (for user entry),
+    and tracks the lifecycle from pending through approval/denial/expiry.
+
+    Attributes
+    ----------
+    id : uuid.UUID
+        Primary key (from UUIDMixin).
+    device_code : str
+        Unique device code for client polling (indexed).
+    user_code : str
+        Human-friendly code for user entry (e.g. ``ABCD-EFGH``).
+    client_id : str
+        OAuth2 client that initiated the request.
+    scopes : str
+        Space-separated list of requested scopes.
+    verification_uri : str
+        URI where the user should enter the user_code.
+    verification_uri_complete : str or None
+        Full URI with user_code pre-filled.
+    interval : int
+        Minimum polling interval in seconds (default 5).
+    status : DeviceCodeStatus
+        Current status of the request.
+    user_id : uuid.UUID or None
+        Foreign key to users table (set when user approves).
+    expires_at : datetime
+        Expiration timestamp (default 15 minutes).
+    created_at : datetime
+        Row creation timestamp (from TimestampMixin).
+    updated_at : datetime
+        Last update timestamp (from TimestampMixin).
+    """
+
+    __tablename__ = "device_codes"
+
+    device_code: Mapped[str] = mapped_column(
+        String(255),
+        unique=True,
+        nullable=False,
+        index=True,
+    )
+    user_code: Mapped[str] = mapped_column(
+        String(16),
+        unique=True,
+        nullable=False,
+        index=True,
+    )
+    client_id: Mapped[str] = mapped_column(
+        String(255),
+        nullable=False,
+    )
+    scopes: Mapped[str] = mapped_column(
+        Text,
+        default="",
+        nullable=False,
+    )
+    verification_uri: Mapped[str] = mapped_column(
+        String(2048),
+        nullable=False,
+    )
+    verification_uri_complete: Mapped[str | None] = mapped_column(
+        String(2048),
+        nullable=True,
+    )
+    interval: Mapped[int] = mapped_column(
+        Integer,
+        default=5,
+        nullable=False,
+    )
+    status: Mapped[DeviceCodeStatus] = mapped_column(
+        Enum(DeviceCodeStatus, name="device_code_status", native_enum=False),
+        default=DeviceCodeStatus.PENDING,
+        nullable=False,
+    )
+    user_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+    )
+
+    # Relationships
+    user: Mapped[User | None] = relationship()
+
+    def __repr__(self) -> str:
+        return f"<DeviceCode user_code={self.user_code} status={self.status.value}>"

--- a/tests/models/test_device_code.py
+++ b/tests/models/test_device_code.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Unit tests for DeviceCode model."""
+
+from datetime import datetime, timezone
+
+from shomer.models.device_code import DeviceCode, DeviceCodeStatus
+
+
+class TestDeviceCodeModel:
+    """Tests for DeviceCode SQLAlchemy model definition."""
+
+    def test_tablename(self) -> None:
+        assert DeviceCode.__tablename__ == "device_codes"
+
+    def test_required_fields(self) -> None:
+        now = datetime.now(timezone.utc)
+        dc = DeviceCode(
+            device_code="dev-code-123",
+            user_code="ABCD-EFGH",
+            client_id="my-client",
+            scopes="openid profile",
+            verification_uri="https://auth.example.com/device",
+            expires_at=now,
+        )
+        assert dc.device_code == "dev-code-123"
+        assert dc.user_code == "ABCD-EFGH"
+        assert dc.client_id == "my-client"
+        assert dc.scopes == "openid profile"
+        assert dc.verification_uri == "https://auth.example.com/device"
+        assert dc.expires_at == now
+
+    def test_default_status(self) -> None:
+        col = DeviceCode.__table__.c.status
+        assert col.default.arg == DeviceCodeStatus.PENDING
+
+    def test_default_interval(self) -> None:
+        col = DeviceCode.__table__.c.interval
+        assert col.default.arg == 5
+
+    def test_device_code_unique(self) -> None:
+        col = DeviceCode.__table__.c.device_code
+        assert col.unique is True
+
+    def test_user_code_unique(self) -> None:
+        col = DeviceCode.__table__.c.user_code
+        assert col.unique is True
+
+    def test_device_code_indexed(self) -> None:
+        col = DeviceCode.__table__.c.device_code
+        assert col.index is True
+
+    def test_user_code_indexed(self) -> None:
+        col = DeviceCode.__table__.c.user_code
+        assert col.index is True
+
+    def test_user_id_nullable(self) -> None:
+        col = DeviceCode.__table__.c.user_id
+        assert col.nullable is True
+
+    def test_user_id_foreign_key(self) -> None:
+        col = DeviceCode.__table__.c.user_id
+        fk = list(col.foreign_keys)[0]
+        assert fk.column.table.name == "users"
+
+    def test_verification_uri_complete_nullable(self) -> None:
+        col = DeviceCode.__table__.c.verification_uri_complete
+        assert col.nullable is True
+
+    def test_repr(self) -> None:
+        dc = DeviceCode(
+            device_code="x",
+            user_code="ABCD-EFGH",
+            client_id="c",
+            verification_uri="https://x",
+            expires_at=datetime.now(timezone.utc),
+            status=DeviceCodeStatus.PENDING,
+        )
+        r = repr(dc)
+        assert "ABCD-EFGH" in r
+        assert "pending" in r
+
+
+class TestDeviceCodeStatus:
+    """Tests for DeviceCodeStatus enum."""
+
+    def test_pending(self) -> None:
+        assert DeviceCodeStatus.PENDING.value == "pending"
+
+    def test_approved(self) -> None:
+        assert DeviceCodeStatus.APPROVED.value == "approved"
+
+    def test_denied(self) -> None:
+        assert DeviceCodeStatus.DENIED.value == "denied"
+
+    def test_expired(self) -> None:
+        assert DeviceCodeStatus.EXPIRED.value == "expired"
+
+    def test_all_values(self) -> None:
+        values = {s.value for s in DeviceCodeStatus}
+        assert values == {"pending", "approved", "denied", "expired"}


### PR DESCRIPTION
## feat(models): DeviceCode

## Summary

DeviceCode SQLAlchemy model for RFC 8628 device authorization grant with status tracking, human-friendly user codes, and Alembic migration.

## Changes

- [x] DeviceCode model with all RFC 8628 fields
- [x] DeviceCodeStatus enum (pending, approved, denied, expired)
- [x] user_code: String(16), unique, indexed (e.g. ABCD-EFGH)
- [x] device_code: String(255), unique, indexed
- [x] user_id nullable FK → users (SET NULL on delete)
- [x] Default interval=5, default status=pending
- [x] Alembic migration 0013
- [x] Registered in models/__init__.py
- [x] Unit: 16 tests

## Related Issue

Closes #52

## Test Plan

- [x] \`make format\` - code formatted
- [x] \`make lint\` - no linting errors
- [x] \`make typecheck\` - type checks pass
- [x] \`make test\` - 664 passed, 100% coverage
- [x] \`make bdd\` - no new BDD (model only)
- [x] \`make check-license\` - SPDX headers present