### PR TITLE
feat(models): UserMFA, MFABackupCode, MFAEmailCode

### DIFF
--- a/alembic/versions/0016_add_mfa_tables.py
+++ b/alembic/versions/0016_add_mfa_tables.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Add MFA tables: user_mfa, mfa_backup_codes, mfa_email_codes.
+
+Revision ID: 0016
+Revises: 0015
+Create Date: 2026-03-21
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0016"
+down_revision: Union[str, None] = "0015"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create user_mfa, mfa_backup_codes, and mfa_email_codes tables."""
+    op.create_table(
+        "user_mfa",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("user_id", sa.Uuid(), nullable=False),
+        sa.Column("totp_secret_encrypted", sa.Text(), nullable=True),
+        sa.Column("is_enabled", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column("methods", sa.JSON(), nullable=False, server_default="[]"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint("user_id"),
+    )
+    op.create_index("ix_user_mfa_user_id", "user_mfa", ["user_id"])
+
+    op.create_table(
+        "mfa_backup_codes",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("user_mfa_id", sa.Uuid(), nullable=False),
+        sa.Column("code_hash", sa.String(255), nullable=False),
+        sa.Column("is_used", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["user_mfa_id"], ["user_mfa.id"], ondelete="CASCADE"),
+    )
+    op.create_index(
+        "ix_mfa_backup_codes_user_mfa_id", "mfa_backup_codes", ["user_mfa_id"]
+    )
+
+    op.create_table(
+        "mfa_email_codes",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("user_id", sa.Uuid(), nullable=False),
+        sa.Column("email", sa.String(255), nullable=False),
+        sa.Column("code", sa.String(6), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("is_used", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+    )
+    op.create_index("ix_mfa_email_codes_user_id", "mfa_email_codes", ["user_id"])
+
+
+def downgrade() -> None:
+    """Drop MFA tables."""
+    op.drop_table("mfa_email_codes")
+    op.drop_table("mfa_backup_codes")
+    op.drop_table("user_mfa")

--- a/src/shomer/models/__init__.py
+++ b/src/shomer/models/__init__.py
@@ -11,6 +11,8 @@ from shomer.models.access_token import AccessToken as AccessToken
 from shomer.models.authorization_code import AuthorizationCode as AuthorizationCode
 from shomer.models.device_code import DeviceCode as DeviceCode
 from shomer.models.jwk import JWK as JWK
+from shomer.models.mfa_backup_code import MFABackupCode as MFABackupCode
+from shomer.models.mfa_email_code import MFAEmailCode as MFAEmailCode
 from shomer.models.oauth2_client import OAuth2Client as OAuth2Client
 from shomer.models.par_request import PARRequest as PARRequest
 from shomer.models.password_reset_token import PasswordResetToken as PasswordResetToken
@@ -18,6 +20,7 @@ from shomer.models.refresh_token import RefreshToken as RefreshToken
 from shomer.models.session import Session as Session
 from shomer.models.user import User as User
 from shomer.models.user_email import UserEmail as UserEmail
+from shomer.models.user_mfa import UserMFA as UserMFA
 from shomer.models.user_password import UserPassword as UserPassword
 from shomer.models.user_profile import UserProfile as UserProfile
 from shomer.models.verification_code import VerificationCode as VerificationCode

--- a/src/shomer/models/mfa_backup_code.py
+++ b/src/shomer/models/mfa_backup_code.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""MFABackupCode model for single-use recovery codes."""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Boolean, ForeignKey, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+if TYPE_CHECKING:
+    from shomer.models.user_mfa import UserMFA
+
+from shomer.core.database import Base, TimestampMixin, UUIDMixin
+
+
+class MFABackupCode(Base, UUIDMixin, TimestampMixin):
+    """Single-use MFA backup (recovery) code.
+
+    Backup codes are hashed with Argon2id before storage.
+    Each code can only be used once.
+
+    Attributes
+    ----------
+    id : uuid.UUID
+        Primary key (from UUIDMixin).
+    user_mfa_id : uuid.UUID
+        Foreign key to the UserMFA record.
+    code_hash : str
+        Argon2id hash of the backup code.
+    is_used : bool
+        Whether this code has been consumed.
+    user_mfa : UserMFA
+        The associated MFA configuration.
+    created_at : datetime
+        Row creation timestamp (from TimestampMixin).
+    updated_at : datetime
+        Last update timestamp (from TimestampMixin).
+    """
+
+    __tablename__ = "mfa_backup_codes"
+
+    user_mfa_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("user_mfa.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    code_hash: Mapped[str] = mapped_column(
+        String(255),
+        nullable=False,
+    )
+    is_used: Mapped[bool] = mapped_column(
+        Boolean,
+        default=False,
+        nullable=False,
+    )
+
+    # Relationships
+    user_mfa: Mapped[UserMFA] = relationship(back_populates="backup_codes")
+
+    def __repr__(self) -> str:
+        return f"<MFABackupCode id={self.id} used={self.is_used}>"

