### PR TITLE
feat(oauth2): POST /oauth2/par

### DIFF
--- a/features/oauth2_par.feature
+++ b/features/oauth2_par.feature
@@ -1,0 +1,55 @@
+Feature: OAuth2 Pushed Authorization Request endpoint
+
+  Scenario: PAR without client auth returns 401
+    When I send a form POST to "/oauth2/par" with
+      """
+      {"response_type": "code", "redirect_uri": "https://app.example.com/callback", "scope": "openid", "state": "xyz"}
+      """
+    Then the response status code should be 401
+    And the response body should contain "invalid_client"
+
+  Scenario: PAR with unknown client returns 401
+    When I send a form POST to "/oauth2/par" with
+      """
+      {"response_type": "code", "client_id": "unknown", "client_secret": "wrong", "redirect_uri": "https://app.example.com/callback", "scope": "openid", "state": "xyz"}
+      """
+    Then the response status code should be 401
+    And the response body should contain "invalid_client"
+
+  Scenario: PAR with missing redirect_uri returns 400
+    Given a verified user and an OAuth2 client with all grants
+    When I send a form POST to "/oauth2/par" with
+      """
+      {"response_type": "code", "scope": "openid", "state": "xyz", "client_id": "bdd-full-client", "client_secret": "bdd-test-secret-value"}
+      """
+    Then the response status code should be 400
+    And the response body should contain "invalid_request"
+
+  Scenario: PAR with missing response_type returns 400
+    Given a verified user and an OAuth2 client with all grants
+    When I send a form POST to "/oauth2/par" with
+      """
+      {"redirect_uri": "https://app.example.com/callback", "scope": "openid", "state": "xyz", "client_id": "bdd-full-client", "client_secret": "bdd-test-secret-value"}
+      """
+    Then the response status code should be 400
+    And the response body should contain "invalid_request"
+
+  Scenario: PAR with valid parameters returns 201 with request_uri
+    Given a verified user and an OAuth2 client with all grants
+    When I send a form POST to "/oauth2/par" with
+      """
+      {"response_type": "code", "redirect_uri": "https://app.example.com/callback", "scope": "openid", "state": "abc123", "client_id": "bdd-full-client", "client_secret": "bdd-test-secret-value"}
+      """
+    Then the response status code should be 201
+    And the response should have JSON key "request_uri"
+    And the response should have JSON key "expires_in"
+    And the response body should contain "urn:ietf:params:oauth:request_uri:"
+
+  Scenario: PAR response contains correct expires_in
+    Given a verified user and an OAuth2 client with all grants
+    When I send a form POST to "/oauth2/par" with
+      """
+      {"response_type": "code", "redirect_uri": "https://app.example.com/callback", "scope": "openid profile", "state": "def456", "client_id": "bdd-full-client", "client_secret": "bdd-test-secret-value"}
+      """
+    Then the response status code should be 201
+    And the response body should contain "expires_in"

