### PR TITLE
feat(oauth2): request_uri support in GET /oauth2/authorize

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -24,6 +24,7 @@ def before_scenario(context, scenario):
     # Clear auth state from previous scenarios
     context.bearer_token = None
     context.session_cookie = None
+    context.par_request_uri = None
 
 
 def before_all(context):

--- a/features/oauth2_par_authorize.feature
+++ b/features/oauth2_par_authorize.feature
@@ -1,0 +1,28 @@
+Feature: OAuth2 authorize with request_uri (RFC 9126)
+
+  Scenario: Authorize with unknown request_uri renders error
+    When I send a GET request to "/oauth2/authorize?client_id=bdd-full-client&request_uri=urn:ietf:params:oauth:request_uri:nonexistent"
+    Then the response status code should be 400
+    And the response body should contain "Unknown"
+
+  Scenario: Authorize with request_uri but no client_id renders error
+    When I send a GET request to "/oauth2/authorize?request_uri=urn:ietf:params:oauth:request_uri:abc"
+    Then the response status code should be 400
+    And the response body should contain "client_id is required"
+
+  Scenario: Authorize with valid request_uri redirects to login
+    Given a verified user and an OAuth2 client with all grants
+    And a pushed authorization request for the OAuth2 client
+    When I send a GET request to "/oauth2/authorize?client_id=bdd-full-client&request_uri=${request_uri}"
+    Then the response status code should be 200
+    And the response body should contain "Login"
+
+  Scenario: Authorize with used request_uri renders error (single-use)
+    Given a verified user and an OAuth2 client with all grants
+    And a pushed authorization request for the OAuth2 client
+    When I send a GET request to "/oauth2/authorize?client_id=bdd-full-client&request_uri=${request_uri}"
+    Then the response status code should be 200
+    And the response body should contain "Login"
+    When I send a GET request to "/oauth2/authorize?client_id=bdd-full-client&request_uri=${request_uri}"
+    Then the response status code should be 400
+    And the response body should contain "Unknown"

--- a/features/steps/http_steps.py
+++ b/features/steps/http_steps.py
@@ -57,8 +57,26 @@ def step_set_json_payload(context):
     context.json_payload = json.loads(context.text)
 
 
+def _substitute_vars(context, text):
+    """Replace ${variable} placeholders with context values."""
+    auth_code = getattr(context, "oauth2_auth_code", None)
+    if auth_code and "${auth_code}" in text:
+        text = text.replace("${auth_code}", auth_code)
+    bearer = getattr(context, "bearer_token", None)
+    if bearer and "${bearer_token}" in text:
+        text = text.replace("${bearer_token}", bearer)
+    dc = getattr(context, "device_code", None)
+    if dc and "${device_code}" in text:
+        text = text.replace("${device_code}", dc)
+    par_uri = getattr(context, "par_request_uri", None)
+    if par_uri and "${request_uri}" in text:
+        text = text.replace("${request_uri}", urllib.parse.quote(par_uri, safe=""))
+    return text
+
+
 @when('I send a GET request to "{path}"')
 def step_get_request(context, path):
+    path = _substitute_vars(context, path)
     _send(context, "GET", path)
 
 
@@ -115,17 +133,7 @@ def _send_form(context, path, form_data):
 
 @when('I send a form POST to "{path}" with')
 def step_post_form(context, path):
-    text = context.text
-    # Substitute context variables
-    auth_code = getattr(context, "oauth2_auth_code", None)
-    if auth_code and "${auth_code}" in text:
-        text = text.replace("${auth_code}", auth_code)
-    bearer = getattr(context, "bearer_token", None)
-    if bearer and "${bearer_token}" in text:
-        text = text.replace("${bearer_token}", bearer)
-    dc = getattr(context, "device_code", None)
-    if dc and "${device_code}" in text:
-        text = text.replace("${device_code}", dc)
+    text = _substitute_vars(context, context.text)
     form_data = json.loads(text)
     _send_form(context, path, form_data)
 

