### PR TITLE
feat(rbac): permission evaluation service (wildcard, expiration)

### DIFF
--- a/src/shomer/services/rbac_service.py
+++ b/src/shomer/services/rbac_service.py
@@ -1,0 +1,214 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""RBAC permission evaluation service.
+
+Resolves user roles, collects scopes, and evaluates permissions
+with wildcard support and role expiration.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from shomer.models.role_scope import RoleScope
+from shomer.models.scope import Scope
+from shomer.models.user_role import UserRole
+
+
+class RBACService:
+    """Evaluate RBAC permissions for users.
+
+    Resolves roles assigned to a user (optionally scoped to a tenant),
+    collects all scopes from active (non-expired) roles, and checks
+    permissions with wildcard matching.
+
+    Attributes
+    ----------
+    session : AsyncSession
+        Database session.
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def get_user_roles(
+        self,
+        user_id: uuid.UUID,
+        tenant_id: uuid.UUID | None = None,
+    ) -> list[UserRole]:
+        """Resolve all active role assignments for a user.
+
+        Returns roles that are either global (``tenant_id IS NULL``) or
+        scoped to the given tenant. Expired roles are excluded.
+
+        Parameters
+        ----------
+        user_id : uuid.UUID
+            The user's ID.
+        tenant_id : uuid.UUID or None
+            Optional tenant scope. If provided, includes both global
+            and tenant-specific roles.
+
+        Returns
+        -------
+        list[UserRole]
+            Active role assignments.
+        """
+        now = datetime.now(timezone.utc)
+        stmt = select(UserRole).where(
+            UserRole.user_id == user_id,
+        )
+        result = await self.session.execute(stmt)
+        all_roles = result.scalars().all()
+
+        active: list[UserRole] = []
+        for ur in all_roles:
+            # Skip expired roles
+            if ur.expires_at is not None and ur.expires_at < now:
+                continue
+            # Include global roles (tenant_id is None) and tenant-specific
+            if ur.tenant_id is None or ur.tenant_id == tenant_id:
+                active.append(ur)
+        return active
+
+    async def get_user_scopes(
+        self,
+        user_id: uuid.UUID,
+        tenant_id: uuid.UUID | None = None,
+    ) -> set[str]:
+        """Collect all scope names from the user's active roles.
+
+        Parameters
+        ----------
+        user_id : uuid.UUID
+            The user's ID.
+        tenant_id : uuid.UUID or None
+            Optional tenant scope.
+
+        Returns
+        -------
+        set[str]
+            Set of scope names the user has.
+        """
+        user_roles = await self.get_user_roles(user_id, tenant_id)
+        if not user_roles:
+            return set()
+
+        role_ids = [ur.role_id for ur in user_roles]
+
+        # Get all scopes for these roles via RoleScope junction
+        stmt = (
+            select(Scope.name)
+            .join(RoleScope, RoleScope.scope_id == Scope.id)
+            .where(RoleScope.role_id.in_(role_ids))
+        )
+        result = await self.session.execute(stmt)
+        return {row[0] for row in result.all()}
+
+    async def has_permission(
+        self,
+        user_id: uuid.UUID,
+        scope: str,
+        tenant_id: uuid.UUID | None = None,
+    ) -> bool:
+        """Check if a user has a specific permission.
+
+        Supports wildcard matching: a user scope of ``admin:*`` matches
+        a required scope of ``admin:users:read``.
+
+        Parameters
+        ----------
+        user_id : uuid.UUID
+            The user's ID.
+        scope : str
+            The required scope (e.g. ``admin:users:read``).
+        tenant_id : uuid.UUID or None
+            Optional tenant scope.
+
+        Returns
+        -------
+        bool
+            ``True`` if the user has the required permission.
+        """
+        user_scopes = await self.get_user_scopes(user_id, tenant_id)
+        return self._matches_any(scope, user_scopes)
+
+    async def has_any_permission(
+        self,
+        user_id: uuid.UUID,
+        scopes: list[str],
+        tenant_id: uuid.UUID | None = None,
+    ) -> bool:
+        """Check if a user has at least one of the required permissions.
+
+        Parameters
+        ----------
+        user_id : uuid.UUID
+            The user's ID.
+        scopes : list[str]
+            Required scopes (at least one must match).
+        tenant_id : uuid.UUID or None
+            Optional tenant scope.
+
+        Returns
+        -------
+        bool
+            ``True`` if the user has at least one of the required scopes.
+        """
+        user_scopes = await self.get_user_scopes(user_id, tenant_id)
+        return any(self._matches_any(s, user_scopes) for s in scopes)
+
+    @staticmethod
+    def _matches_any(required: str, available: set[str]) -> bool:
+        """Check if a required scope matches any available scope.
+
+        Uses ``fnmatch``-style wildcard matching where ``*`` matches
+        any segment. For example, ``admin:*`` matches ``admin:users:read``.
+
+        Parameters
+        ----------
+        required : str
+            The scope to check.
+        available : set[str]
+            The user's available scopes (may contain wildcards).
+
+        Returns
+        -------
+        bool
+            ``True`` if any available scope matches the required one.
+        """
+        for scope in available:
+            if scope == required:
+                return True
+            # Wildcard matching: "admin:*" matches "admin:users:read"
+            if "*" in scope and fnmatch.fnmatch(required, scope):
+                return True
+        return False
+
+    @staticmethod
+    def scope_matches(pattern: str, scope: str) -> bool:
+        """Check if a scope pattern matches a specific scope.
+
+        Parameters
+        ----------
+        pattern : str
+            Scope pattern (may contain ``*`` wildcards).
+        scope : str
+            The scope to check against.
+
+        Returns
+        -------
+        bool
+            ``True`` if the pattern matches the scope.
+        """
+        if pattern == scope:
+            return True
+        if "*" in pattern:
+            return fnmatch.fnmatch(scope, pattern)
+        return False

--- a/tests/services/test_rbac_service.py
+++ b/tests/services/test_rbac_service.py
@@ -1,0 +1,328 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Unit tests for RBACService."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+from shomer.services.rbac_service import RBACService
+
+
+def _mock_user_role(
+    *,
+    role_id: uuid.UUID | None = None,
+    tenant_id: uuid.UUID | None = None,
+    expires_at: datetime | None = None,
+) -> MagicMock:
+    ur = MagicMock()
+    ur.role_id = role_id or uuid.uuid4()
+    ur.tenant_id = tenant_id
+    ur.expires_at = expires_at
+    return ur
+
+
+class TestGetUserRoles:
+    """Tests for resolving user roles."""
+
+    def test_returns_global_roles(self) -> None:
+        async def _run() -> None:
+            ur = _mock_user_role()
+            mock_result = MagicMock()
+            mock_result.scalars.return_value.all.return_value = [ur]
+            db = AsyncMock()
+            db.execute.return_value = mock_result
+
+            svc = RBACService(db)
+            roles = await svc.get_user_roles(uuid.uuid4())
+            assert len(roles) == 1
+
+        asyncio.run(_run())
+
+    def test_includes_tenant_specific_roles(self) -> None:
+        async def _run() -> None:
+            tid = uuid.uuid4()
+            global_role = _mock_user_role()
+            tenant_role = _mock_user_role(tenant_id=tid)
+            other_tenant = _mock_user_role(tenant_id=uuid.uuid4())
+
+            mock_result = MagicMock()
+            mock_result.scalars.return_value.all.return_value = [
+                global_role,
+                tenant_role,
+                other_tenant,
+            ]
+            db = AsyncMock()
+            db.execute.return_value = mock_result
+
+            svc = RBACService(db)
+            roles = await svc.get_user_roles(uuid.uuid4(), tenant_id=tid)
+            assert len(roles) == 2  # global + matching tenant
+
+        asyncio.run(_run())
+
+    def test_excludes_expired_roles(self) -> None:
+        async def _run() -> None:
+            expired = _mock_user_role(
+                expires_at=datetime.now(timezone.utc) - timedelta(hours=1)
+            )
+            active = _mock_user_role(
+                expires_at=datetime.now(timezone.utc) + timedelta(hours=1)
+            )
+            no_expiry = _mock_user_role()
+
+            mock_result = MagicMock()
+            mock_result.scalars.return_value.all.return_value = [
+                expired,
+                active,
+                no_expiry,
+            ]
+            db = AsyncMock()
+            db.execute.return_value = mock_result
+
+            svc = RBACService(db)
+            roles = await svc.get_user_roles(uuid.uuid4())
+            assert len(roles) == 2  # active + no_expiry
+
+        asyncio.run(_run())
+
+    def test_empty_when_no_roles(self) -> None:
+        async def _run() -> None:
+            mock_result = MagicMock()
+            mock_result.scalars.return_value.all.return_value = []
+            db = AsyncMock()
+            db.execute.return_value = mock_result
+
+            svc = RBACService(db)
+            roles = await svc.get_user_roles(uuid.uuid4())
+            assert roles == []
+
+        asyncio.run(_run())
+
+
+class TestGetUserScopes:
+    """Tests for collecting scopes from user roles."""
+
+    def test_returns_scopes_from_roles(self) -> None:
+        async def _run() -> None:
+            rid = uuid.uuid4()
+            ur = _mock_user_role(role_id=rid)
+
+            mock_roles_result = MagicMock()
+            mock_roles_result.scalars.return_value.all.return_value = [ur]
+
+            mock_scopes_result = MagicMock()
+            mock_scopes_result.all.return_value = [
+                ("admin:users:read",),
+                ("admin:users:write",),
+            ]
+
+            db = AsyncMock()
+            db.execute.side_effect = [mock_roles_result, mock_scopes_result]
+
+            svc = RBACService(db)
+            scopes = await svc.get_user_scopes(uuid.uuid4())
+            assert scopes == {"admin:users:read", "admin:users:write"}
+
+        asyncio.run(_run())
+
+    def test_empty_when_no_roles(self) -> None:
+        async def _run() -> None:
+            mock_result = MagicMock()
+            mock_result.scalars.return_value.all.return_value = []
+            db = AsyncMock()
+            db.execute.return_value = mock_result
+
+            svc = RBACService(db)
+            scopes = await svc.get_user_scopes(uuid.uuid4())
+            assert scopes == set()
+
+        asyncio.run(_run())
+
+
+class TestHasPermission:
+    """Tests for has_permission with wildcard support."""
+
+    def test_exact_match(self) -> None:
+        async def _run() -> None:
+            rid = uuid.uuid4()
+            ur = _mock_user_role(role_id=rid)
+
+            mock_roles_result = MagicMock()
+            mock_roles_result.scalars.return_value.all.return_value = [ur]
+            mock_scopes_result = MagicMock()
+            mock_scopes_result.all.return_value = [("admin:users:read",)]
+
+            db = AsyncMock()
+            db.execute.side_effect = [mock_roles_result, mock_scopes_result]
+
+            svc = RBACService(db)
+            assert await svc.has_permission(uuid.uuid4(), "admin:users:read") is True
+
+        asyncio.run(_run())
+
+    def test_wildcard_match(self) -> None:
+        async def _run() -> None:
+            rid = uuid.uuid4()
+            ur = _mock_user_role(role_id=rid)
+
+            mock_roles_result = MagicMock()
+            mock_roles_result.scalars.return_value.all.return_value = [ur]
+            mock_scopes_result = MagicMock()
+            mock_scopes_result.all.return_value = [("admin:*",)]
+
+            db = AsyncMock()
+            db.execute.side_effect = [mock_roles_result, mock_scopes_result]
+
+            svc = RBACService(db)
+            assert await svc.has_permission(uuid.uuid4(), "admin:users:read") is True
+
+        asyncio.run(_run())
+
+    def test_no_match(self) -> None:
+        async def _run() -> None:
+            rid = uuid.uuid4()
+            ur = _mock_user_role(role_id=rid)
+
+            mock_roles_result = MagicMock()
+            mock_roles_result.scalars.return_value.all.return_value = [ur]
+            mock_scopes_result = MagicMock()
+            mock_scopes_result.all.return_value = [("editor:posts:read",)]
+
+            db = AsyncMock()
+            db.execute.side_effect = [mock_roles_result, mock_scopes_result]
+
+            svc = RBACService(db)
+            assert await svc.has_permission(uuid.uuid4(), "admin:users:read") is False
+
+        asyncio.run(_run())
+
+    def test_star_matches_all(self) -> None:
+        async def _run() -> None:
+            rid = uuid.uuid4()
+            ur = _mock_user_role(role_id=rid)
+
+            mock_roles_result = MagicMock()
+            mock_roles_result.scalars.return_value.all.return_value = [ur]
+            mock_scopes_result = MagicMock()
+            mock_scopes_result.all.return_value = [("*",)]
+
+            db = AsyncMock()
+            db.execute.side_effect = [mock_roles_result, mock_scopes_result]
+
+            svc = RBACService(db)
+            assert await svc.has_permission(uuid.uuid4(), "anything:here") is True
+
+        asyncio.run(_run())
+
+    def test_expired_role_not_matched(self) -> None:
+        async def _run() -> None:
+            expired = _mock_user_role(
+                expires_at=datetime.now(timezone.utc) - timedelta(hours=1)
+            )
+
+            mock_roles_result = MagicMock()
+            mock_roles_result.scalars.return_value.all.return_value = [expired]
+
+            db = AsyncMock()
+            db.execute.return_value = mock_roles_result
+
+            svc = RBACService(db)
+            assert await svc.has_permission(uuid.uuid4(), "admin:users:read") is False
+
+        asyncio.run(_run())
+
+
+class TestHasAnyPermission:
+    """Tests for has_any_permission."""
+
+    def test_matches_one_of_many(self) -> None:
+        async def _run() -> None:
+            rid = uuid.uuid4()
+            ur = _mock_user_role(role_id=rid)
+
+            mock_roles_result = MagicMock()
+            mock_roles_result.scalars.return_value.all.return_value = [ur]
+            mock_scopes_result = MagicMock()
+            mock_scopes_result.all.return_value = [("editor:posts:write",)]
+
+            db = AsyncMock()
+            db.execute.side_effect = [mock_roles_result, mock_scopes_result]
+
+            svc = RBACService(db)
+            result = await svc.has_any_permission(
+                uuid.uuid4(),
+                ["admin:users:read", "editor:posts:write"],
+            )
+            assert result is True
+
+        asyncio.run(_run())
+
+    def test_no_match_returns_false(self) -> None:
+        async def _run() -> None:
+            rid = uuid.uuid4()
+            ur = _mock_user_role(role_id=rid)
+
+            mock_roles_result = MagicMock()
+            mock_roles_result.scalars.return_value.all.return_value = [ur]
+            mock_scopes_result = MagicMock()
+            mock_scopes_result.all.return_value = [("viewer:*",)]
+
+            db = AsyncMock()
+            db.execute.side_effect = [mock_roles_result, mock_scopes_result]
+
+            svc = RBACService(db)
+            result = await svc.has_any_permission(
+                uuid.uuid4(),
+                ["admin:users:read", "editor:posts:write"],
+            )
+            assert result is False
+
+        asyncio.run(_run())
+
+
+class TestScopeMatches:
+    """Tests for static scope_matches method."""
+
+    def test_exact_match(self) -> None:
+        assert RBACService.scope_matches("admin:users:read", "admin:users:read") is True
+
+    def test_no_match(self) -> None:
+        assert (
+            RBACService.scope_matches("admin:users:read", "admin:users:write") is False
+        )
+
+    def test_wildcard_star(self) -> None:
+        assert RBACService.scope_matches("admin:*", "admin:users:read") is True
+
+    def test_wildcard_all(self) -> None:
+        assert RBACService.scope_matches("*", "anything") is True
+
+    def test_wildcard_partial(self) -> None:
+        assert RBACService.scope_matches("admin:users:*", "admin:users:read") is True
+
+    def test_wildcard_no_match(self) -> None:
+        assert RBACService.scope_matches("editor:*", "admin:users:read") is False
+
+    def test_no_wildcard_no_match(self) -> None:
+        assert RBACService.scope_matches("admin", "admin:users") is False
+
+
+class TestMatchesAny:
+    """Tests for static _matches_any method."""
+
+    def test_exact(self) -> None:
+        assert RBACService._matches_any("a:b", {"a:b", "c:d"}) is True
+
+    def test_wildcard(self) -> None:
+        assert RBACService._matches_any("a:b:c", {"a:*"}) is True
+
+    def test_no_match(self) -> None:
+        assert RBACService._matches_any("x:y", {"a:b"}) is False
+
+    def test_empty_available(self) -> None:
+        assert RBACService._matches_any("a:b", set()) is False


### PR DESCRIPTION
## feat(rbac): permission evaluation service (wildcard, expiration)

## Summary

RBAC service for evaluating permissions: resolves user roles, checks scope membership with wildcard support (e.g., "admin:*" matches "admin:users:read"), respects role expiration.

## Changes

- [x] Resolve roles for user + tenant
- [x] Collect scopes from all active roles
- [x] Wildcard scope matching (e.g., "admin:*")
- [x] Role expiration check
- [x] `has_permission(user_id, scope, tenant_id)` method
- [x] `has_any_permission(user_id, scopes, tenant_id)` method
- [x] Unit tests with wildcard and expiration scenarios

## Dependencies

- #71 - RBAC models

## Related Issue

Closes #72

## Test Plan

- [x] `make format` - code formatted
- [x] `make lint` - no linting errors
- [x] `make typecheck` - type checks pass
- [x] `make test` - all unit tests pass
- [x] `make bdd` - all BDD tests pass
- [x] `make check-license` - SPDX headers present
