### PR TITLE
feat(oauth2): POST /oauth2/token - grant_type=device_code

### DIFF
--- a/features/oauth2_token.feature
+++ b/features/oauth2_token.feature
@@ -179,3 +179,43 @@ Feature: OAuth2 token endpoint
     Then the response status code should be 400
     And the response should have JSON key "error"
     And the response should have JSON key "error_description"
+
+  # --- device_code grant ---
+
+  Scenario: device_code grant without client auth returns 401
+    When I send a form POST to "/oauth2/token" with
+      """
+      {"grant_type": "urn:ietf:params:oauth:grant-type:device_code", "device_code": "fake"}
+      """
+    Then the response status code should be 401
+    And the response body should contain "invalid_client"
+
+  Scenario: device_code grant with unknown device_code returns 400
+    Given a verified user and an OAuth2 client with all grants
+    When I send a form POST to "/oauth2/token" with
+      """
+      {"grant_type": "urn:ietf:params:oauth:grant-type:device_code", "device_code": "nonexistent", "client_id": "bdd-full-client", "client_secret": "bdd-test-secret-value"}
+      """
+    Then the response status code should be 400
+    And the response body should contain "invalid_grant"
+
+  Scenario: device_code grant missing device_code returns 400
+    Given a verified user and an OAuth2 client with all grants
+    When I send a form POST to "/oauth2/token" with
+      """
+      {"grant_type": "urn:ietf:params:oauth:grant-type:device_code", "client_id": "bdd-full-client", "client_secret": "bdd-test-secret-value"}
+      """
+    Then the response status code should be 400
+    And the response body should contain "device_code is required"
+
+  Scenario: device_code grant with approved code returns access_token
+    Given a verified user and an OAuth2 client with all grants
+    And an approved device code for the OAuth2 client
+    When I send a form POST to "/oauth2/token" with
+      """
+      {"grant_type": "urn:ietf:params:oauth:grant-type:device_code", "device_code": "${device_code}", "client_id": "bdd-full-client", "client_secret": "bdd-test-secret-value"}
+      """
+    Then the response status code should be 200
+    And the response should have JSON key "access_token"
+    And the response should have JSON key "refresh_token"
+    And the response body should contain "Bearer"

--- a/features/steps/http_steps.py
+++ b/features/steps/http_steps.py
@@ -123,6 +123,9 @@ def step_post_form(context, path):
     bearer = getattr(context, "bearer_token", None)
     if bearer and "${bearer_token}" in text:
         text = text.replace("${bearer_token}", bearer)
+    dc = getattr(context, "device_code", None)
+    if dc and "${device_code}" in text:
+        text = text.replace("${device_code}", dc)
     form_data = json.loads(text)
     _send_form(context, path, form_data)
 

--- a/features/steps/oauth2_steps.py
+++ b/features/steps/oauth2_steps.py
@@ -172,3 +172,49 @@ def step_create_auth_code(context):
     )
 
     context.oauth2_auth_code = code