--- a/features/steps/oauth2_steps.py
+++ b/features/steps/oauth2_steps.py
@@ -218,3 +218,36 @@ def step_create_approved_device_code(context):
         f"UPDATE device_codes SET status = 'APPROVED', user_id = '{user_id}' "
         f"WHERE device_code = '{device_code}';"
     )
+
+
+@given("a pushed authorization request for the OAuth2 client")
+def step_create_par_request(context):
+    """Create a PAR request via POST /oauth2/par.
+
+    Requires ``a verified user and an OAuth2 client with all grants``
+    to have run first. Stores the request_uri on ``context.par_request_uri``.
+    """
+    import json
+    import urllib.parse
+    import urllib.request
+
+    form_data = urllib.parse.urlencode(
+        {
+            "response_type": "code",
+            "redirect_uri": "https://app.example.com/callback",
+            "scope": "openid profile",
+            "state": "par-bdd-state",
+            "client_id": context.oauth2_client_id,
+            "client_secret": context.oauth2_client_secret,
+        }
+    ).encode()
+    req = urllib.request.Request(
+        context.base_url + "/oauth2/par",
+        data=form_data,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+    resp = urllib.request.urlopen(req, timeout=10)
+    assert resp.status == 201, f"PAR request failed: {resp.status}"
+    body = json.loads(resp.read().decode())
+    context.par_request_uri = body["request_uri"]

--- a/src/shomer/routes/oauth2.py
+++ b/src/shomer/routes/oauth2.py
@@ -37,11 +37,15 @@ async def authorize(
     login_hint: str | None = None,
     code_challenge: str | None = None,
     code_challenge_method: str | None = None,
+    request_uri: str | None = None,
 ) -> Any:
-    """OAuth2 authorization endpoint per RFC 6749 §4.1.1.
+    """OAuth2 authorization endpoint per RFC 6749 §4.1.1 and RFC 9126.
 
     Validates the request, checks authentication, and either redirects
     to login, shows consent, or issues an authorization code.
+
+    When ``request_uri`` is provided, the stored PAR parameters are
+    resolved and used instead of the query parameters (RFC 9126 §4).
 
     Parameters
     ----------
@@ -69,12 +73,43 @@ async def authorize(
         PKCE code challenge.
     code_challenge_method : str or None
         PKCE challenge method.
+    request_uri : str or None
+        PAR request_uri (RFC 9126). Overrides query parameters.
 
     Returns
     -------
     RedirectResponse
         Redirect to login, consent, or callback with code.
     """
+    # RFC 9126 §4: resolve request_uri to stored parameters
+    if request_uri:
+        if not client_id:
+            return _render_oauth2_error(
+                request, "invalid_request", "client_id is required with request_uri"
+            )
+        from shomer.services.par_service import PARError, PARService
+
+        par_svc = PARService(db)
+        try:
+            params = await par_svc.resolve_request_uri(
+                request_uri=request_uri,
+                client_id=client_id,
+            )
+        except PARError as exc:
+            return _render_oauth2_error(request, exc.error, exc.description)
+
+        # Override query params with stored PAR parameters
+        client_id = params.get("client_id") or client_id
+        redirect_uri = params.get("redirect_uri") or redirect_uri
+        response_type = params.get("response_type") or response_type
+        scope = params.get("scope") or scope
+        state = params.get("state") or state
+        nonce = params.get("nonce") or nonce
+        code_challenge = params.get("code_challenge") or code_challenge
+        code_challenge_method = (
+            params.get("code_challenge_method") or code_challenge_method
+        )
+
     svc = AuthorizeService(db)
 
     # Validate request parameters

--- a/src/shomer/services/par_service.py
+++ b/src/shomer/services/par_service.py
@@ -9,6 +9,7 @@ import secrets
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from shomer.models.par_request import PARRequest
@@ -161,3 +162,58 @@ class PARService:
             request_uri=request_uri,
             expires_in=int(PAR_TTL.total_seconds()),
         )
+
+    async def resolve_request_uri(
+        self,
+        *,
+        request_uri: str,
+        client_id: str,
+    ) -> dict[str, str | None]:
+        """Resolve a request_uri to stored authorization parameters.
+
+        Looks up the PARRequest, verifies the client_id matches,
+        checks expiration, and marks the request as used (single-use)
+        by deleting it.
+
+        Parameters
+        ----------
+        request_uri : str
+            The ``urn:ietf:params:oauth:request_uri:...`` to resolve.
+        client_id : str
+            The client_id from the authorize request (must match).
+
+        Returns
+        -------
+        dict[str, str | None]
+            The stored authorization parameters.
+
+        Raises
+        ------
+        PARError
+            If the request_uri is unknown, expired, or client mismatch.
+        """
+        stmt = select(PARRequest).where(PARRequest.request_uri == request_uri)
+        result = await self.session.execute(stmt)
+        par = result.scalar_one_or_none()
+
+        if par is None:
+            raise PARError("invalid_request", "Unknown or already used request_uri")
+
+        # Verify client_id matches
+        if par.client_id != client_id:
+            raise PARError("invalid_request", "client_id mismatch with request_uri")
+
+        # Check expiration
+        now = datetime.now(timezone.utc)
+        if par.expires_at < now:
+            # Clean up expired request
+            await self.session.delete(par)
+            await self.session.flush()
+            raise PARError("invalid_request", "request_uri has expired")
+
+        # Single-use: delete after retrieval
+        parameters: dict[str, str | None] = par.parameters
+        await self.session.delete(par)
+        await self.session.flush()
+
+        return parameters

--- a/tests/routes/test_oauth2_unit.py
+++ b/tests/routes/test_oauth2_unit.py
@@ -318,6 +318,117 @@ class TestAuthorizeRoute:
         asyncio.run(_run())
 
 
+class TestAuthorizeWithRequestUri:
+    """Unit tests for GET /oauth2/authorize with request_uri (RFC 9126)."""
+
+    @patch("shomer.routes.oauth2._render_oauth2_error")
+    def test_request_uri_without_client_id_returns_error(
+        self, mock_render: MagicMock
+    ) -> None:
+        """request_uri without client_id renders error page."""
+
+        async def _run() -> None:
+            mock_render.return_value = MagicMock(status_code=400)
+            req = MagicMock()
+            db = AsyncMock()
+            resp = await authorize(
+                req,
+                db,
+                request_uri="urn:ietf:params:oauth:request_uri:abc",
+            )
+            mock_render.assert_called_once()
+            assert resp.status_code == 400
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.oauth2._render_oauth2_error")
+    @patch("shomer.services.par_service.PARService")
+    def test_request_uri_unknown_renders_error(
+        self, mock_par_cls: MagicMock, mock_render: MagicMock
+    ) -> None:
+        """Unknown request_uri renders error page."""
+
+        async def _run() -> None:
+            from shomer.services.par_service import PARError
+
+            mock_par = AsyncMock()
+            mock_par.resolve_request_uri.side_effect = PARError(
+                "invalid_request", "Unknown or already used request_uri"
+            )
+            mock_par_cls.return_value = mock_par
+            mock_render.return_value = MagicMock(status_code=400)
+            req = MagicMock()
+            db = AsyncMock()
+            resp = await authorize(
+                req,
+                db,
+                client_id="c",
+                request_uri="urn:ietf:params:oauth:request_uri:bad",
+            )
+            mock_render.assert_called_once()
+            assert resp.status_code == 400
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.oauth2.SessionService")
+    @patch("shomer.routes.oauth2.AuthorizeService")
+    @patch("shomer.services.par_service.PARService")
+    def test_request_uri_resolves_to_stored_params(
+        self,
+        mock_par_cls: MagicMock,
+        mock_auth_cls: MagicMock,
+        mock_sess_cls: MagicMock,
+    ) -> None:
+        """Valid request_uri resolves parameters and passes to validate_request."""
+
+        async def _run() -> None:
+            # PAR resolves to stored params
+            mock_par = AsyncMock()
+            mock_par.resolve_request_uri.return_value = {
+                "client_id": "c",
+                "redirect_uri": "https://app.example.com/cb",
+                "response_type": "code",
+                "scope": "openid",
+                "state": "xyz",
+                "nonce": None,
+                "code_challenge": None,
+                "code_challenge_method": None,
+            }
+            mock_par_cls.return_value = mock_par
+
+            # AuthorizeService validates
+            mock_auth_svc = AsyncMock()
+            mock_auth_svc.validate_request.return_value = MagicMock()
+            mock_auth_cls.return_value = mock_auth_svc
+
+            # No session → redirect to login
+            mock_sess = AsyncMock()
+            mock_sess.validate.return_value = None
+            mock_sess_cls.return_value = mock_sess
+
+            req = MagicMock()
+            req.cookies.get.return_value = None
+            req.url = "http://test/oauth2/authorize?client_id=c&request_uri=urn:x"
+            db = AsyncMock()
+
+            resp = await authorize(
+                req,
+                db,
+                client_id="c",
+                request_uri="urn:ietf:params:oauth:request_uri:abc",
+            )
+            # Should redirect to login (params resolved, but no session)
+            assert resp.status_code == 302
+            assert "/ui/login" in resp.headers["location"]
+            # Validate was called with resolved params
+            mock_auth_svc.validate_request.assert_awaited_once()
+            call_kwargs = mock_auth_svc.validate_request.call_args[1]
+            assert call_kwargs["redirect_uri"] == "https://app.example.com/cb"
+            assert call_kwargs["response_type"] == "code"
+
+        asyncio.run(_run())
+
+
 class TestAuthorizeConsent:
     """Unit tests for POST /oauth2/authorize (consent)."""
 

--- a/tests/services/test_par_service.py
+++ b/tests/services/test_par_service.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -179,5 +179,145 @@ class TestPARService:
                 )
             par_obj = db.add.call_args[0][0]
             assert par_obj.expires_at > datetime.now(timezone.utc)
+
+        asyncio.run(_run())
+
+
+class TestResolveRequestUri:
+    """Tests for PARService.resolve_request_uri."""
+
+    def _make_par(
+        self,
+        *,
+        client_id: str = "c",
+        expired: bool = False,
+    ) -> MagicMock:
+        """Create a mock PARRequest."""
+        from datetime import datetime, timedelta, timezone
+
+        par = MagicMock()
+        par.client_id = client_id
+        par.parameters = {
+            "client_id": client_id,
+            "redirect_uri": "https://app.example.com/cb",
+            "response_type": "code",
+            "scope": "openid",
+            "state": "xyz",
+            "nonce": None,
+            "code_challenge": None,
+            "code_challenge_method": None,
+        }
+        if expired:
+            par.expires_at = datetime.now(timezone.utc) - timedelta(seconds=10)
+        else:
+            par.expires_at = datetime.now(timezone.utc) + timedelta(seconds=50)
+        return par
+
+    def test_resolve_success(self) -> None:
+        """Valid request_uri returns stored parameters and deletes the record."""
+
+        async def _run() -> None:
+            mock_par = self._make_par()
+            mock_result = MagicMock()
+            mock_result.scalar_one_or_none.return_value = mock_par
+
+            db = AsyncMock()
+            db.execute.return_value = mock_result
+            svc = PARService(db)
+
+            params = await svc.resolve_request_uri(
+                request_uri="urn:ietf:params:oauth:request_uri:abc",
+                client_id="c",
+            )
+            assert params["response_type"] == "code"
+            assert params["scope"] == "openid"
+            db.delete.assert_awaited_once_with(mock_par)
+
+        asyncio.run(_run())
+
+    def test_unknown_request_uri_raises(self) -> None:
+        """Unknown request_uri raises PARError."""
+
+        async def _run() -> None:
+            mock_result = MagicMock()
+            mock_result.scalar_one_or_none.return_value = None
+
+            db = AsyncMock()
+            db.execute.return_value = mock_result
+            svc = PARService(db)
+
+            with pytest.raises(PARError) as exc_info:
+                await svc.resolve_request_uri(
+                    request_uri="urn:ietf:params:oauth:request_uri:unknown",
+                    client_id="c",
+                )
+            assert exc_info.value.error == "invalid_request"
+            assert "Unknown" in exc_info.value.description
+
+        asyncio.run(_run())
+
+    def test_client_mismatch_raises(self) -> None:
+        """Mismatched client_id raises PARError."""
+
+        async def _run() -> None:
+            mock_par = self._make_par(client_id="other-client")
+            mock_result = MagicMock()
+            mock_result.scalar_one_or_none.return_value = mock_par
+
+            db = AsyncMock()
+            db.execute.return_value = mock_result
+            svc = PARService(db)
+
+            with pytest.raises(PARError) as exc_info:
+                await svc.resolve_request_uri(
+                    request_uri="urn:ietf:params:oauth:request_uri:abc",
+                    client_id="c",
+                )
+            assert exc_info.value.error == "invalid_request"
+            assert "mismatch" in exc_info.value.description
+
+        asyncio.run(_run())
+
+    def test_expired_request_uri_raises(self) -> None:
+        """Expired request_uri raises PARError and deletes the record."""
+
+        async def _run() -> None:
+            mock_par = self._make_par(expired=True)
+            mock_result = MagicMock()
+            mock_result.scalar_one_or_none.return_value = mock_par
+
+            db = AsyncMock()
+            db.execute.return_value = mock_result
+            svc = PARService(db)
+
+            with pytest.raises(PARError) as exc_info:
+                await svc.resolve_request_uri(
+                    request_uri="urn:ietf:params:oauth:request_uri:abc",
+                    client_id="c",
+                )
+            assert exc_info.value.error == "invalid_request"
+            assert "expired" in exc_info.value.description
+            db.delete.assert_awaited_once_with(mock_par)
+
+        asyncio.run(_run())
+
+    def test_single_use_deletes_record(self) -> None:
+        """After resolve, the PARRequest is deleted (single-use)."""
+
+        async def _run() -> None:
+            mock_par = self._make_par()
+            mock_result = MagicMock()
+            mock_result.scalar_one_or_none.return_value = mock_par
+
+            db = AsyncMock()
+            db.execute.return_value = mock_result
+            svc = PARService(db)
+
+            await svc.resolve_request_uri(
+                request_uri="urn:ietf:params:oauth:request_uri:abc",
+                client_id="c",
+            )
+            db.delete.assert_awaited_once_with(mock_par)
+            assert db.flush.await_count >= 1
 
         asyncio.run(_run())


### PR DESCRIPTION
## feat(oauth2): request_uri support in GET /oauth2/authorize

## Summary

Modify /authorize to support the request_uri parameter. Resolves the PARRequest, verifies client_id consistency, uses stored parameters. The request_uri is single-use.

## Changes

- [x] Detect request_uri parameter in /authorize
- [x] Lookup PARRequest by request_uri
- [x] Verify client_id matches
- [x] Check expiration
- [x] Use stored parameters (override any query params)
- [x] Mark request_uri as used (single-use)
- [x] Integration test

## Dependencies

- #31 - /authorize endpoint
- #58 - PAR endpoint

## Related Issue

Closes #59

## Test Plan

- [x] `make format` - code formatted
- [x] `make lint` - no linting errors
- [x] `make typecheck` - type checks pass
- [x] `make test` - all unit tests pass
- [x] `make bdd` - all BDD tests pass
- [x] `make check-license` - SPDX headers present
