### PR TITLE
feat(oauth2): token exchange validation and scope escalation service

### DIFF
--- a/src/shomer/services/token_exchange_service.py
+++ b/src/shomer/services/token_exchange_service.py
@@ -1,0 +1,361 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Token Exchange service per RFC 8693."""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass, field
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from shomer.core.settings import Settings
+from shomer.services.jwt_validation_service import JWTValidationService, TokenError
+
+
+class TokenExchangeError(Exception):
+    """Raised when a token exchange request fails.
+
+    Attributes
+    ----------
+    error : str
+        OAuth2 error code.
+    description : str
+        Human-readable error description.
+    """
+
+    def __init__(self, error: str, description: str) -> None:
+        self.error = error
+        self.description = description
+        super().__init__(description)
+
+
+class TokenType(str, enum.Enum):
+    """Token type identifiers per RFC 8693 §3.
+
+    Attributes
+    ----------
+    ACCESS_TOKEN
+        An OAuth 2.0 access token.
+    REFRESH_TOKEN
+        An OAuth 2.0 refresh token.
+    ID_TOKEN
+        An OpenID Connect ID token.
+    JWT
+        A JWT token (generic).
+    """
+
+    ACCESS_TOKEN = "urn:ietf:params:oauth:token-type:access_token"
+    REFRESH_TOKEN = "urn:ietf:params:oauth:token-type:refresh_token"
+    ID_TOKEN = "urn:ietf:params:oauth:token-type:id_token"
+    JWT = "urn:ietf:params:oauth:token-type:jwt"
+
+
+@dataclass(frozen=True)
+class ExchangeRequest:
+    """Parsed token exchange request per RFC 8693 §2.1.
+
+    Attributes
+    ----------
+    subject_token : str
+        The token to exchange.
+    subject_token_type : TokenType
+        Type of the subject token.
+    actor_token : str or None
+        Optional actor token for delegation.
+    actor_token_type : TokenType or None
+        Type of the actor token.
+    requested_token_type : TokenType
+        Desired type of the issued token.
+    scope : str or None
+        Requested scopes for the new token.
+    audience : str or None
+        Target audience for the new token.
+    """
+
+    subject_token: str
+    subject_token_type: TokenType
+    actor_token: str | None = None
+    actor_token_type: TokenType | None = None
+    requested_token_type: TokenType = TokenType.ACCESS_TOKEN
+    scope: str | None = None
+    audience: str | None = None
+
+
+@dataclass
+class ExchangeResult:
+    """Result of a successful token exchange.
+
+    Attributes
+    ----------
+    subject : str
+        The ``sub`` claim from the validated subject token.
+    scopes : list[str]
+        Computed scopes for the new token.
+    audience : str
+        Target audience for the new token.
+    act : dict[str, str] or None
+        Actor claim for delegation (``{"sub": "<actor_sub>"}``).
+    """
+
+    subject: str
+    scopes: list[str] = field(default_factory=list)
+    audience: str = ""
+    act: dict[str, str] | None = None
+
+
+#: Grant type URI for token exchange per RFC 8693.
+TOKEN_EXCHANGE_GRANT = "urn:ietf:params:oauth:grant-type:token-exchange"
+
+
+class TokenExchangeService:
+    """Validate and process token exchange requests per RFC 8693.
+
+    Validates subject and actor tokens, checks client permissions,
+    computes scopes (intersection of requested vs allowed), and
+    supports impersonation and delegation flows.
+
+    Attributes
+    ----------
+    settings : Settings
+        Application configuration.
+    session : AsyncSession
+        Database session.
+    jwt_validation : JWTValidationService
+        JWT validation service for token verification.
+    """
+
+    def __init__(self, settings: Settings, session: AsyncSession) -> None:
+        self.settings = settings
+        self.session = session
+        self.jwt_validation = JWTValidationService(settings, session)
+
+    async def validate_exchange(
+        self,
+        *,
+        request: ExchangeRequest,
+        client_id: str,
+        client_grant_types: list[str],
+        client_scopes: list[str],
+    ) -> ExchangeResult:
+        """Validate a token exchange request and compute the result.
+
+        Parameters
+        ----------
+        request : ExchangeRequest
+            The parsed exchange request.
+        client_id : str
+            The authenticated client's identifier.
+        client_grant_types : list[str]
+            Grant types allowed for the client.
+        client_scopes : list[str]
+            Scopes allowed for the client.
+
+        Returns
+        -------
+        ExchangeResult
+            The validated exchange result with subject, scopes, and
+            optional actor claim.
+
+        Raises
+        ------
+        TokenExchangeError
+            If validation fails at any step.
+        """
+        # 1. Check client is authorized for token exchange
+        self._check_client_permission(client_grant_types)
+
+        # 2. Validate subject token
+        subject_claims = await self._validate_subject_token(request)
+
+        # 3. Compute scopes
+        scopes = self._compute_scopes(
+            requested=request.scope,
+            subject_scopes=subject_claims.get("scope", ""),
+            client_scopes=client_scopes,
+        )
+
+        # 4. Determine audience
+        audience = request.audience or client_id
+
+        # 5. Handle delegation (actor token present)
+        act: dict[str, str] | None = None
+        if request.actor_token:
+            act = await self._validate_actor_token(request)
+
+        subject = subject_claims.get("sub", "")
+        if not subject:
+            raise TokenExchangeError(
+                "invalid_request", "Subject token missing sub claim"
+            )
+
+        return ExchangeResult(
+            subject=subject,
+            scopes=scopes,
+            audience=audience,
+            act=act,
+        )
+
+    def _check_client_permission(self, client_grant_types: list[str]) -> None:
+        """Verify the client is authorized for token exchange.
+
+        Parameters
+        ----------
+        client_grant_types : list[str]
+            Grant types allowed for the client.
+
+        Raises
+        ------
+        TokenExchangeError
+            If token exchange is not in the client's allowed grants.
+        """
+        if TOKEN_EXCHANGE_GRANT not in client_grant_types:
+            raise TokenExchangeError(
+                "unauthorized_client",
+                "Client is not authorized for token exchange",
+            )
+
+    async def _validate_subject_token(self, request: ExchangeRequest) -> dict[str, Any]:
+        """Validate the subject token via JWT verification.
+
+        Parameters
+        ----------
+        request : ExchangeRequest
+            The exchange request containing the subject token.
+
+        Returns
+        -------
+        dict[str, Any]
+            The validated claims from the subject token.
+
+        Raises
+        ------
+        TokenExchangeError
+            If the subject token is invalid.
+        """
+        result = await self.jwt_validation.validate(request.subject_token)
+
+        if not result.valid:
+            error_map = {
+                TokenError.EXPIRED: "Subject token has expired",
+                TokenError.INVALID_SIGNATURE: "Subject token has invalid signature",
+                TokenError.INVALID_CLAIMS: "Subject token has invalid claims",
+                TokenError.KEY_NOT_FOUND: "Subject token key not found",
+                TokenError.DECODE_ERROR: "Subject token is malformed",
+            }
+            msg = error_map.get(result.error, result.error_message)  # type: ignore[arg-type]
+            raise TokenExchangeError("invalid_grant", msg)
+
+        return result.claims or {}
+
+    def _compute_scopes(
+        self,
+        *,
+        requested: str | None,
+        subject_scopes: str,
+        client_scopes: list[str],
+    ) -> list[str]:
+        """Compute the resulting scopes for the exchanged token.
+
+        The result is the intersection of requested scopes, subject token
+        scopes, and client allowed scopes. If no scopes are requested,
+        the subject token's scopes are used (filtered by client allowlist).
+
+        Parameters
+        ----------
+        requested : str or None
+            Space-separated requested scopes.
+        subject_scopes : str
+            Space-separated scopes from the subject token.
+        client_scopes : list[str]
+            Scopes allowed for the client.
+
+        Returns
+        -------
+        list[str]
+            The computed scopes.
+        """
+        subject_set = set(subject_scopes.split()) if subject_scopes else set()
+        client_set = set(client_scopes)
+
+        if requested:
+            requested_set = set(requested.split())
+            # Intersection of all three: requested ∩ subject ∩ client
+            return sorted(requested_set & subject_set & client_set)
+
+        # No scope requested: use subject scopes filtered by client allowlist
+        return sorted(subject_set & client_set)
+
+    async def _validate_actor_token(self, request: ExchangeRequest) -> dict[str, str]:
+        """Validate the actor token for delegation flows.
+
+        Parameters
+        ----------
+        request : ExchangeRequest
+            The exchange request containing the actor token.
+
+        Returns
+        -------
+        dict[str, str]
+            The ``act`` claim (``{"sub": "<actor_sub>"}``).
+
+        Raises
+        ------
+        TokenExchangeError
+            If the actor token is invalid or missing sub claim.
+        """
+        if not request.actor_token:
+            raise TokenExchangeError(
+                "invalid_request", "actor_token is required for delegation"
+            )
+
+        if request.actor_token_type is None:
+            raise TokenExchangeError(
+                "invalid_request",
+                "actor_token_type is required when actor_token is provided",
+            )
+
+        result = await self.jwt_validation.validate(request.actor_token)
+
+        if not result.valid:
+            raise TokenExchangeError(
+                "invalid_grant",
+                f"Actor token is invalid: {result.error_message}",
+            )
+
+        actor_sub = (result.claims or {}).get("sub")
+        if not actor_sub:
+            raise TokenExchangeError("invalid_grant", "Actor token missing sub claim")
+
+        return {"sub": actor_sub}
+
+    @staticmethod
+    def parse_token_type(token_type: str | None) -> TokenType | None:
+        """Parse a token type URI to a TokenType enum.
+
+        Parameters
+        ----------
+        token_type : str or None
+            The token type URI string.
+
+        Returns
+        -------
+        TokenType or None
+            The parsed token type, or ``None`` if the input is empty.
+
+        Raises
+        ------
+        TokenExchangeError
+            If the token type URI is not recognized.
+        """
+        if not token_type:
+            return None
+        try:
+            return TokenType(token_type)
+        except ValueError:
+            raise TokenExchangeError(
+                "invalid_request",
+                f"Unsupported token type: {token_type}",
+            )

--- a/tests/services/test_token_exchange_service.py
+++ b/tests/services/test_token_exchange_service.py
@@ -1,0 +1,495 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Unit tests for TokenExchangeService."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from shomer.services.jwt_validation_service import (
+    TokenError,
+    TokenValidationResult,
+)
+from shomer.services.token_exchange_service import (
+    TOKEN_EXCHANGE_GRANT,
+    ExchangeRequest,
+    ExchangeResult,
+    TokenExchangeError,
+    TokenExchangeService,
+    TokenType,
+)
+
+
+def _make_service() -> tuple[TokenExchangeService, MagicMock]:
+    """Create a TokenExchangeService with mocked dependencies."""
+    settings = MagicMock()
+    settings.jwt_issuer = "https://auth.shomer.local"
+    settings.jwt_clock_skew = 0
+    db = AsyncMock()
+    svc = TokenExchangeService(settings, db)
+    return svc, svc.jwt_validation  # type: ignore[return-value]
+
+
+def _valid_result(
+    sub: str = "user-123", scope: str = "openid profile"
+) -> TokenValidationResult:
+    return TokenValidationResult(
+        valid=True,
+        claims={"sub": sub, "scope": scope, "aud": "client-a"},
+    )
+
+
+def _invalid_result(
+    error: TokenError = TokenError.EXPIRED, msg: str = "expired"
+) -> TokenValidationResult:
+    return TokenValidationResult(valid=False, error=error, error_message=msg)
+
+
+class TestClientPermission:
+    """Tests for client permission check."""
+
+    def test_client_without_exchange_grant_rejected(self) -> None:
+        async def _run() -> None:
+            svc, jwt_val = _make_service()
+            req = ExchangeRequest(
+                subject_token="tok",
+                subject_token_type=TokenType.ACCESS_TOKEN,
+            )
+            with pytest.raises(TokenExchangeError) as exc_info:
+                await svc.validate_exchange(
+                    request=req,
+                    client_id="c",
+                    client_grant_types=["authorization_code"],
+                    client_scopes=["openid"],
+                )
+            assert exc_info.value.error == "unauthorized_client"
+
+        asyncio.run(_run())
+
+    def test_client_with_exchange_grant_accepted(self) -> None:
+        async def _run() -> None:
+            svc, jwt_val = _make_service()
+            jwt_val.validate = AsyncMock(return_value=_valid_result())
+            req = ExchangeRequest(
+                subject_token="tok",
+                subject_token_type=TokenType.ACCESS_TOKEN,
+            )
+            result = await svc.validate_exchange(
+                request=req,
+                client_id="c",
+                client_grant_types=[TOKEN_EXCHANGE_GRANT],
+                client_scopes=["openid", "profile"],
+            )
+            assert isinstance(result, ExchangeResult)
+
+        asyncio.run(_run())
+
+
+class TestSubjectTokenValidation:
+    """Tests for subject token validation."""
+
+    def test_expired_subject_token_rejected(self) -> None:
+        async def _run() -> None:
+            svc, jwt_val = _make_service()
+            jwt_val.validate = AsyncMock(
+                return_value=_invalid_result(TokenError.EXPIRED, "expired")
+            )
+            req = ExchangeRequest(
+                subject_token="expired-tok",
+                subject_token_type=TokenType.ACCESS_TOKEN,
+            )
+            with pytest.raises(TokenExchangeError) as exc_info:
+                await svc.validate_exchange(
+                    request=req,
+                    client_id="c",
+                    client_grant_types=[TOKEN_EXCHANGE_GRANT],
+                    client_scopes=["openid"],
+                )
+            assert exc_info.value.error == "invalid_grant"
+            assert "expired" in exc_info.value.description.lower()
+
+        asyncio.run(_run())
+
+    def test_invalid_signature_rejected(self) -> None:
+        async def _run() -> None:
+            svc, jwt_val = _make_service()
+            jwt_val.validate = AsyncMock(
+                return_value=_invalid_result(TokenError.INVALID_SIGNATURE, "bad sig")
+            )
+            req = ExchangeRequest(
+                subject_token="bad-tok",
+                subject_token_type=TokenType.ACCESS_TOKEN,
+            )
+            with pytest.raises(TokenExchangeError) as exc_info:
+                await svc.validate_exchange(
+                    request=req,
+                    client_id="c",
+                    client_grant_types=[TOKEN_EXCHANGE_GRANT],
+                    client_scopes=[],
+                )
+            assert exc_info.value.error == "invalid_grant"
+            assert "signature" in exc_info.value.description.lower()
+
+        asyncio.run(_run())
+
+    def test_malformed_token_rejected(self) -> None:
+        async def _run() -> None:
+            svc, jwt_val = _make_service()
+            jwt_val.validate = AsyncMock(
+                return_value=_invalid_result(TokenError.DECODE_ERROR, "malformed")
+            )
+            req = ExchangeRequest(
+                subject_token="garbage",
+                subject_token_type=TokenType.ACCESS_TOKEN,
+            )
+            with pytest.raises(TokenExchangeError) as exc_info:
+                await svc.validate_exchange(
+                    request=req,
+                    client_id="c",
+                    client_grant_types=[TOKEN_EXCHANGE_GRANT],
+                    client_scopes=[],
+                )
+            assert exc_info.value.error == "invalid_grant"
+            assert "malformed" in exc_info.value.description.lower()
+
+        asyncio.run(_run())
+
+    def test_missing_sub_claim_rejected(self) -> None:
+        async def _run() -> None:
+            svc, jwt_val = _make_service()
+            jwt_val.validate = AsyncMock(
+                return_value=TokenValidationResult(
+                    valid=True, claims={"scope": "openid"}
+                )
+            )
+            req = ExchangeRequest(
+                subject_token="no-sub",
+                subject_token_type=TokenType.ACCESS_TOKEN,
+            )
+            with pytest.raises(TokenExchangeError) as exc_info:
+                await svc.validate_exchange(
+                    request=req,
+                    client_id="c",
+                    client_grant_types=[TOKEN_EXCHANGE_GRANT],
+                    client_scopes=["openid"],
+                )
+            assert "sub claim" in exc_info.value.description
+
+        asyncio.run(_run())
+
+    def test_valid_subject_token_extracts_sub(self) -> None:
+        async def _run() -> None:
+            svc, jwt_val = _make_service()
+            jwt_val.validate = AsyncMock(return_value=_valid_result(sub="uid-456"))
+            req = ExchangeRequest(
+                subject_token="good-tok",
+                subject_token_type=TokenType.ACCESS_TOKEN,
+            )
+            result = await svc.validate_exchange(
+                request=req,
+                client_id="c",
+                client_grant_types=[TOKEN_EXCHANGE_GRANT],
+                client_scopes=["openid", "profile"],
+            )
+            assert result.subject == "uid-456"
+
+        asyncio.run(_run())
+
+
+class TestScopeComputation:
+    """Tests for scope intersection logic."""
+
+    def test_no_requested_scope_uses_subject_filtered(self) -> None:
+        async def _run() -> None:
+            svc, jwt_val = _make_service()
+            jwt_val.validate = AsyncMock(
+                return_value=_valid_result(scope="openid profile email")
+            )
+            req = ExchangeRequest(
+                subject_token="tok",
+                subject_token_type=TokenType.ACCESS_TOKEN,
+            )
+            result = await svc.validate_exchange(
+                request=req,
+                client_id="c",
+                client_grant_types=[TOKEN_EXCHANGE_GRANT],
+                client_scopes=["openid", "profile"],
+            )
+            # email not in client_scopes → filtered out
+            assert result.scopes == ["openid", "profile"]
+
+        asyncio.run(_run())
+
+    def test_requested_scope_intersection(self) -> None:
+        async def _run() -> None:
+            svc, jwt_val = _make_service()
+            jwt_val.validate = AsyncMock(
+                return_value=_valid_result(scope="openid profile email")
+            )
+            req = ExchangeRequest(
+                subject_token="tok",
+                subject_token_type=TokenType.ACCESS_TOKEN,
+                scope="openid email",
+            )
+            result = await svc.validate_exchange(
+                request=req,
+                client_id="c",
+                client_grant_types=[TOKEN_EXCHANGE_GRANT],
+                client_scopes=["openid", "profile", "email"],
+            )
+            # requested ∩ subject ∩ client = openid, email
+            assert result.scopes == ["email", "openid"]
+
+        asyncio.run(_run())
+
+    def test_requested_scope_not_in_subject_excluded(self) -> None:
+        async def _run() -> None:
+            svc, jwt_val = _make_service()
+            jwt_val.validate = AsyncMock(return_value=_valid_result(scope="openid"))
+            req = ExchangeRequest(
+                subject_token="tok",
+                subject_token_type=TokenType.ACCESS_TOKEN,
+                scope="openid profile",
+            )
+            result = await svc.validate_exchange(
+                request=req,
+                client_id="c",
+                client_grant_types=[TOKEN_EXCHANGE_GRANT],
+                client_scopes=["openid", "profile"],
+            )
+            # profile not in subject → excluded
+            assert result.scopes == ["openid"]
+
+        asyncio.run(_run())
+
+    def test_empty_subject_scopes_yields_empty(self) -> None:
+        async def _run() -> None:
+            svc, jwt_val = _make_service()
+            jwt_val.validate = AsyncMock(return_value=_valid_result(scope=""))
+            req = ExchangeRequest(
+                subject_token="tok",
+                subject_token_type=TokenType.ACCESS_TOKEN,
+            )
+            result = await svc.validate_exchange(
+                request=req,
+                client_id="c",
+                client_grant_types=[TOKEN_EXCHANGE_GRANT],
+                client_scopes=["openid"],
+            )
+            assert result.scopes == []
+
+        asyncio.run(_run())
+
+
+class TestImpersonation:
+    """Tests for impersonation (act-as) flow."""
+
+    def test_impersonation_no_actor_token(self) -> None:
+        """Without actor_token, act claim is None (impersonation)."""
+
+        async def _run() -> None:
+            svc, jwt_val = _make_service()
+            jwt_val.validate = AsyncMock(return_value=_valid_result())
+            req = ExchangeRequest(
+                subject_token="tok",
+                subject_token_type=TokenType.ACCESS_TOKEN,
+            )
+            result = await svc.validate_exchange(
+                request=req,
+                client_id="c",
+                client_grant_types=[TOKEN_EXCHANGE_GRANT],
+                client_scopes=["openid", "profile"],
+            )
+            assert result.act is None
+            assert result.subject == "user-123"
+
+        asyncio.run(_run())
+
+
+class TestDelegation:
+    """Tests for delegation (on-behalf-of) flow with actor token."""
+
+    def test_delegation_with_valid_actor_token(self) -> None:
+        async def _run() -> None:
+            svc, jwt_val = _make_service()
+            jwt_val.validate = AsyncMock(
+                side_effect=[
+                    _valid_result(sub="user-123"),
+                    _valid_result(sub="service-abc"),
+                ]
+            )
+            req = ExchangeRequest(
+                subject_token="user-tok",
+                subject_token_type=TokenType.ACCESS_TOKEN,
+                actor_token="service-tok",
+                actor_token_type=TokenType.ACCESS_TOKEN,
+            )
+            result = await svc.validate_exchange(
+                request=req,
+                client_id="c",
+                client_grant_types=[TOKEN_EXCHANGE_GRANT],
+                client_scopes=["openid", "profile"],
+            )
+            assert result.subject == "user-123"
+            assert result.act == {"sub": "service-abc"}
+
+        asyncio.run(_run())
+
+    def test_delegation_invalid_actor_token(self) -> None:
+        async def _run() -> None:
+            svc, jwt_val = _make_service()
+            jwt_val.validate = AsyncMock(
+                side_effect=[
+                    _valid_result(sub="user-123"),
+                    _invalid_result(TokenError.EXPIRED, "expired"),
+                ]
+            )
+            req = ExchangeRequest(
+                subject_token="user-tok",
+                subject_token_type=TokenType.ACCESS_TOKEN,
+                actor_token="bad-actor",
+                actor_token_type=TokenType.ACCESS_TOKEN,
+            )
+            with pytest.raises(TokenExchangeError) as exc_info:
+                await svc.validate_exchange(
+                    request=req,
+                    client_id="c",
+                    client_grant_types=[TOKEN_EXCHANGE_GRANT],
+                    client_scopes=["openid"],
+                )
+            assert exc_info.value.error == "invalid_grant"
+            assert "Actor token" in exc_info.value.description
+
+        asyncio.run(_run())
+
+    def test_delegation_actor_missing_sub(self) -> None:
+        async def _run() -> None:
+            svc, jwt_val = _make_service()
+            jwt_val.validate = AsyncMock(
+                side_effect=[
+                    _valid_result(sub="user-123"),
+                    TokenValidationResult(valid=True, claims={"scope": "openid"}),
+                ]
+            )
+            req = ExchangeRequest(
+                subject_token="user-tok",
+                subject_token_type=TokenType.ACCESS_TOKEN,
+                actor_token="no-sub-actor",
+                actor_token_type=TokenType.ACCESS_TOKEN,
+            )
+            with pytest.raises(TokenExchangeError) as exc_info:
+                await svc.validate_exchange(
+                    request=req,
+                    client_id="c",
+                    client_grant_types=[TOKEN_EXCHANGE_GRANT],
+                    client_scopes=["openid"],
+                )
+            assert "sub claim" in exc_info.value.description
+
+        asyncio.run(_run())
+
+    def test_delegation_missing_actor_token_type(self) -> None:
+        async def _run() -> None:
+            svc, jwt_val = _make_service()
+            jwt_val.validate = AsyncMock(return_value=_valid_result())
+            req = ExchangeRequest(
+                subject_token="user-tok",
+                subject_token_type=TokenType.ACCESS_TOKEN,
+                actor_token="actor-tok",
+                actor_token_type=None,
+            )
+            with pytest.raises(TokenExchangeError) as exc_info:
+                await svc.validate_exchange(
+                    request=req,
+                    client_id="c",
+                    client_grant_types=[TOKEN_EXCHANGE_GRANT],
+                    client_scopes=["openid"],
+                )
+            assert "actor_token_type" in exc_info.value.description
+
+        asyncio.run(_run())
+
+
+class TestAudience:
+    """Tests for audience resolution."""
+
+    def test_default_audience_is_client_id(self) -> None:
+        async def _run() -> None:
+            svc, jwt_val = _make_service()
+            jwt_val.validate = AsyncMock(return_value=_valid_result())
+            req = ExchangeRequest(
+                subject_token="tok",
+                subject_token_type=TokenType.ACCESS_TOKEN,
+            )
+            result = await svc.validate_exchange(
+                request=req,
+                client_id="my-client",
+                client_grant_types=[TOKEN_EXCHANGE_GRANT],
+                client_scopes=["openid", "profile"],
+            )
+            assert result.audience == "my-client"
+
+        asyncio.run(_run())
+
+    def test_explicit_audience_overrides_default(self) -> None:
+        async def _run() -> None:
+            svc, jwt_val = _make_service()
+            jwt_val.validate = AsyncMock(return_value=_valid_result())
+            req = ExchangeRequest(
+                subject_token="tok",
+                subject_token_type=TokenType.ACCESS_TOKEN,
+                audience="target-service",
+            )
+            result = await svc.validate_exchange(
+                request=req,
+                client_id="my-client",
+                client_grant_types=[TOKEN_EXCHANGE_GRANT],
+                client_scopes=["openid", "profile"],
+            )
+            assert result.audience == "target-service"
+
+        asyncio.run(_run())
+
+
+class TestParseTokenType:
+    """Tests for TokenExchangeService.parse_token_type."""
+
+    def test_parse_access_token(self) -> None:
+        result = TokenExchangeService.parse_token_type(
+            "urn:ietf:params:oauth:token-type:access_token"
+        )
+        assert result == TokenType.ACCESS_TOKEN
+
+    def test_parse_refresh_token(self) -> None:
+        result = TokenExchangeService.parse_token_type(
+            "urn:ietf:params:oauth:token-type:refresh_token"
+        )
+        assert result == TokenType.REFRESH_TOKEN
+
+    def test_parse_id_token(self) -> None:
+        result = TokenExchangeService.parse_token_type(
+            "urn:ietf:params:oauth:token-type:id_token"
+        )
+        assert result == TokenType.ID_TOKEN
+
+    def test_parse_jwt(self) -> None:
+        result = TokenExchangeService.parse_token_type(
+            "urn:ietf:params:oauth:token-type:jwt"
+        )
+        assert result == TokenType.JWT
+
+    def test_parse_none_returns_none(self) -> None:
+        assert TokenExchangeService.parse_token_type(None) is None
+
+    def test_parse_empty_returns_none(self) -> None:
+        assert TokenExchangeService.parse_token_type("") is None
+
+    def test_parse_unknown_raises(self) -> None:
+        with pytest.raises(TokenExchangeError) as exc_info:
+            TokenExchangeService.parse_token_type("unknown:type")
+        assert exc_info.value.error == "invalid_request"
+        assert "Unsupported" in exc_info.value.description


### PR DESCRIPTION
## feat(oauth2): token exchange validation and scope escalation service

## Summary

Token Exchange service: validates the subject_token, checks exchange permissions for the client, computes resulting scopes (intersection or controlled escalation), supports impersonation and delegation.

## Changes

- [x] Subject token validation (JWT verification)
- [x] Client permission check for token exchange
- [x] Scope computation (intersection of requested vs allowed)
- [x] Impersonation support (act-as)
- [x] Delegation support (on-behalf-of with actor claim)
- [x] Unit tests

## Dependencies

- #15 - JWT validation

## Related Issue

Closes #62

## Test Plan

- [x] `make format` - code formatted
- [x] `make lint` - no linting errors
- [x] `make typecheck` - type checks pass
- [x] `make test` - all unit tests pass
- [x] `make bdd` - all BDD tests pass
- [x] `make check-license` - SPDX headers present
