### PR TITLE
feat(oauth2): MFA support in grant_type=password

### DIFF
--- a/features/oauth2_password_mfa.feature
+++ b/features/oauth2_password_mfa.feature
@@ -1,0 +1,35 @@
+Feature: OAuth2 password grant with MFA support
+
+  Scenario: Password grant without MFA works normally
+    Given a verified user and an OAuth2 client with all grants
+    When I send a form POST to "/oauth2/token" with
+      """
+      {"grant_type": "password", "username": "token-bdd@example.com", "password": "securepassword123", "client_id": "bdd-full-client", "client_secret": "bdd-test-secret-value", "scope": "openid profile"}
+      """
+    Then the response status code should be 200
+    And the response should have JSON key "access_token"
+
+  Scenario: Password grant with MFA enabled returns mfa_required
+    Given a user with MFA enabled and an OAuth2 client
+    When I send a form POST to "/oauth2/token" with
+      """
+      {"grant_type": "password", "username": "${mfa_user_email}", "password": "securepassword123", "client_id": "bdd-full-client", "client_secret": "bdd-test-secret-value", "scope": "openid"}
+      """
+    Then the response status code should be 403
+    And the response body should contain "mfa_required"
+    And the response should have JSON key "mfa_token"
+
+  Scenario: Password grant MFA completion with TOTP code returns tokens
+    Given a user with MFA enabled and an OAuth2 client
+    When I send a form POST to "/oauth2/token" with
+      """
+      {"grant_type": "password", "username": "${mfa_user_email}", "password": "securepassword123", "client_id": "bdd-full-client", "client_secret": "bdd-test-secret-value", "scope": "openid"}
+      """
+    Then the response status code should be 403
+    When I send a form POST to "/oauth2/token" with
+      """
+      {"grant_type": "password", "mfa_token": "${mfa_login_token}", "mfa_code": "${mfa_totp_code}", "client_id": "bdd-full-client", "client_secret": "bdd-test-secret-value", "scope": "openid"}
+      """
+    Then the response status code should be 200
+    And the response should have JSON key "access_token"
+    And the response should have JSON key "refresh_token"

--- a/features/steps/http_steps.py
+++ b/features/steps/http_steps.py
@@ -164,6 +164,7 @@ def _send_form(context, path, form_data):
         context.response = None
         context.response_status = 0
         context.response_body = str(e)
+    _capture_mfa_token(context)
 
 
 @when('I send a form POST to "{path}" with')

--- a/features/steps/mfa_steps.py
+++ b/features/steps/mfa_steps.py
@@ -97,3 +97,52 @@ def step_setup_user_with_mfa(context):
     assert enable_body["mfa_enabled"] is True
     context.mfa_backup_codes = enable_body.get("backup_codes", [])
     context.mfa_user_email = email