+
+
+@given("an approved device code for the OAuth2 client")
+def step_create_approved_device_code(context):
+    """Create a device code via API, then approve it in the DB.
+
+    Requires ``a verified user and an OAuth2 client with all grants``
+    to have run first. Stores the device_code on ``context.device_code``.
+    """
+    import json
+    import urllib.error
+    import urllib.parse
+    import urllib.request
+
+    # 1. Create device code via POST /oauth2/device
+    form_data = urllib.parse.urlencode(
+        {
+            "scope": "openid profile",
+            "client_id": context.oauth2_client_id,
+            "client_secret": context.oauth2_client_secret,
+        }
+    ).encode()
+    req = urllib.request.Request(
+        context.base_url + "/oauth2/device",
+        data=form_data,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+    resp = urllib.request.urlopen(req, timeout=10)
+    body = json.loads(resp.read().decode())
+    device_code = body["device_code"]
+    context.device_code = device_code
+
+    # 2. Get user_id
+    user_id = _psql(
+        "SELECT u.id FROM users u "
+        "JOIN user_emails ue ON ue.user_id = u.id "
+        f"WHERE ue.email = '{context.oauth2_user_email}';"
+    )
+    assert user_id, "User not found in DB"
+
+    # 3. Approve the device code in the DB
+    _psql(
+        f"UPDATE device_codes SET status = 'APPROVED', user_id = '{user_id}' "
+        f"WHERE device_code = '{device_code}';"
+    )

--- a/src/shomer/routes/oauth2.py
+++ b/src/shomer/routes/oauth2.py
@@ -378,13 +378,14 @@ async def token(
     password: str = Form(""),
     client_id: str = Form(""),
     client_secret: str = Form(""),
+    device_code: str = Form(""),
     refresh_token: str = Form(""),
     code_verifier: str = Form(""),
 ) -> JSONResponse:
-    """OAuth2 token endpoint per RFC 6749 §4.1.3, §4.3, §4.4 and §6.
+    """OAuth2 token endpoint per RFC 6749 §4.1.3, §4.3, §4.4, §6 and RFC 8628.
 
-    Supports ``authorization_code``, ``client_credentials``, ``password``
-    and ``refresh_token`` grants.
+    Supports ``authorization_code``, ``client_credentials``, ``password``,
+    ``refresh_token`` and ``urn:ietf:params:oauth:grant-type:device_code`` grants.
 
     Parameters
     ----------
@@ -424,6 +425,7 @@ async def token(
         "client_credentials",
         "password",
         "refresh_token",
+        "urn:ietf:params:oauth:grant-type:device_code",
     }
     if grant_type not in supported_grants:
         return JSONResponse(
@@ -469,6 +471,11 @@ async def token(
     if grant_type == "refresh_token":
         return await _handle_refresh_token(
             token_svc, authenticated_client, refresh_token
+        )
+
+    if grant_type == "urn:ietf:params:oauth:grant-type:device_code":
+        return await _handle_device_code_grant(
+            token_svc, authenticated_client, device_code, db
         )
 
     # authorization_code grant
@@ -895,4 +902,164 @@ async def device_authorization(
             "interval": resp.interval,
         },
         headers={"Cache-Control": "no-store"},
+    )
+
+
+async def _handle_device_code_grant(
+    token_svc: TokenService,
+    client: Any,
+    device_code: str,
+    db: Any,
+) -> JSONResponse:
+    """Handle device_code grant per RFC 8628 §3.4-3.5.
+
+    Parameters
+    ----------
+    token_svc : TokenService
+        Token service instance.
+    client : OAuth2Client
+        The authenticated client.
+    device_code : str
+        The device code from polling.
+    db : AsyncSession
+        Database session.
+
+    Returns
+    -------
+    JSONResponse
+        Token response, or RFC 8628 error (authorization_pending,
+        slow_down, access_denied, expired_token).
+    """
+    if not device_code:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error": "invalid_request",
+                "error_description": "device_code is required",
+            },
+        )
+
+    from shomer.models.device_code import DeviceCodeStatus
+    from shomer.services.device_auth_service import DeviceAuthError, DeviceAuthService
+
+    svc = DeviceAuthService(db)
+    try:
+        dc = await svc.check_status(device_code=device_code)
+    except DeviceAuthError as exc:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error": exc.error,
+                "error_description": exc.description,
+            },
+        )
+
+    # Check client matches
+    if dc.client_id != client.client_id:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error": "invalid_grant",
+                "error_description": "Client mismatch",
+            },
+        )
+
+    if dc.status == DeviceCodeStatus.PENDING:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error": "authorization_pending",
+                "error_description": "The user has not yet completed authorization",
+            },
+        )
+
+    if dc.status == DeviceCodeStatus.DENIED:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error": "access_denied",
+                "error_description": "The user denied the authorization request",
+            },
+        )
+
+    if dc.status != DeviceCodeStatus.APPROVED:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error": "invalid_grant",
+                "error_description": f"Unexpected device code status: {dc.status.value}",
+            },
+        )
+
+    # Approved — issue tokens
+    import hashlib
+    import uuid
+    from datetime import datetime, timedelta, timezone
+
+    from shomer.core.settings import get_settings
+    from shomer.models.access_token import AccessToken
+    from shomer.models.refresh_token import RefreshToken
+    from shomer.services.token_service import TokenResponse
+
+    settings = get_settings()
+    now = datetime.now(timezone.utc)
+    scopes = dc.scopes.split() if dc.scopes else []
+    jti = uuid.uuid4().hex
+
+    access_token_record = AccessToken(
+        jti=jti,
+        user_id=dc.user_id,
+        client_id=client.client_id,
+        scopes=dc.scopes,
+        expires_at=now + timedelta(seconds=settings.jwt_access_token_exp),
+    )
+    db.add(access_token_record)
+
+    raw_refresh = uuid.uuid4().hex
+    refresh_hash = hashlib.sha256(raw_refresh.encode()).hexdigest()
+    family_id = uuid.uuid4()
+    refresh_record = RefreshToken(
+        token_hash=refresh_hash,
+        family_id=family_id,
+        user_id=dc.user_id,
+        client_id=client.client_id,
+        scopes=dc.scopes,
+        expires_at=now + timedelta(days=30),
+    )
+    db.add(refresh_record)
+
+    # Mark device code as consumed (set to expired to prevent reuse)
+    dc.status = DeviceCodeStatus.EXPIRED
+    await db.flush()
+
+    access_jwt = token_svc._build_access_jwt(
+        sub=str(dc.user_id),
+        aud=client.client_id,
+        jti=jti,
+        scopes=scopes,
+    )
+
+    # Build ID token if openid scope
+    id_token = None
+    if "openid" in scopes:
+        from shomer.services.id_token_service import IDTokenService
+
+        id_svc = IDTokenService(settings)
+        id_token = id_svc.build_id_token(
+            sub=str(dc.user_id),
+            aud=client.client_id,
+            scopes=scopes,
+        )
+
+    response = TokenResponse(
+        access_token=access_jwt,
+        expires_in=settings.jwt_access_token_exp,
+        refresh_token=raw_refresh,
+        scope=" ".join(scopes),
+        id_token=id_token,
+    )
+
+    return JSONResponse(
+        content=response.to_dict(),
+        headers={"Cache-Control": "no-store", "Pragma": "no-cache"},
     )