--- a/src/shomer/models/mfa_email_code.py
+++ b/src/shomer/models/mfa_email_code.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""MFAEmailCode model for email-based MFA verification."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from shomer.core.database import Base, TimestampMixin, UUIDMixin
+
+
+class MFAEmailCode(Base, UUIDMixin, TimestampMixin):
+    """Email-based MFA verification code.
+
+    A 6-digit code sent to the user's email for MFA verification.
+    Codes expire after a short TTL and are single-use.
+
+    Attributes
+    ----------
+    id : uuid.UUID
+        Primary key (from UUIDMixin).
+    user_id : uuid.UUID
+        Foreign key to the user.
+    email : str
+        Email address the code was sent to.
+    code : str
+        The 6-digit verification code.
+    expires_at : datetime
+        Expiration timestamp.
+    is_used : bool
+        Whether this code has been consumed.
+    created_at : datetime
+        Row creation timestamp (from TimestampMixin).
+    updated_at : datetime
+        Last update timestamp (from TimestampMixin).
+    """
+
+    __tablename__ = "mfa_email_codes"
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    email: Mapped[str] = mapped_column(
+        String(255),
+        nullable=False,
+    )
+    code: Mapped[str] = mapped_column(
+        String(6),
+        nullable=False,
+    )
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+    )
+    is_used: Mapped[bool] = mapped_column(
+        Boolean,
+        default=False,
+        nullable=False,
+    )
+
+    def __repr__(self) -> str:
+        return f"<MFAEmailCode user_id={self.user_id} email={self.email}>"

--- a/src/shomer/models/user.py
+++ b/src/shomer/models/user.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from shomer.models.refresh_token import RefreshToken
     from shomer.models.session import Session
     from shomer.models.user_email import UserEmail
+    from shomer.models.user_mfa import UserMFA
     from shomer.models.user_password import UserPassword
     from shomer.models.user_profile import UserProfile
 
@@ -39,6 +40,8 @@ class User(Base, UUIDMixin, TimestampMixin):
         Last update timestamp (from TimestampMixin).
     profile : UserProfile or None
         One-to-one OIDC profile (lazy-loaded).
