### PR TITLE
feat(rbac): RBAC authorization middleware

### DIFF
--- a/src/shomer/middleware/rbac.py
+++ b/src/shomer/middleware/rbac.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""RBAC authorization dependencies for route-level access control.
+
+Provides ``require_scope`` and ``require_any_scope`` dependency factories
+that check the current user's permissions via :class:`RBACService`.
+
+Usage::
+
+    from shomer.middleware.rbac import require_scope
+
+    @router.get("/admin/users", dependencies=[Depends(require_scope("admin:users:read"))])
+    async def list_users() -> dict: ...
+
+    # Or with require_any_scope:
+    @router.post("/content", dependencies=[Depends(require_any_scope(["editor:write", "admin:*"]))])
+    async def create_content() -> dict: ...
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Coroutine
+from typing import Any
+
+from fastapi import Depends, HTTPException, Request, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from shomer.auth import CurrentUserInfo
+from shomer.deps import get_db
+
+
+def require_scope(scope: str) -> Callable[..., Coroutine[Any, Any, None]]:
+    """Create a dependency that requires a specific RBAC scope.
+
+    Parameters
+    ----------
+    scope : str
+        The required scope (e.g. ``admin:users:read``).
+
+    Returns
+    -------
+    Callable
+        A FastAPI dependency that raises 403 if the user lacks the scope.
+
+    Examples
+    --------
+    ::
+
+        @router.get("/admin", dependencies=[Depends(require_scope("admin:read"))])
+        async def admin_page() -> dict: ...
+    """
+
+    async def _check(
+        request: Request,
+        db: AsyncSession = Depends(get_db),  # noqa: B008
+    ) -> None:
+        user = await _resolve_user(request, db)
+        from shomer.services.rbac_service import RBACService
+
+        svc = RBACService(db)
+        has = await svc.has_permission(
+            user_id=user.user_id,
+            scope=scope,
+            tenant_id=user.tenant_id,
+        )
+        if not has:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Insufficient permissions. Required scope: {scope}",
+            )
+
+    return _check
+
+
+def require_any_scope(scopes: list[str]) -> Callable[..., Coroutine[Any, Any, None]]:
+    """Create a dependency that requires at least one of the given scopes.
+
+    Parameters
+    ----------
+    scopes : list[str]
+        Required scopes (at least one must match).
+
+    Returns
+    -------
+    Callable
+        A FastAPI dependency that raises 403 if the user lacks all scopes.
+
+    Examples
+    --------
+    ::
+
+        @router.post("/content", dependencies=[Depends(require_any_scope(["editor:write", "admin:*"]))])
+        async def create() -> dict: ...
+    """
+
+    async def _check(
+        request: Request,
+        db: AsyncSession = Depends(get_db),  # noqa: B008
+    ) -> None:
+        user = await _resolve_user(request, db)
+        from shomer.services.rbac_service import RBACService
+
+        svc = RBACService(db)
+        has = await svc.has_any_permission(
+            user_id=user.user_id,
+            scopes=scopes,
+            tenant_id=user.tenant_id,
+        )
+        if not has:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Insufficient permissions. Required one of: {', '.join(scopes)}",
+            )
+
+    return _check
+
+
+async def _resolve_user(request: Request, db: AsyncSession) -> CurrentUserInfo:
+    """Resolve the current authenticated user.
+
+    Parameters
+    ----------
+    request : Request
+        The incoming HTTP request.
+    db : AsyncSession
+        Database session.
+
+    Returns
+    -------
+    CurrentUserInfo
+        The authenticated user context.
+
+    Raises
+    ------
+    HTTPException
+        401 if no user is authenticated.
+    """
+    from shomer.auth import get_current_user
+
+    return await get_current_user(request, db)

