### PR TITLE
feat(oauth2): POST /oauth2/device

### DIFF
--- a/features/oauth2_device.feature
+++ b/features/oauth2_device.feature
@@ -1,0 +1,38 @@
+Feature: OAuth2 Device Authorization endpoint
+
+  Scenario: Device auth without client auth returns 401
+    When I send a form POST to "/oauth2/device" with
+      """
+      {"scope": "openid"}
+      """
+    Then the response status code should be 401
+    And the response body should contain "invalid_client"
+
+  Scenario: Device auth with unknown client returns 401
+    When I send a form POST to "/oauth2/device" with
+      """
+      {"scope": "openid", "client_id": "unknown", "client_secret": "wrong"}
+      """
+    Then the response status code should be 401
+
+  Scenario: Device auth with valid client returns device_code and user_code
+    Given a verified user and an OAuth2 client with all grants
+    When I send a form POST to "/oauth2/device" with
+      """
+      {"scope": "openid", "client_id": "bdd-full-client", "client_secret": "bdd-test-secret-value"}
+      """
+    Then the response status code should be 200
+    And the response should have JSON key "device_code"
+    And the response should have JSON key "user_code"
+    And the response should have JSON key "verification_uri"
+    And the response should have JSON key "expires_in"
+    And the response should have JSON key "interval"
+
+  Scenario: Device auth response includes verification_uri_complete
+    Given a verified user and an OAuth2 client with all grants
+    When I send a form POST to "/oauth2/device" with
+      """
+      {"scope": "openid profile", "client_id": "bdd-full-client", "client_secret": "bdd-test-secret-value"}
+      """
+    Then the response status code should be 200
+    And the response should have JSON key "verification_uri_complete"

--- a/src/shomer/routes/oauth2.py
+++ b/src/shomer/routes/oauth2.py
@@ -820,3 +820,79 @@ async def introspect(
     )
 
     return JSONResponse(content=result)
+
+
+@router.post("/device")
+async def device_authorization(
+    request: Request,
+    db: DbSession,
+    scope: str = Form(""),
+    client_id: str = Form(""),
+    client_secret: str = Form(""),
+) -> JSONResponse:
+    """Device Authorization endpoint per RFC 8628 §3.1.
+
+    Initiates a device authorization flow by generating a device_code
+    and user_code for the client to display to the user.
+
+    Parameters
+    ----------
+    request : Request
+        Incoming request (for Authorization header).
+    db : DbSession
+        Database session.
+    scope : str
+        Requested scopes.
+    client_id : str
+        Client identifier.
+    client_secret : str
+        Client secret.
+
+    Returns
+    -------
+    JSONResponse
+        RFC 8628 §3.2 device authorization response.
+    """
+    # Authenticate client
+    client_svc = OAuth2ClientService(db)
+    auth_header = request.headers.get("authorization")
+    try:
+        authenticated_client = await client_svc.authenticate_client(
+            authorization_header=auth_header,
+            body_client_id=client_id or None,
+            body_client_secret=client_secret or None,
+        )
+    except InvalidClientError as exc:
+        return JSONResponse(
+            status_code=401,
+            content={
+                "error": "invalid_client",
+                "error_description": str(exc),
+            },
+            headers={"WWW-Authenticate": "Basic"},
+        )
+
+    from shomer.core.settings import get_settings
+    from shomer.services.device_auth_service import DeviceAuthService
+
+    settings = get_settings()
+    verification_uri = f"{settings.jwt_issuer}/ui/device"
+
+    svc = DeviceAuthService(db)
+    resp = await svc.create_device_code(
+        client_id=authenticated_client.client_id,
+        scopes=scope,
+        verification_uri=verification_uri,
+    )
+
+    return JSONResponse(
+        content={
+            "device_code": resp.device_code,
+            "user_code": resp.user_code,
+            "verification_uri": resp.verification_uri,
+            "verification_uri_complete": resp.verification_uri_complete,
+            "expires_in": resp.expires_in,
+            "interval": resp.interval,
+        },
+        headers={"Cache-Control": "no-store"},
+    )

--- a/tests/routes/test_oauth2_unit.py
+++ b/tests/routes/test_oauth2_unit.py
@@ -590,3 +590,68 @@ class TestIntrospectEndpoint:
                 assert resp.status_code == 401
 
         asyncio.run(_run())
+
+
+class TestDeviceAuthEndpoint:
+    """Unit tests for POST /oauth2/device."""
+
+    def test_device_auth_success(self) -> None:
+        async def _run() -> None:
+            from shomer.routes.oauth2 import device_authorization
+            from shomer.services.device_auth_service import DeviceAuthResponse
+
+            with (
+                patch("shomer.routes.oauth2.OAuth2ClientService") as mock_cls,
+                patch(
+                    "shomer.services.device_auth_service.DeviceAuthService"
+                ) as mock_da_cls,
+            ):
+                mock_client = MagicMock()
+                mock_client.client_id = "tv-app"
+                mock_svc = AsyncMock()
+                mock_svc.authenticate_client.return_value = mock_client
+                mock_cls.return_value = mock_svc
+
+                mock_da = AsyncMock()
+                mock_da.create_device_code.return_value = DeviceAuthResponse(
+                    device_code="dev-123",
+                    user_code="ABCD-EFGH",
+                    verification_uri="https://auth.local/ui/device",
+                    verification_uri_complete="https://auth.local/ui/device?user_code=ABCD-EFGH",
+                )
+                mock_da_cls.return_value = mock_da
+
+                req = MagicMock()
+                req.headers.get.return_value = None
+                db = AsyncMock()
+
+                resp = await device_authorization(req, db, "openid", "tv-app", "secret")
+                assert resp.status_code == 200
+                import json
+
+                body = json.loads(bytes(resp.body))
+                assert body["device_code"] == "dev-123"
+                assert body["user_code"] == "ABCD-EFGH"
+                assert "verification_uri" in body
+                assert "expires_in" in body
+                assert "interval" in body
+
+        asyncio.run(_run())
+
+    def test_device_auth_invalid_client(self) -> None:
+        async def _run() -> None:
+            from shomer.routes.oauth2 import device_authorization
+
+            with patch("shomer.routes.oauth2.OAuth2ClientService") as mock_cls:
+                mock_svc = AsyncMock()
+                mock_svc.authenticate_client.side_effect = InvalidClientError("bad")
+                mock_cls.return_value = mock_svc
+
+                req = MagicMock()
+                req.headers.get.return_value = None
+                db = AsyncMock()
+
+                resp = await device_authorization(req, db, "", "", "")
+                assert resp.status_code == 401
+
+        asyncio.run(_run())


### PR DESCRIPTION
## feat(oauth2): POST /oauth2/device

## Summary

Device Authorization endpoint per RFC 8628 §3.1. Initiates device flow by generating device_code/user_code for client to display to user.

## Changes

- [x] POST /oauth2/device route with client auth
- [x] Scope parameter
- [x] Generate device_code + user_code via DeviceAuthService
- [x] Return RFC 8628 §3.2 response format
- [x] Cache-Control: no-store
- [x] Unit: 2 tests
- [x] BDD: 4 scenarios (401s + 200 happy paths)

## Related Issue

Closes #54

## Test Plan

- [x] \`make format\` - code formatted
- [x] \`make lint\` - no linting errors
- [x] \`make typecheck\` - type checks pass
- [x] \`make test\` - 679 passed, 100% coverage
- [x] \`make bdd\` - device feature: 4/4 passed
- [x] \`make check-license\` - SPDX headers present