+    mfa : UserMFA or None
+        One-to-one MFA configuration (lazy-loaded).
     """
 
     __tablename__ = "users"
@@ -82,6 +85,11 @@ class User(Base, UUIDMixin, TimestampMixin):
     refresh_tokens: Mapped[list[RefreshToken]] = relationship(
         back_populates="user",
         cascade="all, delete-orphan",
+    )
+    mfa: Mapped[UserMFA | None] = relationship(
+        back_populates="user",
+        cascade="all, delete-orphan",
+        uselist=False,
     )
 
     def __repr__(self) -> str:

--- a/src/shomer/models/user_mfa.py
+++ b/src/shomer/models/user_mfa.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""UserMFA model for multi-factor authentication."""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+from sqlalchemy import JSON, Boolean, ForeignKey, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+if TYPE_CHECKING:
+    from shomer.models.mfa_backup_code import MFABackupCode
+    from shomer.models.user import User
+
+from shomer.core.database import Base, TimestampMixin, UUIDMixin
+
+
+class UserMFA(Base, UUIDMixin, TimestampMixin):
+    """MFA configuration for a user.
+
+    Stores the encrypted TOTP secret, enabled state, and list of
+    active MFA methods (totp, email, backup).
+
+    Attributes
+    ----------
+    id : uuid.UUID
+        Primary key (from UUIDMixin).
+    user_id : uuid.UUID
+        Foreign key to the user.
+    totp_secret_encrypted : str or None
+        AES-256-GCM encrypted TOTP secret (base32-encoded before encryption).
+    is_enabled : bool
+        Whether MFA is active for this user.
+    methods : list[str]
+        Active MFA methods (e.g. ``["totp", "email", "backup"]``).
+    user : User
+        The associated user.
+    backup_codes : list[MFABackupCode]
+        Associated backup codes.
+    created_at : datetime
+        Row creation timestamp (from TimestampMixin).
+    updated_at : datetime
+        Last update timestamp (from TimestampMixin).
+    """
+
+    __tablename__ = "user_mfa"
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"),
+        unique=True,
+        nullable=False,
+        index=True,
+    )
+    totp_secret_encrypted: Mapped[str | None] = mapped_column(
+        Text,
+        nullable=True,
+    )
+    is_enabled: Mapped[bool] = mapped_column(
+        Boolean,
+        default=False,
+        nullable=False,
+    )
+    methods: Mapped[list[str]] = mapped_column(
+        JSON,
+        default=list,
+        nullable=False,
+    )
+
+    # Relationships
+    user: Mapped[User] = relationship(back_populates="mfa")
+    backup_codes: Mapped[list[MFABackupCode]] = relationship(
+        back_populates="user_mfa",
+        cascade="all, delete-orphan",
+    )
+
+    def __repr__(self) -> str:
+        return f"<UserMFA user_id={self.user_id} enabled={self.is_enabled}>"

--- a/tests/models/test_mfa_backup_code.py
+++ b/tests/models/test_mfa_backup_code.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Unit tests for MFABackupCode model."""
+
+import uuid
+
+from shomer.models.mfa_backup_code import MFABackupCode
+
+
+class TestMFABackupCodeModel:
+    """Tests for MFABackupCode SQLAlchemy model definition."""
+
+    def test_tablename(self) -> None:
+        assert MFABackupCode.__tablename__ == "mfa_backup_codes"
+
+    def test_required_fields(self) -> None:
+        mfa_id = uuid.uuid4()
+        code = MFABackupCode(
+            user_mfa_id=mfa_id,
+            code_hash="$argon2id$v=19$m=65536,t=3,p=4$hash",
+            is_used=False,
+        )
+        assert code.user_mfa_id == mfa_id
+        assert code.code_hash.startswith("$argon2id")
+        assert code.is_used is False
+
+    def test_mark_as_used(self) -> None:
+        code = MFABackupCode(
+            user_mfa_id=uuid.uuid4(),
+            code_hash="hash",
+            is_used=True,
+        )
+        assert code.is_used is True
+
+    def test_user_mfa_id_indexed(self) -> None:
+        col = MFABackupCode.__table__.c.user_mfa_id
+        assert col.index is True
+
+    def test_repr(self) -> None:
+        code = MFABackupCode(
+            user_mfa_id=uuid.uuid4(),
+            code_hash="hash",
+            is_used=False,
+        )
+        r = repr(code)
+        assert "MFABackupCode" in r
+        assert "False" in r

--- a/tests/models/test_mfa_email_code.py
+++ b/tests/models/test_mfa_email_code.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Unit tests for MFAEmailCode model."""
+
+import uuid
+from datetime import datetime, timezone
+
+from shomer.models.mfa_email_code import MFAEmailCode
+
+
+class TestMFAEmailCodeModel:
+    """Tests for MFAEmailCode SQLAlchemy model definition."""
+
+    def test_tablename(self) -> None:
+        assert MFAEmailCode.__tablename__ == "mfa_email_codes"
+
+    def test_required_fields(self) -> None:
+        now = datetime.now(timezone.utc)
+        uid = uuid.uuid4()
+        ec = MFAEmailCode(
+            user_id=uid,
+            email="user@example.com",
+            code="123456",
+            expires_at=now,
+            is_used=False,
+        )
+        assert ec.user_id == uid
+        assert ec.email == "user@example.com"
+        assert ec.code == "123456"
+        assert ec.expires_at == now
+        assert ec.is_used is False
+
+    def test_mark_as_used(self) -> None:
+        ec = MFAEmailCode(
+            user_id=uuid.uuid4(),
+            email="u@b.com",
+            code="654321",
+            expires_at=datetime.now(timezone.utc),
+            is_used=True,
+        )
+        assert ec.is_used is True
+
+    def test_code_max_length_6(self) -> None:
+        col = MFAEmailCode.__table__.c.code
+        assert getattr(col.type, "length", None) == 6
+
+    def test_user_id_indexed(self) -> None:
+        col = MFAEmailCode.__table__.c.user_id
+        assert col.index is True
+
+    def test_repr(self) -> None:
+        uid = uuid.uuid4()
+        ec = MFAEmailCode(
+            user_id=uid,
+            email="test@example.com",
+            code="111111",
+            expires_at=datetime.now(timezone.utc),
+        )
+        r = repr(ec)
+        assert str(uid) in r
+        assert "test@example.com" in r