+
+
+@given("a user with MFA enabled and an OAuth2 client")
+def step_setup_user_mfa_and_client(context):
+    """Create a user with MFA enabled and ensure the BDD OAuth2 client exists.
+
+    Combines the MFA user setup with the OAuth2 client from
+    ``a verified user and an OAuth2 client with all grants``.
+    """
+    # First create the OAuth2 client (reuse the existing step)
+    from features.steps.oauth2_steps import step_setup_oauth2_full
+
+    step_setup_oauth2_full(context)
+
+    # Now create the MFA user using the same password
+    email = context.oauth2_user_email  # token-bdd@example.com
+    password = context.oauth2_user_password  # securepassword123
+
+    # Log in to get session cookie
+    login_data = json.dumps({"email": email, "password": password}).encode()
+    login_req = urllib.request.Request(
+        context.base_url + "/auth/login",
+        data=login_data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        login_resp = urllib.request.urlopen(login_req, timeout=10)
+        cookies = login_resp.headers.get_all("Set-Cookie") or []
+        for cookie in cookies:
+            if "session_id=" in cookie:
+                value = cookie.split("session_id=")[1].split(";")[0]
+                if value and value != '""':
+                    context.session_cookie = value
+    except urllib.error.HTTPError:
+        pass
+
+    # Setup MFA
+    status_code, setup_body = _mfa_api(context, "POST", "/mfa/setup")
+    assert status_code == 200, f"MFA setup failed: {status_code} {setup_body}"
+    context.mfa_totp_secret = setup_body["secret"]
+
+    totp_code = _generate_totp_code(context.mfa_totp_secret)
+    status_code, enable_body = _mfa_api(
+        context, "POST", "/mfa/enable", {"code": totp_code}
+    )
+    assert status_code == 200, f"MFA enable failed: {status_code} {enable_body}"
+    context.mfa_backup_codes = enable_body.get("backup_codes", [])
+    context.mfa_user_email = email

--- a/src/shomer/routes/oauth2.py
+++ b/src/shomer/routes/oauth2.py
@@ -483,6 +483,8 @@ async def token(
     actor_token: str = Form(""),
     actor_token_type: str = Form(""),
     audience: str = Form(""),
+    mfa_token: str = Form(""),
+    mfa_code: str = Form(""),
 ) -> JSONResponse:
     """OAuth2 token endpoint per RFC 6749 §4.1.3, §4.3, §4.4, §6, RFC 8628, and RFC 8693.
 
@@ -578,7 +580,15 @@ async def token(
 
     if grant_type == "password":
         return await _handle_password_grant(
-            token_svc, authenticated_client, username, password, scope
+            token_svc,
+            authenticated_client,
+            username,
+            password,
+            scope,
+            mfa_token,
+            mfa_code,
+            db,
+            settings,
         )
 
     if grant_type == "refresh_token":
@@ -702,8 +712,16 @@ async def _handle_password_grant(
     username: str,
     password: str,
     scope: str,
+    mfa_token: str = "",
+    mfa_code: str = "",
+    db: Any = None,
+    settings: Any = None,
 ) -> JSONResponse:
     """Handle resource owner password credentials grant per RFC 6749 §4.3.
+
+    Supports MFA: if the user has MFA enabled and no ``mfa_code`` is
+    provided, returns ``error=mfa_required`` with a short-lived
+    ``mfa_token``. The client must resend with ``mfa_token`` + ``mfa_code``.
 
     Parameters
     ----------
@@ -717,6 +735,14 @@ async def _handle_password_grant(
         Resource owner password.
     scope : str
         Requested scopes (space-separated).
+    mfa_token : str
+        MFA challenge token (second request).
+    mfa_code : str
+        TOTP or backup code (second request).
+    db : AsyncSession
+        Database session.
+    settings : Settings
+        Application settings.
 
     Returns
     -------
@@ -733,6 +759,12 @@ async def _handle_password_grant(
             },
         )
 
+    # Step 2: MFA completion (mfa_token + mfa_code provided)
+    if mfa_token and mfa_code:
+        return await _complete_password_mfa(
+            token_svc, client, mfa_token, mfa_code, scope, db, settings
+        )
+
     if not username or not password:
         return JSONResponse(
             status_code=400,
@@ -742,6 +774,7 @@ async def _handle_password_grant(
             },
         )
 
+    # Step 1: Verify password, then check MFA
     try:
         response = await token_svc.issue_password_grant(
             username=username,
@@ -757,6 +790,172 @@ async def _handle_password_grant(
                 "error_description": exc.description,
             },
         )
+
+    # Check if user has MFA enabled
+    if db is not None:
+        from sqlalchemy import select
+
+        from shomer.models.queries import get_user_by_email
+        from shomer.models.user_mfa import UserMFA
+
+        user = await get_user_by_email(db, username)
+        if user is not None:
+            mfa_stmt = select(UserMFA).where(UserMFA.user_id == user.id)
+            mfa_result = await db.execute(mfa_stmt)
+            user_mfa = mfa_result.scalar_one_or_none()
+
+            if user_mfa is not None and user_mfa.is_enabled:
+                # MFA required: return challenge instead of tokens
+                from shomer.routes.auth import _build_mfa_token
+
+                mfa_challenge_token = _build_mfa_token(str(user.id), settings)
+                return JSONResponse(
+                    status_code=403,
+                    content={
+                        "error": "mfa_required",
+                        "error_description": "MFA verification required",
+                        "mfa_token": mfa_challenge_token,
+                        "methods": user_mfa.methods,
+                    },
+                )
+
+    return JSONResponse(
+        content=response.to_dict(),
+        headers={"Cache-Control": "no-store", "Pragma": "no-cache"},
+    )
+
+
+async def _complete_password_mfa(
+    token_svc: TokenService,
+    client: Any,
+    mfa_token: str,
+    mfa_code: str,
+    scope: str,
+    db: Any,
+    settings: Any,
+) -> JSONResponse:
+    """Complete the MFA step of a password grant.
+
+    Parameters
+    ----------
+    token_svc : TokenService
+        Token service instance.
+    client : OAuth2Client
+        The authenticated client.
+    mfa_token : str
+        The MFA challenge JWT.
+    mfa_code : str
+        TOTP or backup code.
+    scope : str
+        Requested scopes.
+    db : AsyncSession
+        Database session.
+    settings : Settings
+        Application settings.
+
+    Returns
+    -------
+    JSONResponse
+        Token response or error.
+    """
+    from shomer.routes.auth import verify_mfa_token
+
+    user_id_str = verify_mfa_token(mfa_token, settings)
+    if user_id_str is None:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error": "invalid_grant",
+                "error_description": "Invalid or expired MFA token",
+            },
+        )
+
+    import uuid
+
+    from sqlalchemy import select
+
+    from shomer.models.user_mfa import UserMFA
+    from shomer.services.mfa_service import MFAService
+
+    user_id = uuid.UUID(user_id_str)
+
+    mfa_stmt = select(UserMFA).where(UserMFA.user_id == user_id)
+    mfa_result = await db.execute(mfa_stmt)
+    user_mfa = mfa_result.scalar_one_or_none()
+
+    if user_mfa is None or not user_mfa.is_enabled:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error": "invalid_grant",
+                "error_description": "MFA is not enabled",
+            },
+        )
+
+    # Verify TOTP code
+    svc = MFAService(db, settings)
+    secret = svc.decrypt_totp_secret(user_mfa.totp_secret_encrypted or "")
+    if not MFAService.verify_totp_code(secret, mfa_code):
+        # Try backup code
+        backup_valid = await svc.verify_backup_code(user_mfa.id, mfa_code)
+        if not backup_valid:
+            return JSONResponse(
+                status_code=400,
+                content={
+                    "error": "invalid_grant",
+                    "error_description": "Invalid MFA code",
+                },
+            )
+
+    # MFA verified — issue tokens for the user
+    import hashlib
+
+    from shomer.models.access_token import AccessToken
+    from shomer.models.refresh_token import RefreshToken
+
+    now = __import__("datetime").datetime.now(__import__("datetime").timezone.utc)
+    jti = uuid.uuid4().hex
+    scopes = (scope or "").split() if scope else []
+
+    access_token_record = AccessToken(
+        jti=jti,
+        user_id=user_id,
+        client_id=client.client_id,
+        scopes=" ".join(scopes),
+        expires_at=now
+        + __import__("datetime").timedelta(seconds=settings.jwt_access_token_exp),
+    )
+    db.add(access_token_record)
+
+    raw_refresh = uuid.uuid4().hex
+    refresh_hash = hashlib.sha256(raw_refresh.encode()).hexdigest()
+    family_id = uuid.uuid4()
+    refresh_record = RefreshToken(
+        token_hash=refresh_hash,
+        family_id=family_id,
+        user_id=user_id,
+        client_id=client.client_id,
+        scopes=" ".join(scopes),
+        expires_at=now + __import__("datetime").timedelta(days=30),
+    )
+    db.add(refresh_record)
+    await db.flush()
+
+    access_jwt = token_svc._build_access_jwt(
+        sub=user_id_str,
+        aud=client.client_id,
+        jti=jti,
+        scopes=scopes,
+    )
+
+    from shomer.services.token_service import TokenResponse
+
+    response = TokenResponse(
+        access_token=access_jwt,
+        expires_in=settings.jwt_access_token_exp,
+        refresh_token=raw_refresh,
+        scope=" ".join(scopes),
+    )
 
     return JSONResponse(
         content=response.to_dict(),

--- a/tests/routes/test_oauth2_unit.py
+++ b/tests/routes/test_oauth2_unit.py
@@ -154,6 +154,124 @@ class TestHandlePasswordGrant:
 
         asyncio.run(_run())
 
+    def test_mfa_required_returns_403(self) -> None:
+        """User with MFA enabled gets mfa_required error."""
+
+        async def _run() -> None:
+            client = _mock_client(grant_types=["password"])
+            svc = AsyncMock()
+            svc.issue_password_grant.return_value = TokenResponse(access_token="tok")
+
+            mock_user = MagicMock()
+            mock_user.id = "00000000-0000-0000-0000-000000000001"
+
+            mock_mfa = MagicMock()
+            mock_mfa.is_enabled = True
+            mock_mfa.methods = ["totp"]
+            mock_mfa_result = MagicMock()
+            mock_mfa_result.scalar_one_or_none.return_value = mock_mfa
+
+            db = AsyncMock()
+            db.execute.return_value = mock_mfa_result
+
+            settings = MagicMock()
+            settings.jwk_encryption_key = "test-key"
+
+            with patch(
+                "shomer.models.queries.get_user_by_email",
+                new_callable=AsyncMock,
+                return_value=mock_user,
+            ):
+                resp = await _handle_password_grant(
+                    svc, client, "u@b.com", "pw", "", "", "", db, settings
+                )
+            assert resp.status_code == 403
+            import json
+
+            body = json.loads(bytes(resp.body))
+            assert body["error"] == "mfa_required"
+            assert "mfa_token" in body
+
+        asyncio.run(_run())
+
+    def test_mfa_completion_with_valid_code(self) -> None:
+        """Second request with mfa_token + mfa_code issues tokens."""
+
+        async def _run() -> None:
+            client = _mock_client(grant_types=["password"])
+            client.client_id = "c"
+            svc = MagicMock()
+            svc._build_access_jwt.return_value = "new-jwt"
+
+            settings = MagicMock()
+            settings.jwk_encryption_key = "test-key"
+            settings.jwt_access_token_exp = 3600
+
+            # Build a valid mfa_token
+            from shomer.routes.auth import _build_mfa_token
+
+            mfa_tok = _build_mfa_token("00000000-0000-0000-0000-000000000001", settings)
+
+            mock_mfa = MagicMock()
+            mock_mfa.is_enabled = True
+            mock_mfa.totp_secret_encrypted = "enc"
+            mock_mfa.id = "mfa-id"
+            mock_mfa_result = MagicMock()
+            mock_mfa_result.scalar_one_or_none.return_value = mock_mfa
+
+            db = AsyncMock()
+            db.execute.return_value = mock_mfa_result
+
+            with patch("shomer.services.mfa_service.MFAService") as mock_mfa_cls:
+                mock_mfa_svc = MagicMock()
+                mock_mfa_svc.decrypt_totp_secret.return_value = "SECRET"
+                mock_mfa_cls.return_value = mock_mfa_svc
+                mock_mfa_cls.verify_totp_code.return_value = True
+
+                resp = await _handle_password_grant(
+                    svc,
+                    client,
+                    "",
+                    "",
+                    "openid",
+                    mfa_tok,
+                    "123456",
+                    db,
+                    settings,
+                )
+            assert resp.status_code == 200
+            import json
+
+            body = json.loads(bytes(resp.body))
+            assert body["access_token"] == "new-jwt"
+
+        asyncio.run(_run())
+
+    def test_mfa_completion_invalid_token(self) -> None:
+        """Invalid mfa_token returns error."""
+
+        async def _run() -> None:
+            client = _mock_client(grant_types=["password"])
+            settings = MagicMock()
+            settings.jwk_encryption_key = "test-key"
+            svc = AsyncMock()
+
+            resp = await _handle_password_grant(
+                svc,
+                client,
+                "",
+                "",
+                "",
+                "bad-token",
+                "123456",
+                AsyncMock(),
+                settings,
+            )
+            assert resp.status_code == 400
+            assert b"invalid_grant" in resp.body
+
+        asyncio.run(_run())
+
 
 class TestAuthorizeRoute:
     """Unit tests for GET /oauth2/authorize."""


### PR DESCRIPTION
## feat(oauth2): MFA support in grant_type=password

## Summary

Modify the password grant to support MFA: if MFA is enabled, return error=mfa_required with an mfa_token. The client must resend with mfa_token + mfa_code to complete authentication.

## Changes

- [x] Check MFA status after password verification in password grant
- [x] Return error=mfa_required + mfa_token if MFA enabled
- [x] Accept mfa_token + mfa_code parameters for MFA completion
- [x] Issue tokens only after MFA verification
- [x] Integration tests

## Dependencies

- #35 - password grant
- #65 - MFA service

## Related Issue

Closes #69

## Test Plan

- [x] `make format` - code formatted
- [x] `make lint` - no linting errors
- [x] `make typecheck` - type checks pass
- [x] `make test` - all unit tests pass
- [x] `make bdd` - all BDD tests pass
- [x] `make check-license` - SPDX headers present
