### PR TITLE
feat(models): PersonalAccessToken (prefix shm_pat_)

### DIFF
--- a/alembic/versions/0018_add_personal_access_tokens.py
+++ b/alembic/versions/0018_add_personal_access_tokens.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Add personal_access_tokens table.
+
+Revision ID: 0018
+Revises: 0017
+Create Date: 2026-03-22
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0018"
+down_revision: Union[str, None] = "0017"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create personal_access_tokens table."""
+    op.create_table(
+        "personal_access_tokens",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("user_id", sa.Uuid(), nullable=False),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("token_prefix", sa.String(20), nullable=False),
+        sa.Column("token_hash", sa.String(64), nullable=False),
+        sa.Column("scopes", sa.Text(), nullable=False, server_default=""),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("is_revoked", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint("token_hash"),
+    )
+    op.create_index(
+        "ix_personal_access_tokens_user_id",
+        "personal_access_tokens",
+        ["user_id"],
+    )
+    op.create_index(
+        "ix_personal_access_tokens_token_hash",
+        "personal_access_tokens",
+        ["token_hash"],
+    )
+
+
+def downgrade() -> None:
+    """Drop personal_access_tokens table."""
+    op.drop_table("personal_access_tokens")

--- a/src/shomer/models/__init__.py
+++ b/src/shomer/models/__init__.py
@@ -16,6 +16,9 @@ from shomer.models.mfa_email_code import MFAEmailCode as MFAEmailCode
 from shomer.models.oauth2_client import OAuth2Client as OAuth2Client
 from shomer.models.par_request import PARRequest as PARRequest
 from shomer.models.password_reset_token import PasswordResetToken as PasswordResetToken
+from shomer.models.personal_access_token import (
+    PersonalAccessToken as PersonalAccessToken,
+)
 from shomer.models.refresh_token import RefreshToken as RefreshToken
 from shomer.models.role import Role as Role
 from shomer.models.role_scope import RoleScope as RoleScope

--- a/src/shomer/models/personal_access_token.py
+++ b/src/shomer/models/personal_access_token.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""PersonalAccessToken model for API key authentication."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+if TYPE_CHECKING:
+    from shomer.models.user import User
+
+from shomer.core.database import Base, TimestampMixin, UUIDMixin
+
+#: Token prefix for easy identification in logs and revocation.
+PAT_PREFIX = "shm_pat_"
+
+
+class PersonalAccessToken(Base, UUIDMixin, TimestampMixin):
+    """Personal Access Token for programmatic API access.
+
+    Tokens are prefixed with ``shm_pat_`` for easy identification.
+    Only the hash of the token value is stored; the raw token is
+    shown once at creation time.
+
+    Attributes
+    ----------
+    id : uuid.UUID
+        Primary key (from UUIDMixin).
+    user_id : uuid.UUID
+        Foreign key to the token owner.
+    name : str
+        Human-readable label (e.g. ``"CI deploy key"``).
+    token_prefix : str
+        First 8 characters of the token (``shm_pat_...``) for display.
+    token_hash : str
+        SHA-256 hash of the full token for lookup and verification.
+    scopes : str
+        Space-separated scopes granted to this token.
+    expires_at : datetime or None
+        Optional expiration. ``None`` means non-expiring.
+    last_used_at : datetime or None
+        Timestamp of the last API call using this token.
+    is_revoked : bool
+        Whether the token has been revoked.
+    user : User
+        The token owner.
+    created_at : datetime
+        Row creation timestamp (from TimestampMixin).
+    updated_at : datetime
+        Last update timestamp (from TimestampMixin).
+    """
+
+    __tablename__ = "personal_access_tokens"
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    name: Mapped[str] = mapped_column(
+        String(255),
+        nullable=False,
+    )
+    token_prefix: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+    )
+    token_hash: Mapped[str] = mapped_column(
+        String(64),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    scopes: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+        default="",
+    )
+    expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+    last_used_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+    is_revoked: Mapped[bool] = mapped_column(
+        Boolean,
+        default=False,
+        nullable=False,
+    )
+
+    # Relationships
+    user: Mapped[User] = relationship()
+
+    def __repr__(self) -> str:
+        return f"<PersonalAccessToken name={self.name} prefix={self.token_prefix}>"

--- a/tests/models/test_personal_access_token.py
+++ b/tests/models/test_personal_access_token.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Unit tests for PersonalAccessToken model."""
+
+import uuid
+from datetime import datetime, timezone
+
+from shomer.models.personal_access_token import PAT_PREFIX, PersonalAccessToken
+
+
+class TestPersonalAccessTokenModel:
+    """Tests for PersonalAccessToken SQLAlchemy model definition."""
+
+    def test_tablename(self) -> None:
+        assert PersonalAccessToken.__tablename__ == "personal_access_tokens"
+
+    def test_required_fields(self) -> None:
+        uid = uuid.uuid4()
+        pat = PersonalAccessToken(
+            user_id=uid,
+            name="CI deploy key",
+            token_prefix="shm_pat_ab",
+            token_hash="a" * 64,
+            scopes="api:read api:write",
+            is_revoked=False,
+        )
+        assert pat.user_id == uid
+        assert pat.name == "CI deploy key"
+        assert pat.token_prefix == "shm_pat_ab"
+        assert pat.token_hash == "a" * 64
+        assert pat.scopes == "api:read api:write"
+        assert pat.is_revoked is False
+        assert pat.expires_at is None
+        assert pat.last_used_at is None
+
+    def test_token_hash_unique(self) -> None:
+        col = PersonalAccessToken.__table__.c.token_hash
+        assert col.unique is True
+
+    def test_token_hash_indexed(self) -> None:
+        col = PersonalAccessToken.__table__.c.token_hash
+        assert col.index is True
+
+    def test_user_id_indexed(self) -> None:
+        col = PersonalAccessToken.__table__.c.user_id
+        assert col.index is True
+
+    def test_with_expiration(self) -> None:
+        now = datetime.now(timezone.utc)
+        pat = PersonalAccessToken(
+            user_id=uuid.uuid4(),
+            name="temp key",
+            token_prefix="shm_pat_cd",
+            token_hash="b" * 64,
+            scopes="",
+            expires_at=now,
+            is_revoked=False,
+        )
+        assert pat.expires_at == now
+
+    def test_with_last_used(self) -> None:
+        now = datetime.now(timezone.utc)
+        pat = PersonalAccessToken(
+            user_id=uuid.uuid4(),
+            name="active key",
+            token_prefix="shm_pat_ef",
+            token_hash="c" * 64,
+            scopes="api:read",
+            last_used_at=now,
+            is_revoked=False,
+        )
+        assert pat.last_used_at == now
+
+    def test_pat_prefix_constant(self) -> None:
+        assert PAT_PREFIX == "shm_pat_"
+
+    def test_repr(self) -> None:
+        pat = PersonalAccessToken(
+            user_id=uuid.uuid4(),
+            name="my-key",
+            token_prefix="shm_pat_gh",
+            token_hash="d" * 64,
+            scopes="",
+            is_revoked=False,
+        )
+        r = repr(pat)
+        assert "my-key" in r
+        assert "shm_pat_gh" in r
+
+    def test_revoked_token(self) -> None:
+        pat = PersonalAccessToken(
+            user_id=uuid.uuid4(),
+            name="revoked",
+            token_prefix="shm_pat_ij",
+            token_hash="e" * 64,
+            scopes="",
+            is_revoked=True,
+        )
+        assert pat.is_revoked is True


### PR DESCRIPTION
## feat(models): PersonalAccessToken (prefix shm_pat_)

## Summary

PersonalAccessToken model with shm_pat_ prefix, hashed token value, name, scopes, expiration, last_used_at tracking.

## Changes

- [x] PersonalAccessToken model (name, token_prefix, token_hash, scopes, expires_at, last_used_at, user_id)
- [x] Token prefix: `shm_pat_` for easy identification
- [x] Index on token_hash for fast lookup
- [x] Alembic migration

## Dependencies

- #4 - User model

## Related Issue

Closes #74

## Test Plan

- [x] `make format` - code formatted
- [x] `make lint` - no linting errors
- [x] `make typecheck` - type checks pass
- [x] `make test` - all unit tests pass
- [x] `make bdd` - all BDD tests pass
- [x] `make check-license` - SPDX headers present
