### PR TITLE
fix(bdd): stabilize flaky BDD tests (email timing)

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -46,8 +46,52 @@ def before_all(context):
             pass
         time.sleep(1)
 
+    # Warm up the Celery worker by sending a dummy registration
+    # and waiting for the email to arrive in MailCatcher.
+    _warmup_celery_worker(context.base_url)
+
     context.playwright = sync_playwright().start()
     context.browser = context.playwright.chromium.launch(headless=True)
+
+
+def _warmup_celery_worker(base_url):
+    """Send a dummy registration to ensure Celery worker is processing tasks."""
+    import json
+
+    data = json.dumps({
+        "email": "warmup-probe@example.com",
+        "password": "warmup12345678",
+    }).encode()
+    req = urllib.request.Request(
+        base_url + "/auth/register",
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        urllib.request.urlopen(req, timeout=10)
+    except Exception:
+        pass
+
+    # Wait for the email to arrive (proves the worker is warm)
+    for _ in range(30):
+        try:
+            resp = urllib.request.urlopen(
+                MAILCATCHER_URL + "/messages", timeout=5
+            )
+            messages = json.loads(resp.read().decode())
+            if messages:
+                break
+        except Exception:
+            pass
+        time.sleep(1)
+
+    # Clear the warmup email
+    try:
+        req = urllib.request.Request(MAILCATCHER_URL + "/messages", method="DELETE")
+        urllib.request.urlopen(req, timeout=2)
+    except Exception:
+        pass
 
 
 def after_all(context):

--- a/features/steps/mail_steps.py
+++ b/features/steps/mail_steps.py
@@ -141,12 +141,18 @@ def register_and_verify_user(context, email, password):
     except urllib.error.HTTPError:
         pass  # 201 or duplicate — both ok
 
-    # Wait for email and extract code
-    msg = get_latest_email(email)
-    assert msg is not None, f"No verification email received for {email}"
-    # Prefer HTML body (parsed by MailCatcher), fallback to raw source
-    body = msg.get("html", "") or msg.get("source", "") or msg.get("body", "")
-    code = extract_verification_code(body)
+    # Wait for email and extract code (with retry for empty body)
+    code = None
+    for attempt in range(3):
+        msg = get_latest_email(email)
+        assert msg is not None, f"No verification email received for {email}"
+        # Prefer HTML body (parsed by MailCatcher), fallback to raw source
+        body = msg.get("html", "") or msg.get("source", "") or msg.get("body", "")
+        code = extract_verification_code(body)
+        if code is not None:
+            break
+        # Body was empty — wait and re-fetch
+        time.sleep(2)
     assert code is not None, f"No verification code found in email: {body[:200]}"
 
     # Verify


### PR DESCRIPTION
## Summary

- Add Celery worker warmup in `before_all`: sends a dummy registration and waits for email delivery before running tests
- Add retry loop in `register_and_verify_user`: re-fetches email up to 3 times with 2s delay when verification code is empty
- Increases resilience against slow Celery cold starts in CI

## Related Issue

Closes #237

## Test Plan

- [x] `make format` - code formatted
- [x] `make lint` - no linting errors
- [x] `make typecheck` - type checks pass
- [x] `make test` - all unit tests pass
- [x] `make bdd` - BDD tests pass (with fresh Docker build)
- [x] `make check-license` - SPDX headers present