--- a/src/shomer/routes/oauth2.py
+++ b/src/shomer/routes/oauth2.py
@@ -829,6 +829,108 @@ async def introspect(
     return JSONResponse(content=result)
 
 
+@router.post("/par")
+async def pushed_authorization_request(
+    request: Request,
+    db: DbSession,
+    response_type: str = Form(""),
+    redirect_uri: str = Form(""),
+    scope: str = Form(""),
+    state: str = Form(""),
+    nonce: str = Form(""),
+    code_challenge: str = Form(""),
+    code_challenge_method: str = Form(""),
+    client_id: str = Form(""),
+    client_secret: str = Form(""),
+) -> JSONResponse:
+    """Pushed Authorization Request endpoint per RFC 9126 §2.
+
+    Accepts authorization parameters via authenticated POST, validates
+    them, stores the request, and returns a ``request_uri`` that the
+    client can use at ``/authorize``.
+
+    Parameters
+    ----------
+    request : Request
+        Incoming request (for Authorization header).
+    db : DbSession
+        Database session.
+    response_type : str
+        Requested response type.
+    redirect_uri : str
+        Requested redirect URI.
+    scope : str
+        Requested scopes.
+    state : str
+        CSRF state parameter.
+    nonce : str
+        OIDC nonce.
+    code_challenge : str
+        PKCE code challenge.
+    code_challenge_method : str
+        PKCE challenge method.
+    client_id : str
+        Client identifier.
+    client_secret : str
+        Client secret.
+
+    Returns
+    -------
+    JSONResponse
+        RFC 9126 §2.2 response with ``request_uri`` and ``expires_in``.
+    """
+    # Authenticate client
+    client_svc = OAuth2ClientService(db)
+    auth_header = request.headers.get("authorization")
+    try:
+        authenticated_client = await client_svc.authenticate_client(
+            authorization_header=auth_header,
+            body_client_id=client_id or None,
+            body_client_secret=client_secret or None,
+        )
+    except InvalidClientError as exc:
+        return JSONResponse(
+            status_code=401,
+            content={
+                "error": "invalid_client",
+                "error_description": str(exc),
+            },
+            headers={"WWW-Authenticate": "Basic"},
+        )
+
+    from shomer.services.par_service import PARError, PARService
+
+    svc = PARService(db)
+    try:
+        par_response = await svc.push_authorization_request(
+            client_id=authenticated_client.client_id,
+            redirect_uri=redirect_uri or None,
+            response_type=response_type or None,
+            scope=scope or None,
+            state=state or None,
+            nonce=nonce or None,
+            code_challenge=code_challenge or None,
+            code_challenge_method=code_challenge_method or None,
+        )
+    except PARError as exc:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error": exc.error,
+                "error_description": exc.description,
+            },
+        )
+
+    return JSONResponse(
+        status_code=201,
+        content={
+            "request_uri": par_response.request_uri,
+            "expires_in": par_response.expires_in,
+        },
+        headers={"Cache-Control": "no-store"},
+    )
+
+
 @router.post("/device")
 async def device_authorization(
     request: Request,

--- a/src/shomer/services/par_service.py
+++ b/src/shomer/services/par_service.py
@@ -1,0 +1,163 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Pushed Authorization Request service per RFC 9126."""
+
+from __future__ import annotations
+
+import secrets
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from shomer.models.par_request import PARRequest
+from shomer.services.authorize_service import AuthorizeService
+
+#: Default PAR request lifetime (60 seconds per RFC 9126 §2.2).
+PAR_TTL = timedelta(seconds=60)
+
+
+class PARError(Exception):
+    """Raised when a Pushed Authorization Request fails.
+
+    Attributes
+    ----------
+    error : str
+        OAuth2 error code.
+    description : str
+        Human-readable error description.
+    """
+
+    def __init__(self, error: str, description: str) -> None:
+        self.error = error
+        self.description = description
+        super().__init__(description)
+
+
+@dataclass
+class PARResponse:
+    """Successful PAR response per RFC 9126 §2.2.
+
+    Attributes
+    ----------
+    request_uri : str
+        The ``urn:ietf:params:oauth:request_uri:...`` identifier.
+    expires_in : int
+        Lifetime of the request_uri in seconds.
+    """
+
+    request_uri: str
+    expires_in: int
+
+
+class PARService:
+    """Handle Pushed Authorization Requests per RFC 9126.
+
+    Validates authorization parameters (same rules as ``/authorize``),
+    stores them in the database, and returns a ``request_uri`` the client
+    can use at the authorization endpoint.
+
+    Attributes
+    ----------
+    session : AsyncSession
+        Database session.
+    authorize_service : AuthorizeService
+        Service for parameter validation.
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+        self.authorize_service = AuthorizeService(session)
+
+    async def push_authorization_request(
+        self,
+        *,
+        client_id: str,
+        redirect_uri: str | None = None,
+        response_type: str | None = None,
+        scope: str | None = None,
+        state: str | None = None,
+        nonce: str | None = None,
+        code_challenge: str | None = None,
+        code_challenge_method: str | None = None,
+    ) -> PARResponse:
+        """Validate and store a pushed authorization request.
+
+        Parameters
+        ----------
+        client_id : str
+            The authenticated client identifier.
+        redirect_uri : str or None
+            Requested redirect URI.
+        response_type : str or None
+            Requested response type.
+        scope : str or None
+            Requested scopes.
+        state : str or None
+            CSRF state parameter.
+        nonce : str or None
+            OIDC nonce.
+        code_challenge : str or None
+            PKCE code challenge.
+        code_challenge_method : str or None
+            PKCE challenge method.
+
+        Returns
+        -------
+        PARResponse
+            The request_uri and expiration.
+
+        Raises
+        ------
+        PARError
+            If parameter validation fails.
+        """
+        from shomer.services.authorize_service import AuthorizeError
+
+        try:
+            await self.authorize_service.validate_request(
+                client_id=client_id,
+                redirect_uri=redirect_uri,
+                response_type=response_type,
+                scope=scope,
+                state=state,
+                nonce=nonce,
+                code_challenge=code_challenge,
+                code_challenge_method=code_challenge_method,
+            )
+        except AuthorizeError as exc:
+            raise PARError(exc.error, exc.description) from exc
+
+        # Generate request_uri per RFC 9126 §2.2
+        token = secrets.token_urlsafe(32)
+        request_uri = f"urn:ietf:params:oauth:request_uri:{token}"
+
+        now = datetime.now(timezone.utc)
+        expires_at = now + PAR_TTL
+
+        # Store all parameters as JSON
+        parameters: dict[str, str | None] = {
+            "client_id": client_id,
+            "redirect_uri": redirect_uri,
+            "response_type": response_type,
+            "scope": scope,
+            "state": state,
+            "nonce": nonce,
+            "code_challenge": code_challenge,
+            "code_challenge_method": code_challenge_method,
+        }
+
+        par_request = PARRequest(
+            request_uri=request_uri,
+            client_id=client_id,
+            parameters=parameters,
+            expires_at=expires_at,
+        )
+        self.session.add(par_request)
+        await self.session.flush()
+
+        return PARResponse(
+            request_uri=request_uri,
+            expires_in=int(PAR_TTL.total_seconds()),
+        )

--- a/tests/routes/test_oauth2_unit.py
+++ b/tests/routes/test_oauth2_unit.py
@@ -772,3 +772,184 @@ class TestDeviceCodeGrant:
                 assert b"Client mismatch" in resp.body
 
         asyncio.run(_run())
+
+
+class TestPAREndpoint:
+    """Unit tests for POST /oauth2/par."""
+
+    def test_par_success(self) -> None:
+        """Valid PAR request returns 201 with request_uri and expires_in."""
+
+        async def _run() -> None:
+            from shomer.routes.oauth2 import pushed_authorization_request
+            from shomer.services.par_service import PARResponse
+
+            with (
+                patch("shomer.routes.oauth2.OAuth2ClientService") as mock_cls,
+                patch("shomer.services.par_service.PARService") as mock_par_cls,
+            ):
+                mock_client = MagicMock()
+                mock_client.client_id = "test-client"
+                mock_svc = AsyncMock()
+                mock_svc.authenticate_client.return_value = mock_client
+                mock_cls.return_value = mock_svc
+
+                mock_par = AsyncMock()
+                mock_par.push_authorization_request.return_value = PARResponse(
+                    request_uri="urn:ietf:params:oauth:request_uri:abc123",
+                    expires_in=60,
+                )
+                mock_par_cls.return_value = mock_par
+
+                req = MagicMock()
+                req.headers.get.return_value = None
+                db = AsyncMock()
+
+                resp = await pushed_authorization_request(
+                    req,
+                    db,
+                    "code",
+                    "https://app.example.com/cb",
+                    "openid",
+                    "xyz",
+                    "",
+                    "",
+                    "",
+                    "test-client",
+                    "secret",
+                )
+                assert resp.status_code == 201
+                import json
+
+                body = json.loads(bytes(resp.body))
+                assert body["request_uri"] == "urn:ietf:params:oauth:request_uri:abc123"
+                assert body["expires_in"] == 60
+
+        asyncio.run(_run())
+
+    def test_par_invalid_client(self) -> None:
+        """Invalid client returns 401."""
+
+        async def _run() -> None:
+            from shomer.routes.oauth2 import pushed_authorization_request
+
+            with patch("shomer.routes.oauth2.OAuth2ClientService") as mock_cls:
+                mock_svc = AsyncMock()
+                mock_svc.authenticate_client.side_effect = InvalidClientError("bad")
+                mock_cls.return_value = mock_svc
+
+                req = MagicMock()
+                req.headers.get.return_value = None
+                db = AsyncMock()
+
+                resp = await pushed_authorization_request(
+                    req,
+                    db,
+                    "code",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                )
+                assert resp.status_code == 401
+                assert b"invalid_client" in resp.body
+
+        asyncio.run(_run())
+
+    def test_par_validation_error(self) -> None:
+        """Invalid parameters return 400 with error details."""
+
+        async def _run() -> None:
+            from shomer.routes.oauth2 import pushed_authorization_request
+            from shomer.services.par_service import PARError
+
+            with (
+                patch("shomer.routes.oauth2.OAuth2ClientService") as mock_cls,
+                patch("shomer.services.par_service.PARService") as mock_par_cls,
+            ):
+                mock_client = MagicMock()
+                mock_client.client_id = "c"
+                mock_svc = AsyncMock()
+                mock_svc.authenticate_client.return_value = mock_client
+                mock_cls.return_value = mock_svc
+
+                mock_par = AsyncMock()
+                mock_par.push_authorization_request.side_effect = PARError(
+                    "invalid_request", "redirect_uri is required"
+                )
+                mock_par_cls.return_value = mock_par
+
+                req = MagicMock()
+                req.headers.get.return_value = None
+                db = AsyncMock()
+
+                resp = await pushed_authorization_request(
+                    req,
+                    db,
+                    "code",
+                    "",
+                    "openid",
+                    "xyz",
+                    "",
+                    "",
+                    "",
+                    "c",
+                    "s",
+                )
+                assert resp.status_code == 400
+                import json
+
+                body = json.loads(bytes(resp.body))
+                assert body["error"] == "invalid_request"
+                assert "redirect_uri" in body["error_description"]
+
+        asyncio.run(_run())
+
+    def test_par_response_has_cache_control(self) -> None:
+        """PAR response has Cache-Control: no-store header."""
+
+        async def _run() -> None:
+            from shomer.routes.oauth2 import pushed_authorization_request
+            from shomer.services.par_service import PARResponse
+
+            with (
+                patch("shomer.routes.oauth2.OAuth2ClientService") as mock_cls,
+                patch("shomer.services.par_service.PARService") as mock_par_cls,
+            ):
+                mock_client = MagicMock()
+                mock_client.client_id = "c"
+                mock_svc = AsyncMock()
+                mock_svc.authenticate_client.return_value = mock_client
+                mock_cls.return_value = mock_svc
+
+                mock_par = AsyncMock()
+                mock_par.push_authorization_request.return_value = PARResponse(
+                    request_uri="urn:ietf:params:oauth:request_uri:x",
+                    expires_in=60,
+                )
+                mock_par_cls.return_value = mock_par
+
+                req = MagicMock()
+                req.headers.get.return_value = None
+                db = AsyncMock()
+
+                resp = await pushed_authorization_request(
+                    req,
+                    db,
+                    "code",
+                    "https://a.com/cb",
+                    "openid",
+                    "xyz",
+                    "",
+                    "",
+                    "",
+                    "c",
+                    "s",
+                )
+                assert resp.headers.get("cache-control") == "no-store"
+
+        asyncio.run(_run())

--- a/tests/services/test_par_service.py
+++ b/tests/services/test_par_service.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Unit tests for PARService."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from shomer.services.authorize_service import AuthorizeError
+from shomer.services.par_service import PARError, PARResponse, PARService
+
+
+class TestPARService:
+    """Tests for PARService.push_authorization_request."""
+
+    def test_success_returns_request_uri(self) -> None:
+        """Valid parameters produce a request_uri starting with the URN prefix."""
+
+        async def _run() -> None:
+            db = AsyncMock()
+            svc = PARService(db)
+            with patch.object(
+                svc.authorize_service, "validate_request", new_callable=AsyncMock
+            ) as mock_validate:
+                mock_validate.return_value = None
+                resp = await svc.push_authorization_request(
+                    client_id="c",
+                    redirect_uri="https://app.example.com/cb",
+                    response_type="code",
+                    scope="openid",
+                    state="xyz",
+                )
+            assert isinstance(resp, PARResponse)
+            assert resp.request_uri.startswith("urn:ietf:params:oauth:request_uri:")
+            assert resp.expires_in == 60
+            db.add.assert_called_once()
+            db.flush.assert_awaited_once()
+
+        asyncio.run(_run())
+
+    def test_stores_parameters_as_json(self) -> None:
+        """All authorization parameters are stored in the PARRequest."""
+
+        async def _run() -> None:
+            db = AsyncMock()
+            svc = PARService(db)
+            with patch.object(
+                svc.authorize_service, "validate_request", new_callable=AsyncMock
+            ):
+                await svc.push_authorization_request(
+                    client_id="c",
+                    redirect_uri="https://app.example.com/cb",
+                    response_type="code",
+                    scope="openid profile",
+                    state="xyz",
+                    nonce="n1",
+                    code_challenge="cc",
+                    code_challenge_method="S256",
+                )
+            par_obj = db.add.call_args[0][0]
+            assert par_obj.parameters["client_id"] == "c"
+            assert par_obj.parameters["scope"] == "openid profile"
+            assert par_obj.parameters["nonce"] == "n1"
+            assert par_obj.parameters["code_challenge"] == "cc"
+            assert par_obj.parameters["code_challenge_method"] == "S256"
+
+        asyncio.run(_run())
+
+    def test_request_uri_is_unique_per_call(self) -> None:
+        """Each call generates a unique request_uri."""
+
+        async def _run() -> None:
+            db = AsyncMock()
+            svc = PARService(db)
+            with patch.object(
+                svc.authorize_service, "validate_request", new_callable=AsyncMock
+            ):
+                r1 = await svc.push_authorization_request(
+                    client_id="c",
+                    redirect_uri="https://app.example.com/cb",
+                    response_type="code",
+                    state="a",
+                )
+                r2 = await svc.push_authorization_request(
+                    client_id="c",
+                    redirect_uri="https://app.example.com/cb",
+                    response_type="code",
+                    state="b",
+                )
+            assert r1.request_uri != r2.request_uri
+
+        asyncio.run(_run())
+
+    def test_validation_error_raises_par_error(self) -> None:
+        """AuthorizeError from validation is wrapped in PARError."""
+
+        async def _run() -> None:
+            db = AsyncMock()
+            svc = PARService(db)
+            with patch.object(
+                svc.authorize_service,
+                "validate_request",
+                new_callable=AsyncMock,
+                side_effect=AuthorizeError("invalid_request", "client_id is required"),
+            ):
+                with pytest.raises(PARError) as exc_info:
+                    await svc.push_authorization_request(
+                        client_id="",
+                        response_type="code",
+                    )
+                assert exc_info.value.error == "invalid_request"
+                assert "client_id" in exc_info.value.description
+
+        asyncio.run(_run())
+
+    def test_unsupported_response_type_raises_par_error(self) -> None:
+        """Unsupported response_type from validation becomes PARError."""
+
+        async def _run() -> None:
+            db = AsyncMock()
+            svc = PARService(db)
+            with patch.object(
+                svc.authorize_service,
+                "validate_request",
+                new_callable=AsyncMock,
+                side_effect=AuthorizeError(
+                    "unsupported_response_type", "bad response_type"
+                ),
+            ):
+                with pytest.raises(PARError) as exc_info:
+                    await svc.push_authorization_request(
+                        client_id="c",
+                        response_type="token",
+                    )
+                assert exc_info.value.error == "unsupported_response_type"
+
+        asyncio.run(_run())
+
+    def test_client_id_stored_on_par_request(self) -> None:
+        """The client_id is stored on the PARRequest model."""
+
+        async def _run() -> None:
+            db = AsyncMock()
+            svc = PARService(db)
+            with patch.object(
+                svc.authorize_service, "validate_request", new_callable=AsyncMock
+            ):
+                await svc.push_authorization_request(
+                    client_id="my-client",
+                    redirect_uri="https://app.example.com/cb",
+                    response_type="code",
+                    state="xyz",
+                )
+            par_obj = db.add.call_args[0][0]
+            assert par_obj.client_id == "my-client"
+
+        asyncio.run(_run())
+
+    def test_expires_at_set(self) -> None:
+        """The PARRequest has an expires_at in the future."""
+
+        async def _run() -> None:
+            from datetime import datetime, timezone
+
+            db = AsyncMock()
+            svc = PARService(db)
+            with patch.object(
+                svc.authorize_service, "validate_request", new_callable=AsyncMock
+            ):
+                await svc.push_authorization_request(
+                    client_id="c",
+                    redirect_uri="https://app.example.com/cb",
+                    response_type="code",
+                    state="xyz",
+                )
+            par_obj = db.add.call_args[0][0]
+            assert par_obj.expires_at > datetime.now(timezone.utc)
+
+        asyncio.run(_run())


### PR DESCRIPTION
## feat(oauth2): POST /oauth2/par

## Summary

PAR endpoint per RFC 9126. Receives authorization parameters via POST, authenticates the client, validates parameters, stores the request, and returns request_uri + expires_in.

## Changes

- [x] POST `/oauth2/par` route
- [x] Client authentication
- [x] Parameter validation (same rules as /authorize)
- [x] Store PARRequest with generated request_uri
- [x] Return request_uri + expires_in
- [x] Integration test

## Dependencies

- #28 - client service
- #57 - PARRequest model

## Related Issue

Closes #58

## Test Plan

- [x] `make format` - code formatted
- [x] `make lint` - no linting errors
- [x] `make typecheck` - type checks pass
- [x] `make test` - all unit tests pass
- [x] `make bdd` - all BDD tests pass
- [x] `make check-license` - SPDX headers present
