### PR TITLE
feat(auth): two-step MFA challenge in POST /auth/login

### DIFF
--- a/features/mfa_login_challenge.feature
+++ b/features/mfa_login_challenge.feature
@@ -1,0 +1,58 @@
+Feature: Two-step MFA login challenge
+
+  Scenario: Login without MFA returns normal session
+    Given a registered and verified user "mfa-no-mfa@example.com" with password "securepassword123"
+    When I send a POST request to "/auth/login" with JSON
+      """
+      {"email": "mfa-no-mfa@example.com", "password": "securepassword123"}
+      """
+    Then the response status code should be 200
+    And the response body should contain "Login successful"
+
+  Scenario: Login with MFA enabled returns mfa_required
+    Given a user with MFA enabled
+    When I send a POST request to "/auth/login" with JSON
+      """
+      {"email": "${mfa_user_email}", "password": "securepassword123"}
+      """
+    Then the response status code should be 200
+    And the response should have JSON key "mfa_required"
+    And the response should have JSON key "mfa_token"
+    And the response body should contain "true"
+
+  Scenario: Complete MFA challenge with TOTP code creates session
+    Given a user with MFA enabled
+    When I send a POST request to "/auth/login" with JSON
+      """
+      {"email": "${mfa_user_email}", "password": "securepassword123"}
+      """
+    Then the response status code should be 200
+    And the response should have JSON key "mfa_token"
+    When I send a POST request to "/mfa/verify-challenge" with JSON
+      """
+      {"mfa_token": "${mfa_login_token}", "code": "${mfa_totp_code}", "method": "totp"}
+      """
+    Then the response status code should be 200
+    And the response body should contain "Login complete"
+
+  Scenario: MFA challenge with invalid token returns 401
+    When I send a POST request to "/mfa/verify-challenge" with JSON
+      """
+      {"mfa_token": "invalid-token", "code": "123456", "method": "totp"}
+      """
+    Then the response status code should be 401
+    And the response body should contain "Invalid or expired MFA token"
+
+  Scenario: MFA challenge with wrong TOTP code returns 400
+    Given a user with MFA enabled
+    When I send a POST request to "/auth/login" with JSON
+      """
+      {"email": "${mfa_user_email}", "password": "securepassword123"}
+      """
+    Then the response status code should be 200
+    When I send a POST request to "/mfa/verify-challenge" with JSON
+      """
+      {"mfa_token": "${mfa_login_token}", "code": "000000", "method": "totp"}
+      """
+    Then the response status code should be 400
+    And the response body should contain "Invalid TOTP"

--- a/features/steps/http_steps.py
+++ b/features/steps/http_steps.py
@@ -40,6 +40,7 @@ def _send(context, method, path, data=None):
         context.response = None
         context.response_status = 0
         context.response_body = str(e)
+    _capture_mfa_token(context)
 
 
 def _capture_session_cookie(context, response):
@@ -50,6 +51,18 @@ def _capture_session_cookie(context, response):
             value = cookie.split("session_id=")[1].split(";")[0]
             if value and value != '""':
                 context.session_cookie = value
+
+
+def _capture_mfa_token(context):
+    """Extract mfa_token from response body if present."""
+    body = getattr(context, "response_body", "")
+    if body and '"mfa_token"' in body:
+        try:
+            data = json.loads(body)
+            if "mfa_token" in data:
+                context.mfa_login_token = data["mfa_token"]
+        except (json.JSONDecodeError, ValueError):
+            pass
 
 
 @given("I have a JSON payload")
@@ -86,6 +99,12 @@ def _substitute_vars(context, text):
     mfa_backup = getattr(context, "mfa_backup_codes", None)
     if mfa_backup and "${mfa_backup_code}" in text:
         text = text.replace("${mfa_backup_code}", mfa_backup[0])
+    mfa_email = getattr(context, "mfa_user_email", None)
+    if mfa_email and "${mfa_user_email}" in text:
+        text = text.replace("${mfa_user_email}", mfa_email)
+    mfa_login_tok = getattr(context, "mfa_login_token", None)
+    if mfa_login_tok and "${mfa_login_token}" in text:
+        text = text.replace("${mfa_login_token}", mfa_login_tok)
     return text
 
 

--- a/features/steps/mfa_steps.py
+++ b/features/steps/mfa_steps.py
@@ -96,3 +96,4 @@ def step_setup_user_with_mfa(context):
     assert status_code == 200, f"MFA enable failed: {status_code} {enable_body}"
     assert enable_body["mfa_enabled"] is True
     context.mfa_backup_codes = enable_body.get("backup_codes", [])
