### PR TITLE
feat(pat): PAT service (create, validate, revoke, track usage)

### DIFF
--- a/src/shomer/services/pat_service.py
+++ b/src/shomer/services/pat_service.py
@@ -1,0 +1,282 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Personal Access Token service.
+
+Manages PAT lifecycle: creation (with ``shm_pat_`` prefix), validation
+by hash lookup, revocation, and last-used tracking.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from shomer.models.personal_access_token import PAT_PREFIX, PersonalAccessToken
+
+
+class PATError(Exception):
+    """Raised when a PAT operation fails.
+
+    Attributes
+    ----------
+    message : str
+        Human-readable error description.
+    """
+
+    def __init__(self, message: str) -> None:
+        self.message = message
+        super().__init__(message)
+
+
+@dataclass
+class PATCreateResult:
+    """Result of PAT creation — includes the raw token shown once.
+
+    Attributes
+    ----------
+    id : uuid.UUID
+        The PAT record ID.
+    name : str
+        Human-readable label.
+    token : str
+        The full raw token (shown once, never stored).
+    token_prefix : str
+        First characters for display (``shm_pat_...``).
+    scopes : str
+        Space-separated scopes.
+    expires_at : datetime or None
+        Expiration timestamp.
+    created_at : datetime
+        Creation timestamp.
+    """
+
+    id: uuid.UUID
+    name: str
+    token: str
+    token_prefix: str
+    scopes: str
+    expires_at: datetime | None
+    created_at: datetime
+
+
+@dataclass
+class PATInfo:
+    """PAT metadata (no raw token value).
+
+    Attributes
+    ----------
+    id : uuid.UUID
+        The PAT record ID.
+    name : str
+        Human-readable label.
+    token_prefix : str
+        First characters for display.
+    scopes : str
+        Space-separated scopes.
+    expires_at : datetime or None
+        Expiration timestamp.
+    last_used_at : datetime or None
+        Last usage timestamp.
+    is_revoked : bool
+        Whether the token is revoked.
+    created_at : datetime
+        Creation timestamp.
+    """
+
+    id: uuid.UUID
+    name: str
+    token_prefix: str
+    scopes: str
+    expires_at: datetime | None
+    last_used_at: datetime | None
+    is_revoked: bool
+    created_at: datetime
+
+
+class PATService:
+    """Manage Personal Access Token lifecycle.
+
+    Attributes
+    ----------
+    session : AsyncSession
+        Database session.
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def create(
+        self,
+        *,
+        user_id: uuid.UUID,
+        name: str,
+        scopes: str = "",
+        expires_at: datetime | None = None,
+    ) -> PATCreateResult:
+        """Create a new Personal Access Token.
+
+        Generates a secure random token with ``shm_pat_`` prefix,
+        hashes it with SHA-256, and stores the hash. The raw token
+        is returned only once.
+
+        Parameters
+        ----------
+        user_id : uuid.UUID
+            The token owner's ID.
+        name : str
+            Human-readable label.
+        scopes : str
+            Space-separated scopes for this token.
+        expires_at : datetime or None
+            Optional expiration.
+
+        Returns
+        -------
+        PATCreateResult
+            The created PAT including the raw token (shown once).
+        """
+        raw_secret = secrets.token_urlsafe(32)
+        raw_token = f"{PAT_PREFIX}{raw_secret}"
+        token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
+        token_prefix = raw_token[:16]
+
+        now = datetime.now(timezone.utc)
+        pat = PersonalAccessToken(
+            user_id=user_id,
+            name=name,
+            token_prefix=token_prefix,
+            token_hash=token_hash,
+            scopes=scopes,
+            expires_at=expires_at,
+            is_revoked=False,
+        )
+        self.session.add(pat)
+        await self.session.flush()
+
+        return PATCreateResult(
+            id=pat.id,
+            name=name,
+            token=raw_token,
+            token_prefix=token_prefix,
+            scopes=scopes,
+            expires_at=expires_at,
+            created_at=now,
+        )
+
+    async def validate(self, raw_token: str) -> PersonalAccessToken:
+        """Validate a PAT by hash lookup.
+
+        Checks that the token exists, is not revoked, and has not
+        expired. Updates ``last_used_at`` on success.
+
+        Parameters
+        ----------
+        raw_token : str
+            The full raw token (``shm_pat_...``).
+
+        Returns
+        -------
+        PersonalAccessToken
+            The validated token record.
+
+        Raises
+        ------
+        PATError
+            If the token is invalid, revoked, or expired.
+        """
+        if not raw_token.startswith(PAT_PREFIX):
+            raise PATError("Invalid token format")
+
+        token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
+
+        stmt = select(PersonalAccessToken).where(
+            PersonalAccessToken.token_hash == token_hash,
+        )
+        result = await self.session.execute(stmt)
+        pat = result.scalar_one_or_none()
+
+        if pat is None:
+            raise PATError("Invalid token")
+
+        if pat.is_revoked:
+            raise PATError("Token has been revoked")
+
+        now = datetime.now(timezone.utc)
+        if pat.expires_at is not None and pat.expires_at < now:
+            raise PATError("Token has expired")
+
+        # Track usage
+        pat.last_used_at = now
+        await self.session.flush()
+
+        return pat
+
+    async def revoke(self, pat_id: uuid.UUID, user_id: uuid.UUID) -> None:
+        """Revoke a PAT.
+
+        Parameters
+        ----------
+        pat_id : uuid.UUID
+            The PAT record ID.
+        user_id : uuid.UUID
+            The token owner's ID (authorization check).
+
+        Raises
+        ------
+        PATError
+            If the PAT is not found or doesn't belong to the user.
+        """
+        stmt = select(PersonalAccessToken).where(
+            PersonalAccessToken.id == pat_id,
+            PersonalAccessToken.user_id == user_id,
+        )
+        result = await self.session.execute(stmt)
+        pat = result.scalar_one_or_none()
+
+        if pat is None:
+            raise PATError("Token not found")
+
+        pat.is_revoked = True
+        await self.session.flush()
+
+    async def list_for_user(self, user_id: uuid.UUID) -> list[PATInfo]:
+        """List all PATs for a user (metadata only).
+
+        Parameters
+        ----------
+        user_id : uuid.UUID
+            The user's ID.
+
+        Returns
+        -------
+        list[PATInfo]
+            PAT metadata without raw token values.
+        """
+        stmt = (
+            select(PersonalAccessToken)
+            .where(PersonalAccessToken.user_id == user_id)
+            .order_by(PersonalAccessToken.created_at.desc())
+        )
+        result = await self.session.execute(stmt)
+        pats = result.scalars().all()
+
+        return [
+            PATInfo(
+                id=p.id,
+                name=p.name,
+                token_prefix=p.token_prefix,
+                scopes=p.scopes,
+                expires_at=p.expires_at,
+                last_used_at=p.last_used_at,
+                is_revoked=p.is_revoked,
+                created_at=p.created_at,
+            )
+            for p in pats
+        ]

--- a/tests/services/test_pat_service.py
+++ b/tests/services/test_pat_service.py
@@ -1,0 +1,261 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Unit tests for PATService."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from shomer.models.personal_access_token import PAT_PREFIX
+from shomer.services.pat_service import PATCreateResult, PATError, PATInfo, PATService
+
+
+class TestPATCreate:
+    """Tests for PAT creation."""
+
+    def test_create_returns_raw_token_with_prefix(self) -> None:
+        async def _run() -> None:
+            db = AsyncMock()
+            svc = PATService(db)
+            result = await svc.create(
+                user_id=uuid.uuid4(), name="CI key", scopes="api:read"
+            )
+            assert isinstance(result, PATCreateResult)
+            assert result.token.startswith(PAT_PREFIX)
+            assert result.token_prefix == result.token[:16]
+            assert result.name == "CI key"
+            assert result.scopes == "api:read"
+            db.add.assert_called_once()
+            db.flush.assert_awaited_once()
+
+        asyncio.run(_run())
+
+    def test_create_stores_hash_not_raw(self) -> None:
+        async def _run() -> None:
+            import hashlib
+
+            db = AsyncMock()
+            svc = PATService(db)
+            result = await svc.create(user_id=uuid.uuid4(), name="key")
+            pat_obj = db.add.call_args[0][0]
+            expected_hash = hashlib.sha256(result.token.encode()).hexdigest()
+            assert pat_obj.token_hash == expected_hash
+            assert result.token not in pat_obj.token_hash
+
+        asyncio.run(_run())
+
+    def test_create_with_expiration(self) -> None:
+        async def _run() -> None:
+            db = AsyncMock()
+            svc = PATService(db)
+            exp = datetime.now(timezone.utc) + timedelta(days=30)
+            result = await svc.create(user_id=uuid.uuid4(), name="tmp", expires_at=exp)
+            assert result.expires_at == exp
+
+        asyncio.run(_run())
+
+    def test_each_create_generates_unique_token(self) -> None:
+        async def _run() -> None:
+            db = AsyncMock()
+            svc = PATService(db)
+            r1 = await svc.create(user_id=uuid.uuid4(), name="a")
+            r2 = await svc.create(user_id=uuid.uuid4(), name="b")
+            assert r1.token != r2.token
+
+        asyncio.run(_run())
+
+
+class TestPATValidate:
+    """Tests for PAT validation."""
+
+    def test_valid_token(self) -> None:
+        async def _run() -> None:
+            import hashlib
+
+            raw = f"{PAT_PREFIX}test-secret-123"
+            token_hash = hashlib.sha256(raw.encode()).hexdigest()
+
+            mock_pat = MagicMock()
+            mock_pat.token_hash = token_hash
+            mock_pat.is_revoked = False
+            mock_pat.expires_at = None
+            mock_pat.last_used_at = None
+
+            mock_result = MagicMock()
+            mock_result.scalar_one_or_none.return_value = mock_pat
+
+            db = AsyncMock()
+            db.execute.return_value = mock_result
+
+            svc = PATService(db)
+            pat = await svc.validate(raw)
+            assert pat is mock_pat
+            assert pat.last_used_at is not None
+            db.flush.assert_awaited_once()
+
+        asyncio.run(_run())
+
+    def test_invalid_prefix_raises(self) -> None:
+        async def _run() -> None:
+            db = AsyncMock()
+            svc = PATService(db)
+            with pytest.raises(PATError, match="Invalid token format"):
+                await svc.validate("bad_prefix_token")
+
+        asyncio.run(_run())
+
+    def test_unknown_token_raises(self) -> None:
+        async def _run() -> None:
+            mock_result = MagicMock()
+            mock_result.scalar_one_or_none.return_value = None
+
+            db = AsyncMock()
+            db.execute.return_value = mock_result
+
+            svc = PATService(db)
+            with pytest.raises(PATError, match="Invalid token"):
+                await svc.validate(f"{PAT_PREFIX}unknown-token")
+
+        asyncio.run(_run())
+
+    def test_revoked_token_raises(self) -> None:
+        async def _run() -> None:
+            mock_pat = MagicMock()
+            mock_pat.is_revoked = True
+
+            mock_result = MagicMock()
+            mock_result.scalar_one_or_none.return_value = mock_pat
+
+            db = AsyncMock()
+            db.execute.return_value = mock_result
+
+            svc = PATService(db)
+            with pytest.raises(PATError, match="revoked"):
+                await svc.validate(f"{PAT_PREFIX}some-token")
+
+        asyncio.run(_run())
+
+    def test_expired_token_raises(self) -> None:
+        async def _run() -> None:
+            mock_pat = MagicMock()
+            mock_pat.is_revoked = False
+            mock_pat.expires_at = datetime.now(timezone.utc) - timedelta(hours=1)
+
+            mock_result = MagicMock()
+            mock_result.scalar_one_or_none.return_value = mock_pat
+
+            db = AsyncMock()
+            db.execute.return_value = mock_result
+
+            svc = PATService(db)
+            with pytest.raises(PATError, match="expired"):
+                await svc.validate(f"{PAT_PREFIX}expired-token")
+
+        asyncio.run(_run())
+
+    def test_non_expired_token_passes(self) -> None:
+        async def _run() -> None:
+            mock_pat = MagicMock()
+            mock_pat.is_revoked = False
+            mock_pat.expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
+            mock_pat.last_used_at = None
+
+            mock_result = MagicMock()
+            mock_result.scalar_one_or_none.return_value = mock_pat
+
+            db = AsyncMock()
+            db.execute.return_value = mock_result
+
+            svc = PATService(db)
+            pat = await svc.validate(f"{PAT_PREFIX}valid-token")
+            assert pat.last_used_at is not None
+
+        asyncio.run(_run())
+
+
+class TestPATRevoke:
+    """Tests for PAT revocation."""
+
+    def test_revoke_success(self) -> None:
+        async def _run() -> None:
+            mock_pat = MagicMock()
+            mock_pat.is_revoked = False
+
+            mock_result = MagicMock()
+            mock_result.scalar_one_or_none.return_value = mock_pat
+
+            db = AsyncMock()
+            db.execute.return_value = mock_result
+
+            svc = PATService(db)
+            await svc.revoke(uuid.uuid4(), uuid.uuid4())
+            assert mock_pat.is_revoked is True
+            db.flush.assert_awaited_once()
+
+        asyncio.run(_run())
+
+    def test_revoke_not_found_raises(self) -> None:
+        async def _run() -> None:
+            mock_result = MagicMock()
+            mock_result.scalar_one_or_none.return_value = None
+
+            db = AsyncMock()
+            db.execute.return_value = mock_result
+
+            svc = PATService(db)
+            with pytest.raises(PATError, match="not found"):
+                await svc.revoke(uuid.uuid4(), uuid.uuid4())
+
+        asyncio.run(_run())
+
+
+class TestPATListForUser:
+    """Tests for listing user PATs."""
+
+    def test_list_returns_metadata(self) -> None:
+        async def _run() -> None:
+            now = datetime.now(timezone.utc)
+            mock_pat = MagicMock()
+            mock_pat.id = uuid.uuid4()
+            mock_pat.name = "my-key"
+            mock_pat.token_prefix = "shm_pat_abc"
+            mock_pat.scopes = "api:read"
+            mock_pat.expires_at = None
+            mock_pat.last_used_at = now
+            mock_pat.is_revoked = False
+            mock_pat.created_at = now
+
+            mock_result = MagicMock()
+            mock_result.scalars.return_value.all.return_value = [mock_pat]
+
+            db = AsyncMock()
+            db.execute.return_value = mock_result
+
+            svc = PATService(db)
+            pats = await svc.list_for_user(uuid.uuid4())
+            assert len(pats) == 1
+            assert isinstance(pats[0], PATInfo)
+            assert pats[0].name == "my-key"
+            assert pats[0].token_prefix == "shm_pat_abc"
+
+        asyncio.run(_run())
+
+    def test_list_empty(self) -> None:
+        async def _run() -> None:
+            mock_result = MagicMock()
+            mock_result.scalars.return_value.all.return_value = []
+
+            db = AsyncMock()
+            db.execute.return_value = mock_result
+
+            svc = PATService(db)
+            pats = await svc.list_for_user(uuid.uuid4())
+            assert pats == []
+
+        asyncio.run(_run())


### PR DESCRIPTION
## feat(pat): PAT service (create, validate, revoke, track usage)

## Summary

Personal Access Token service: create (generate token with shm_pat_ prefix, return plain text once, store SHA-256 hash), validate (lookup by hash, check expiration/revocation, track last_used_at), revoke, list.

## Changes

- [x] Create PAT: generate secure random token with `shm_pat_` prefix, hash and store
- [x] Return plain text token only at creation time
- [x] Validate PAT: lookup by hash, check expiration and revocation
- [x] Revoke PAT: mark as revoked
- [x] Track usage: update last_used_at on each validation
- [x] List PATs for user (metadata only, no token values)
- [x] Unit tests

## Dependencies

- #1 - hashing
- #74 - PAT model

## Related Issue

Closes #75

## Test Plan

- [x] `make format` - code formatted
- [x] `make lint` - no linting errors
- [x] `make typecheck` - type checks pass
- [x] `make test` - all unit tests pass
- [x] `make bdd` - all BDD tests pass
- [x] `make check-license` - SPDX headers present