--- a/tests/middleware/test_rbac.py
+++ b/tests/middleware/test_rbac.py
@@ -1,0 +1,219 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Unit tests for RBAC middleware dependencies."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from shomer.middleware.rbac import require_any_scope, require_scope
+
+
+def _mock_user(
+    user_id: str = "00000000-0000-0000-0000-000000000001",
+    tenant_id: str | None = None,
+) -> MagicMock:
+    u = MagicMock()
+    u.user_id = uuid.UUID(user_id)
+    u.tenant_id = uuid.UUID(tenant_id) if tenant_id else None
+    return u
+
+
+class TestRequireScope:
+    """Tests for require_scope dependency."""
+
+    def test_allowed_passes(self) -> None:
+        """User with the required scope passes."""
+
+        async def _run() -> None:
+            dep = require_scope("admin:users:read")
+            mock_user = _mock_user()
+
+            with (
+                patch(
+                    "shomer.middleware.rbac._resolve_user",
+                    new_callable=AsyncMock,
+                    return_value=mock_user,
+                ),
+                patch("shomer.services.rbac_service.RBACService") as mock_cls,
+            ):
+                mock_svc = AsyncMock()
+                mock_svc.has_permission.return_value = True
+                mock_cls.return_value = mock_svc
+
+                await dep(MagicMock(), AsyncMock())
+                mock_svc.has_permission.assert_awaited_once()
+
+        asyncio.run(_run())
+
+    def test_denied_raises_403(self) -> None:
+        """User without the required scope gets 403."""
+
+        async def _run() -> None:
+            dep = require_scope("admin:users:delete")
+            mock_user = _mock_user()
+
+            with (
+                patch(
+                    "shomer.middleware.rbac._resolve_user",
+                    new_callable=AsyncMock,
+                    return_value=mock_user,
+                ),
+                patch("shomer.services.rbac_service.RBACService") as mock_cls,
+            ):
+                mock_svc = AsyncMock()
+                mock_svc.has_permission.return_value = False
+                mock_cls.return_value = mock_svc
+
+                with pytest.raises(HTTPException) as exc_info:
+                    await dep(MagicMock(), AsyncMock())
+                assert exc_info.value.status_code == 403
+                assert "admin:users:delete" in str(exc_info.value.detail)
+
+        asyncio.run(_run())
+
+    def test_passes_tenant_id(self) -> None:
+        """Tenant ID from user context is passed to RBAC service."""
+
+        async def _run() -> None:
+            dep = require_scope("api:read")
+            tid = "00000000-0000-0000-0000-000000000099"
+            mock_user = _mock_user(tenant_id=tid)
+
+            with (
+                patch(
+                    "shomer.middleware.rbac._resolve_user",
+                    new_callable=AsyncMock,
+                    return_value=mock_user,
+                ),
+                patch("shomer.services.rbac_service.RBACService") as mock_cls,
+            ):
+                mock_svc = AsyncMock()
+                mock_svc.has_permission.return_value = True
+                mock_cls.return_value = mock_svc
+
+                await dep(MagicMock(), AsyncMock())
+                call_kwargs = mock_svc.has_permission.call_args[1]
+                assert call_kwargs["tenant_id"] == uuid.UUID(tid)
+
+        asyncio.run(_run())
+
+
+class TestRequireAnyScope:
+    """Tests for require_any_scope dependency."""
+
+    def test_one_match_passes(self) -> None:
+        """User with at least one scope passes."""
+
+        async def _run() -> None:
+            dep = require_any_scope(["admin:read", "editor:write"])
+            mock_user = _mock_user()
+
+            with (
+                patch(
+                    "shomer.middleware.rbac._resolve_user",
+                    new_callable=AsyncMock,
+                    return_value=mock_user,
+                ),
+                patch("shomer.services.rbac_service.RBACService") as mock_cls,
+            ):
+                mock_svc = AsyncMock()
+                mock_svc.has_any_permission.return_value = True
+                mock_cls.return_value = mock_svc
+
+                await dep(MagicMock(), AsyncMock())
+
+        asyncio.run(_run())
+
+    def test_no_match_raises_403(self) -> None:
+        """User with no matching scope gets 403."""
+
+        async def _run() -> None:
+            dep = require_any_scope(["admin:read", "editor:write"])
+            mock_user = _mock_user()
+
+            with (
+                patch(
+                    "shomer.middleware.rbac._resolve_user",
+                    new_callable=AsyncMock,
+                    return_value=mock_user,
+                ),
+                patch("shomer.services.rbac_service.RBACService") as mock_cls,
+            ):
+                mock_svc = AsyncMock()
+                mock_svc.has_any_permission.return_value = False
+                mock_cls.return_value = mock_svc
+
+                with pytest.raises(HTTPException) as exc_info:
+                    await dep(MagicMock(), AsyncMock())
+                assert exc_info.value.status_code == 403
+                assert "admin:read" in str(exc_info.value.detail)
+
+        asyncio.run(_run())
+
+    def test_error_message_lists_scopes(self) -> None:
+        """403 error message lists all required scopes."""
+
+        async def _run() -> None:
+            dep = require_any_scope(["x:a", "y:b"])
+            mock_user = _mock_user()
+
+            with (
+                patch(
+                    "shomer.middleware.rbac._resolve_user",
+                    new_callable=AsyncMock,
+                    return_value=mock_user,
+                ),
+                patch("shomer.services.rbac_service.RBACService") as mock_cls,
+            ):
+                mock_svc = AsyncMock()
+                mock_svc.has_any_permission.return_value = False
+                mock_cls.return_value = mock_svc
+
+                with pytest.raises(HTTPException) as exc_info:
+                    await dep(MagicMock(), AsyncMock())
+                detail = str(exc_info.value.detail)
+                assert "x:a" in detail
+                assert "y:b" in detail
+
+        asyncio.run(_run())
+
+
+class TestResolveUser:
+    """Tests for _resolve_user helper."""
+
+    def test_unauthenticated_raises_401(self) -> None:
+        async def _run() -> None:
+            from shomer.middleware.rbac import _resolve_user
+
+            with patch(
+                "shomer.auth.get_current_user",
+                new_callable=AsyncMock,
+                side_effect=HTTPException(status_code=401, detail="Not authenticated"),
+            ):
+                with pytest.raises(HTTPException) as exc_info:
+                    await _resolve_user(MagicMock(), AsyncMock())
+                assert exc_info.value.status_code == 401
+
+        asyncio.run(_run())
+
+    def test_authenticated_returns_user(self) -> None:
+        async def _run() -> None:
+            from shomer.middleware.rbac import _resolve_user
+
+            mock_user = _mock_user()
+            with patch(
+                "shomer.auth.get_current_user",
+                new_callable=AsyncMock,
+                return_value=mock_user,
+            ):
+                result = await _resolve_user(MagicMock(), AsyncMock())
+                assert result.user_id == mock_user.user_id
+
+        asyncio.run(_run())


### PR DESCRIPTION
## feat(rbac): RBAC authorization middleware

## Summary

FastAPI middleware/dependency for route-level authorization. Checks that the current user has the required scope(s) for the requested route. Returns 403 on insufficient permissions.

## Changes

- [x] `require_scope("scope:name")` dependency
- [x] `require_any_scope(["scope:a", "scope:b"])` dependency
- [x] Integration with get_current_user
- [x] 403 Forbidden response with clear error message
- [x] Unit tests

## Dependencies

- #72 - permission evaluation service
- #20 - session service (for user context)

## Related Issue

Closes #73

## Test Plan

- [x] `make format` - code formatted
- [x] `make lint` - no linting errors
- [x] `make typecheck` - type checks pass
- [x] `make test` - all unit tests pass
- [x] `make bdd` - all BDD tests pass
- [x] `make check-license` - SPDX headers present