+    context.mfa_user_email = email

--- a/src/shomer/routes/auth.py
+++ b/src/shomer/routes/auth.py
@@ -206,6 +206,34 @@ async def login(body: LoginRequest, request: Request, db: DbSession) -> JSONResp
             detail="Email not verified",
         )
 
+    # Check if user has MFA enabled
+    from sqlalchemy import select
+
+    from shomer.models.user_mfa import UserMFA
+
+    mfa_stmt = select(UserMFA).where(
+        UserMFA.user_id == user.id,
+    )
+    mfa_result = await db.execute(mfa_stmt)
+    user_mfa = mfa_result.scalar_one_or_none()
+
+    if user_mfa is not None and user_mfa.is_enabled:
+        # MFA required: delete the session we just created (don't finalize)
+        session_svc = SessionService(db)
+        await session_svc.delete(session.id)
+
+        # Issue a short-lived mfa_token
+        mfa_token = _build_mfa_token(str(user.id), get_settings())
+
+        return JSONResponse(
+            content={
+                "mfa_required": True,
+                "mfa_token": mfa_token,
+                "methods": user_mfa.methods,
+                "message": "MFA verification required.",
+            },
+        )
+
     settings = get_settings()
     policy = get_cookie_policy(settings)
     response = JSONResponse(
@@ -233,6 +261,67 @@ async def login(body: LoginRequest, request: Request, db: DbSession) -> JSONResp
         max_age=86400,
     )
     return response
+
+
+#: MFA token expiration in seconds (5 minutes).
+MFA_TOKEN_EXP = 300
+
+
+def _build_mfa_token(user_id: str, settings: object) -> str:
+    """Build a short-lived JWT for MFA challenge.
+
+    Parameters
+    ----------
+    user_id : str
+        The user's UUID as string.
+    settings : Settings
+        Application settings.
+
+    Returns
+    -------
+    str
+        Encoded JWT with 5-minute expiration.
+    """
+    import time
+
+    import jwt as pyjwt
+
+    now = int(time.time())
+    payload = {
+        "sub": user_id,
+        "purpose": "mfa_challenge",
+        "iat": now,
+        "exp": now + MFA_TOKEN_EXP,
+    }
+    key = getattr(settings, "jwk_encryption_key", None) or "dev-secret"
+    return pyjwt.encode(payload, key, algorithm="HS256")
+
+
+def verify_mfa_token(token: str, settings: object) -> str | None:
+    """Verify an MFA challenge token.
+
+    Parameters
+    ----------
+    token : str
+        The MFA JWT token.
+    settings : Settings
+        Application settings.
+
+    Returns
+    -------
+    str or None
+        The user_id if valid, None if invalid/expired.
+    """
+    import jwt as pyjwt
+
+    key = getattr(settings, "jwk_encryption_key", None) or "dev-secret"
+    try:
+        payload = pyjwt.decode(token, key, algorithms=["HS256"])
+        if payload.get("purpose") != "mfa_challenge":
+            return None
+        return payload.get("sub")
+    except pyjwt.exceptions.PyJWTError:
+        return None
 
 
 @router.post("/logout", response_model=MessageResponse)

--- a/src/shomer/routes/mfa.py
+++ b/src/shomer/routes/mfa.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, HTTPException, Request, status
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from sqlalchemy import func, select
@@ -335,6 +335,128 @@ class MFAVerifyRequest(BaseModel):
 
     code: str
     method: str = "totp"