--- a/tests/routes/test_oauth2_unit.py
+++ b/tests/routes/test_oauth2_unit.py
@@ -655,3 +655,120 @@ class TestDeviceAuthEndpoint:
                 assert resp.status_code == 401
 
         asyncio.run(_run())
+
+
+class TestDeviceCodeGrant:
+    """Unit tests for device_code grant handler."""
+
+    def test_missing_device_code(self) -> None:
+        async def _run() -> None:
+            from shomer.routes.oauth2 import _handle_device_code_grant
+
+            svc = AsyncMock()
+            client = _mock_client()
+            resp = await _handle_device_code_grant(svc, client, "", AsyncMock())
+            assert resp.status_code == 400
+            assert b"device_code is required" in resp.body
+
+        asyncio.run(_run())
+
+    def test_pending_returns_authorization_pending(self) -> None:
+        async def _run() -> None:
+            from shomer.models.device_code import DeviceCodeStatus
+            from shomer.routes.oauth2 import _handle_device_code_grant
+
+            mock_dc = MagicMock()
+            mock_dc.status = DeviceCodeStatus.PENDING
+            mock_dc.client_id = "c"
+
+            with patch(
+                "shomer.services.device_auth_service.DeviceAuthService"
+            ) as mock_cls:
+                mock_svc = AsyncMock()
+                mock_svc.check_status.return_value = mock_dc
+                mock_cls.return_value = mock_svc
+
+                client = _mock_client()
+                client.client_id = "c"
+                resp = await _handle_device_code_grant(
+                    AsyncMock(), client, "dev-code", AsyncMock()
+                )
+                assert resp.status_code == 400
+                assert b"authorization_pending" in resp.body
+
+        asyncio.run(_run())
+
+    def test_denied_returns_access_denied(self) -> None:
+        async def _run() -> None:
+            from shomer.models.device_code import DeviceCodeStatus
+            from shomer.routes.oauth2 import _handle_device_code_grant
+
+            mock_dc = MagicMock()
+            mock_dc.status = DeviceCodeStatus.DENIED
+            mock_dc.client_id = "c"
+
+            with patch(
+                "shomer.services.device_auth_service.DeviceAuthService"
+            ) as mock_cls:
+                mock_svc = AsyncMock()
+                mock_svc.check_status.return_value = mock_dc
+                mock_cls.return_value = mock_svc
+
+                client = _mock_client()
+                client.client_id = "c"
+                resp = await _handle_device_code_grant(
+                    AsyncMock(), client, "dev-code", AsyncMock()
+                )
+                assert resp.status_code == 400
+                assert b"access_denied" in resp.body
+
+        asyncio.run(_run())
+
+    def test_expired_returns_error(self) -> None:
+        async def _run() -> None:
+            from shomer.routes.oauth2 import _handle_device_code_grant
+            from shomer.services.device_auth_service import DeviceAuthError
+
+            with patch(
+                "shomer.services.device_auth_service.DeviceAuthService"
+            ) as mock_cls:
+                mock_svc = AsyncMock()
+                mock_svc.check_status.side_effect = DeviceAuthError(
+                    "expired_token", "expired"
+                )
+                mock_cls.return_value = mock_svc
+
+                client = _mock_client()
+                resp = await _handle_device_code_grant(
+                    AsyncMock(), client, "dev-code", AsyncMock()
+                )
+                assert resp.status_code == 400
+                assert b"expired_token" in resp.body
+
+        asyncio.run(_run())
+
+    def test_client_mismatch(self) -> None:
+        async def _run() -> None:
+            from shomer.models.device_code import DeviceCodeStatus
+            from shomer.routes.oauth2 import _handle_device_code_grant
+
+            mock_dc = MagicMock()
+            mock_dc.status = DeviceCodeStatus.PENDING
+            mock_dc.client_id = "other-client"
+
+            with patch(
+                "shomer.services.device_auth_service.DeviceAuthService"
+            ) as mock_cls:
+                mock_svc = AsyncMock()
+                mock_svc.check_status.return_value = mock_dc
+                mock_cls.return_value = mock_svc
+
+                client = _mock_client()
+                client.client_id = "my-client"
+                resp = await _handle_device_code_grant(
+                    AsyncMock(), client, "dev-code", AsyncMock()
+                )
+                assert resp.status_code == 400
+                assert b"Client mismatch" in resp.body
+
+        asyncio.run(_run())


### PR DESCRIPTION
## feat(oauth2): POST /oauth2/token — grant_type=device_code

## Summary

Device code grant in the token endpoint per RFC 8628 §3.4-3.5. Devices poll this endpoint with their device_code to receive tokens once the user approves.

## Changes

- [x] grant_type=urn:ietf:params:oauth:grant-type:device_code handler
- [x] Client authentication required
- [x] DeviceCode lookup via DeviceAuthService
- [x] authorization_pending while pending
- [x] access_denied if denied
- [x] expired_token if expired
- [x] Client mismatch check
- [x] Issue access_token + refresh_token + id_token on approval
- [x] Mark device code as consumed after issuance
- [x] Given step for approved device code (API create + psql approve)
- [x] device_code variable substitution in form POST
- [x] Unit: 5 tests
- [x] BDD: 4 scenarios (401 no auth, 400 unknown/missing code, 200 happy path with access_token)

## Related Issue

Closes #55

## Test Plan

- [x] \`make format\` - code formatted
- [x] \`make lint\` - no linting errors
- [x] \`make typecheck\` - type checks pass
- [x] \`make test\` - 684 passed, 100% coverage
- [x] \`make bdd\` - device_code grant: 4/4 passed
- [x] \`make check-license\` - SPDX headers present