--- a/tests/models/test_user_mfa.py
+++ b/tests/models/test_user_mfa.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Unit tests for UserMFA model."""
+
+import uuid
+
+from shomer.models.user_mfa import UserMFA
+
+
+class TestUserMFAModel:
+    """Tests for UserMFA SQLAlchemy model definition."""
+
+    def test_tablename(self) -> None:
+        assert UserMFA.__tablename__ == "user_mfa"
+
+    def test_required_fields(self) -> None:
+        uid = uuid.uuid4()
+        mfa = UserMFA(user_id=uid, is_enabled=False, methods=[])
+        assert mfa.user_id == uid
+        assert mfa.is_enabled is False
+        assert mfa.methods == []
+        assert mfa.totp_secret_encrypted is None
+
+    def test_enabled_with_methods(self) -> None:
+        mfa = UserMFA(
+            user_id=uuid.uuid4(),
+            is_enabled=True,
+            methods=["totp", "backup"],
+        )
+        assert mfa.is_enabled is True
+        assert "totp" in mfa.methods
+        assert "backup" in mfa.methods
+
+    def test_totp_secret_stored(self) -> None:
+        mfa = UserMFA(
+            user_id=uuid.uuid4(),
+            totp_secret_encrypted="encrypted-base32-secret",
+        )
+        assert mfa.totp_secret_encrypted == "encrypted-base32-secret"
+
+    def test_user_id_unique(self) -> None:
+        col = UserMFA.__table__.c.user_id
+        assert col.unique is True
+
+    def test_user_id_indexed(self) -> None:
+        col = UserMFA.__table__.c.user_id
+        assert col.index is True
+
+    def test_repr(self) -> None:
+        uid = uuid.uuid4()
+        mfa = UserMFA(user_id=uid, is_enabled=True)
+        r = repr(mfa)
+        assert str(uid) in r
+        assert "True" in r


### PR DESCRIPTION
## feat(models): UserMFA, MFABackupCode, MFAEmailCode

## Summary

MFA models: UserMFA (encrypted TOTP secret, enabled flag, active methods), MFABackupCode (hashed codes, single-use), MFAEmailCode (6-digit code with expiration for email fallback).

## Changes

- [x] UserMFA model (totp_secret encrypted, enabled, methods)
- [x] MFABackupCode model (code_hash, used, user_id)
- [x] MFAEmailCode model (code, email, expires_at, used)
- [x] Relationships to User
- [x] Alembic migration

## Dependencies

- #4 - User model

## Related Issue

Closes #64

## Test Plan

- [x] `make format` - code formatted
- [x] `make lint` - no linting errors
- [x] `make typecheck` - type checks pass
- [x] `make test` - all unit tests pass
- [x] `make bdd` - all BDD tests pass
- [x] `make check-license` - SPDX headers present