+
+
+class MFAChallengeRequest(BaseModel):
+    """Request body for the two-step MFA login challenge.
+
+    Attributes
+    ----------
+    mfa_token : str
+        Short-lived JWT from the login response.
+    code : str
+        TOTP code or backup code.
+    method : str
+        Verification method: ``totp`` or ``backup``.
+    """
+
+    mfa_token: str
+    code: str
+    method: str = "totp"
+
+
+@router.post("/verify-challenge")
+async def mfa_verify_challenge(
+    body: MFAChallengeRequest, request: Request, db: DbSession, config: Config
+) -> JSONResponse:
+    """Complete the two-step MFA login challenge.
+
+    Verifies the mfa_token (from login) and the MFA code, then creates
+    a session and returns session cookies.
+
+    Parameters
+    ----------
+    body : MFAChallengeRequest
+        MFA token, code, and method.
+    request : Request
+        FastAPI request (for client metadata and cookies).
+    db : DbSession
+        Database session.
+    config : Config
+        Application settings.
+
+    Returns
+    -------
+    JSONResponse
+        Login confirmation with session cookie.
+    """
+    from shomer.routes.auth import verify_mfa_token
+
+    user_id_str = verify_mfa_token(body.mfa_token, config)
+    if user_id_str is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired MFA token.",
+        )
+
+    import uuid
+
+    user_id = uuid.UUID(user_id_str)
+
+    # Look up user MFA
+    mfa = await _get_user_mfa(db, user_id)
+    if mfa is None or not mfa.is_enabled:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="MFA is not enabled for this user.",
+        )
+
+    svc = MFAService(db, config)
+
+    # Verify the code
+    if body.method == "backup":
+        valid = await svc.verify_backup_code(mfa.id, body.code)
+        if not valid:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invalid backup code.",
+            )
+    else:
+        secret = svc.decrypt_totp_secret(mfa.totp_secret_encrypted or "")
+        if not MFAService.verify_totp_code(secret, body.code):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invalid TOTP code.",
+            )
+
+    # MFA verified — create session
+    from shomer.middleware.cookies import get_cookie_policy
+    from shomer.services.session_service import SessionService
+
+    session_svc = SessionService(db)
+    session, raw_token = await session_svc.create(
+        user_id=user_id,
+        user_agent=request.headers.get("user-agent"),
+        ip_address=request.client.host if request.client else None,
+    )
+    await db.flush()
+
+    policy = get_cookie_policy(config)
+    response = JSONResponse(
+        content={
+            "message": "MFA verification successful. Login complete.",
+            "user_id": user_id_str,
+        },
+    )
+    response.set_cookie(
+        key="session_id",
+        value=raw_token,
+        httponly=policy.httponly,
+        secure=policy.secure,
+        samesite=policy.samesite,
+        domain=policy.domain or None,
+        max_age=86400,
+    )
+    response.set_cookie(
+        key="csrf_token",
+        value=session.csrf_token,
+        httponly=False,
+        secure=policy.secure,
+        samesite=policy.samesite,
+        domain=policy.domain or None,
+        max_age=86400,
+    )
+    return response
 
 
 class EmailCodeRequest(BaseModel):

--- a/tests/routes/test_auth_unit.py
+++ b/tests/routes/test_auth_unit.py
@@ -13,6 +13,7 @@ import pytest
 from fastapi import HTTPException
 
 from shomer.routes.auth import (
+    _build_mfa_token,
     login,
     logout,
     password_change,
@@ -21,6 +22,7 @@ from shomer.routes.auth import (
     register,
     resend,
     verify,
+    verify_mfa_token,
 )
 from shomer.services.auth_service import (
     EmailNotFoundError,
@@ -170,7 +172,12 @@ class TestLoginRoute:
             mock_svc.login.return_value = (mock_user, mock_session, "raw-token")
             mock_cls.return_value = mock_svc
             body = MagicMock(email="a@b.com", password="pw")
-            resp = await login(body, _mock_request(), _mock_db())
+            # Mock MFA query to return no MFA
+            mock_mfa_result = MagicMock()
+            mock_mfa_result.scalar_one_or_none.return_value = None
+            db = AsyncMock()
+            db.execute.return_value = mock_mfa_result
+            resp = await login(body, _mock_request(), db)
             assert resp.status_code == 200
 
         asyncio.run(_run())
@@ -380,3 +387,136 @@ class TestPasswordChangeRoute:
             assert exc_info.value.status_code == 401
 
         asyncio.run(_run())
+
+
+class TestMFALoginChallenge:
+    """Unit tests for MFA two-step login challenge."""
+
+    def test_login_with_mfa_returns_mfa_required(self) -> None:
+        """Login with MFA-enabled user returns mfa_token."""
+
+        async def _run() -> None:
+            mock_user = MagicMock()
+            mock_user.id = uuid.uuid4()
+            mock_session = MagicMock()
+            mock_session.id = uuid.uuid4()
+            mock_session.csrf_token = "csrf"
+
+            mock_mfa = MagicMock()
+            mock_mfa.is_enabled = True
+            mock_mfa.methods = ["totp", "backup"]
+
+            mock_mfa_result = MagicMock()
+            mock_mfa_result.scalar_one_or_none.return_value = mock_mfa
+
+            with (
+                patch("shomer.routes.auth.AuthService") as mock_auth_cls,
+                patch("shomer.routes.auth.SessionService") as mock_sess_cls,
+            ):
+                mock_auth = AsyncMock()
+                mock_auth.login.return_value = (mock_user, mock_session, "tok")
+                mock_auth_cls.return_value = mock_auth
+
+                mock_sess_svc = AsyncMock()
+                mock_sess_cls.return_value = mock_sess_svc
+
+                body = MagicMock(email="u@b.com", password="pw")
+                req = MagicMock()
+                req.headers.get.return_value = "ua"
+                req.client.host = "127.0.0.1"
+
+                db = AsyncMock()
+                db.execute.return_value = mock_mfa_result
+
+                resp = await login(body, req, db)
+                import json
+
+                data = json.loads(bytes(resp.body))
+                assert data["mfa_required"] is True
+                assert "mfa_token" in data
+                assert "totp" in data["methods"]
+                mock_sess_svc.delete.assert_awaited_once_with(mock_session.id)
+
+        asyncio.run(_run())
+
+    def test_login_without_mfa_returns_session(self) -> None:
+        """Login without MFA returns normal session."""
+
+        async def _run() -> None:
+            mock_user = MagicMock()
+            mock_user.id = uuid.uuid4()
+            mock_session = MagicMock()
+            mock_session.csrf_token = "csrf"
+
+            mock_mfa_result = MagicMock()
+            mock_mfa_result.scalar_one_or_none.return_value = None
+
+            with patch("shomer.routes.auth.AuthService") as mock_auth_cls:
+                mock_auth = AsyncMock()
+                mock_auth.login.return_value = (mock_user, mock_session, "tok")
+                mock_auth_cls.return_value = mock_auth
+
+                body = MagicMock(email="u@b.com", password="pw")
+                req = MagicMock()
+                req.headers.get.return_value = "ua"
+                req.client.host = "127.0.0.1"
+
+                db = AsyncMock()
+                db.execute.return_value = mock_mfa_result
+
+                resp = await login(body, req, db)
+                import json
+
+                data = json.loads(bytes(resp.body))
+                assert data["message"] == "Login successful"
+                assert "mfa_required" not in data
+
+        asyncio.run(_run())
+
+
+class TestMFATokenHelpers:
+    """Unit tests for MFA token build/verify."""
+
+    def test_build_and_verify_roundtrip(self) -> None:
+        settings = MagicMock()
+        settings.jwk_encryption_key = "test-key"
+        token = _build_mfa_token("user-123", settings)
+        result = verify_mfa_token(token, settings)
+        assert result == "user-123"
+
+    def test_verify_expired_token(self) -> None:
+        import time
+
+        import jwt as pyjwt
+
+        payload = {
+            "sub": "user-123",
+            "purpose": "mfa_challenge",
+            "iat": int(time.time()) - 600,
+            "exp": int(time.time()) - 300,
+        }
+        token = pyjwt.encode(payload, "test-key", algorithm="HS256")
+        settings = MagicMock()
+        settings.jwk_encryption_key = "test-key"
+        assert verify_mfa_token(token, settings) is None
+
+    def test_verify_wrong_purpose(self) -> None:
+        import time
+
+        import jwt as pyjwt
+
+        payload = {
+            "sub": "user-123",
+            "purpose": "wrong",
+            "iat": int(time.time()),
+            "exp": int(time.time()) + 300,
+        }
+        token = pyjwt.encode(payload, "test-key", algorithm="HS256")
+        settings = MagicMock()
+        settings.jwk_encryption_key = "test-key"
+        assert verify_mfa_token(token, settings) is None
+
+    def test_verify_invalid_token(self) -> None:
+        settings = MagicMock()
+        settings.jwk_encryption_key = "test-key"
+        assert verify_mfa_token("garbage", settings) is None


### PR DESCRIPTION
## feat(auth): two-step MFA challenge in POST /auth/login

## Summary

Modify login to support MFA in two steps: if MFA is enabled, return a temporary mfa_token instead of creating a session. POST /mfa/verify-challenge accepts the mfa_token + TOTP/backup code and creates the session.

## Changes

- [x] Check if user has MFA enabled after password verification
- [x] If MFA enabled: return mfa_token (short-lived JWT) + mfa_required flag
- [x] Do NOT create session until MFA is verified
- [x] POST `/mfa/verify-challenge` accepts mfa_token, verifies MFA code, creates session
- [x] mfa_token expiration (5 minutes)
- [x] Integration tests (login with MFA, login without MFA)

## Dependencies

- #19 - login endpoint
- #65 - MFA service

## Related Issue

Closes #68

## Test Plan

- [x] `make format` - code formatted
- [x] `make lint` - no linting errors
- [x] `make typecheck` - type checks pass
- [x] `make test` - all unit tests pass
- [x] `make bdd` - all BDD tests pass
- [x] `make check-license` - SPDX headers present
