### PR TITLE
feat(pat): PAT API (POST create, GET list, DELETE revoke)

### DIFF
--- a/features/pat_api.feature
+++ b/features/pat_api.feature
@@ -1,0 +1,56 @@
+Feature: Personal Access Token API
+
+  Scenario: POST /api/pats without auth returns 401
+    When I send a POST request to "/api/pats" with JSON
+      """
+      {"name": "test-key", "scopes": "api:read"}
+      """
+    Then the response status code should be 401
+
+  Scenario: GET /api/pats without auth returns 401
+    When I send a GET request to "/api/pats"
+    Then the response status code should be 401
+
+  Scenario: DELETE /api/pats/00000000-0000-0000-0000-000000000001 without auth returns 401
+    When I send a DELETE request to "/api/pats/00000000-0000-0000-0000-000000000001"
+    Then the response status code should be 401
+
+  Scenario: POST /api/pats with auth creates token and returns it
+    Given a registered and verified user "pat-create@example.com" with password "securepassword123"
+    And I am logged in as "pat-create@example.com" with password "securepassword123"
+    When I send a POST request to "/api/pats" with JSON
+      """
+      {"name": "my-ci-key", "scopes": "api:read api:write"}
+      """
+    Then the response status code should be 201
+    And the response should have JSON key "token"
+    And the response should have JSON key "name"
+    And the response body should contain "shm_pat_"
+    And the response body should contain "my-ci-key"
+    And the response body should contain "Save this token"
+
+  Scenario: GET /api/pats with auth returns list of tokens
+    Given a registered and verified user "pat-list@example.com" with password "securepassword123"
+    And I am logged in as "pat-list@example.com" with password "securepassword123"
+    When I send a POST request to "/api/pats" with JSON
+      """
+      {"name": "list-key", "scopes": "api:read"}
+      """
+    Then the response status code should be 201
+    When I send a GET request to "/api/pats"
+    Then the response status code should be 200
+    And the response should have JSON key "tokens"
+    And the response body should contain "list-key"
+    And the response body should contain "shm_pat_"
+
+  Scenario: DELETE /api/pats/{id} with auth revokes token
+    Given a registered and verified user "pat-revoke@example.com" with password "securepassword123"
+    And I am logged in as "pat-revoke@example.com" with password "securepassword123"
+    When I send a POST request to "/api/pats" with JSON
+      """
+      {"name": "revoke-key", "scopes": ""}
+      """
+    Then the response status code should be 201
+    When I send a GET request to "/api/pats"
+    Then the response status code should be 200
+    And the response body should contain "revoke-key"

--- a/src/shomer/app.py
+++ b/src/shomer/app.py
@@ -63,6 +63,7 @@ def create_app() -> FastAPI:
     from shomer.routes.mfa_ui import router as mfa_ui_router
     from shomer.routes.oauth2 import router as oauth2_router
     from shomer.routes.password_ui import router as password_ui_router
+    from shomer.routes.pat import router as pat_router
     from shomer.routes.profile import router as profile_router
     from shomer.routes.settings_ui import router as settings_ui_router
     from shomer.routes.userinfo import router as userinfo_router
@@ -85,6 +86,7 @@ def create_app() -> FastAPI:
     application.include_router(device_ui_router)
     application.include_router(mfa_router)
     application.include_router(mfa_ui_router)
+    application.include_router(pat_router)
     application.include_router(views_router)
 
     return application

--- a/src/shomer/routes/pat.py
+++ b/src/shomer/routes/pat.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Personal Access Token management API endpoints."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from fastapi import APIRouter, HTTPException, status
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from shomer.deps import CurrentUser, DbSession
+from shomer.services.pat_service import PATError, PATService
+
+router = APIRouter(prefix="/api/pats", tags=["pat"])
+
+
+class PATCreateRequest(BaseModel):
+    """Request body for PAT creation.
+
+    Attributes
+    ----------
+    name : str
+        Human-readable label for the token.
+    scopes : str
+        Space-separated scopes.
+    expires_at : datetime or None
+        Optional expiration timestamp.
+    """
+
+    name: str
+    scopes: str = ""
+    expires_at: datetime | None = None
+
+
+@router.post("")
+async def create_pat(
+    body: PATCreateRequest, user: CurrentUser, db: DbSession
+) -> JSONResponse:
+    """Create a new Personal Access Token.
+
+    Returns the raw token value **once**. It cannot be retrieved later.
+
+    Parameters
+    ----------
+    body : PATCreateRequest
+        Token name, scopes, and optional expiration.
+    user : CurrentUser
+        The authenticated user.
+    db : DbSession
+        Database session.
+
+    Returns
+    -------
+    JSONResponse
+        The created PAT including the raw token.
+    """
+    svc = PATService(db)
+    result = await svc.create(
+        user_id=user.user_id,
+        name=body.name,
+        scopes=body.scopes,
+        expires_at=body.expires_at,
+    )
+
+    return JSONResponse(
+        status_code=201,
+        content={
+            "id": str(result.id),
+            "name": result.name,
+            "token": result.token,
+            "token_prefix": result.token_prefix,
+            "scopes": result.scopes,
+            "expires_at": result.expires_at.isoformat() if result.expires_at else None,
+            "created_at": result.created_at.isoformat(),
+            "message": "Save this token — it will not be shown again.",
+        },
+    )
+
+
+@router.get("")
+async def list_pats(user: CurrentUser, db: DbSession) -> JSONResponse:
+    """List all PATs for the authenticated user.
+
+    Returns metadata only — no raw token values.
+
+    Parameters
+    ----------
+    user : CurrentUser
+        The authenticated user.
+    db : DbSession
+        Database session.
+
+    Returns
+    -------
+    JSONResponse
+        List of PAT metadata.
+    """
+    svc = PATService(db)
+    pats = await svc.list_for_user(user.user_id)
+
+    return JSONResponse(
+        content={
+            "tokens": [
+                {
+                    "id": str(p.id),
+                    "name": p.name,
+                    "token_prefix": p.token_prefix,
+                    "scopes": p.scopes,
+                    "expires_at": p.expires_at.isoformat() if p.expires_at else None,
+                    "last_used_at": (
+                        p.last_used_at.isoformat() if p.last_used_at else None
+                    ),
+                    "is_revoked": p.is_revoked,
+                    "created_at": p.created_at.isoformat(),
+                }
+                for p in pats
+            ],
+        },
+    )
+
+
+@router.delete("/{pat_id}")
+async def revoke_pat(
+    pat_id: uuid.UUID, user: CurrentUser, db: DbSession
+) -> JSONResponse:
+    """Revoke a Personal Access Token.
+
+    Parameters
+    ----------
+    pat_id : uuid.UUID
+        The PAT record ID.
+    user : CurrentUser
+        The authenticated user.
+    db : DbSession
+        Database session.
+
+    Returns
+    -------
+    JSONResponse
+        Confirmation of revocation.
+    """
+    svc = PATService(db)
+    try:
+        await svc.revoke(pat_id, user.user_id)
+    except PATError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=exc.message,
+        )
+
+    return JSONResponse(content={"message": "Token revoked successfully."})

--- a/tests/routes/test_pat_unit.py
+++ b/tests/routes/test_pat_unit.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Pure unit tests for PAT route handlers."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from shomer.routes.pat import create_pat, list_pats, revoke_pat
+from shomer.services.pat_service import PATCreateResult, PATError, PATInfo
+
+
+def _mock_user() -> MagicMock:
+    u = MagicMock()
+    u.user_id = uuid.uuid4()
+    return u
+
+
+class TestCreatePAT:
+    """Unit tests for POST /api/pats."""
+
+    def test_create_returns_201_with_token(self) -> None:
+        async def _run() -> None:
+            now = datetime.now(timezone.utc)
+            mock_result = PATCreateResult(
+                id=uuid.uuid4(),
+                name="CI key",
+                token="shm_pat_abcdef123456",
+                token_prefix="shm_pat_abcdef1",
+                scopes="api:read",
+                expires_at=None,
+                created_at=now,
+            )
+
+            with patch("shomer.routes.pat.PATService") as mock_cls:
+                mock_svc = AsyncMock()
+                mock_svc.create.return_value = mock_result
+                mock_cls.return_value = mock_svc
+
+                body = MagicMock(name="CI key", scopes="api:read", expires_at=None)
+                resp = await create_pat(body, _mock_user(), AsyncMock())
+                assert resp.status_code == 201
+                data = json.loads(bytes(resp.body))
+                assert data["token"] == "shm_pat_abcdef123456"
+                assert data["name"] == "CI key"
+                assert "Save this token" in data["message"]
+
+        asyncio.run(_run())
+
+
+class TestListPATs:
+    """Unit tests for GET /api/pats."""
+
+    def test_list_returns_metadata(self) -> None:
+        async def _run() -> None:
+            now = datetime.now(timezone.utc)
+            mock_pats = [
+                PATInfo(
+                    id=uuid.uuid4(),
+                    name="key-1",
+                    token_prefix="shm_pat_abc",
+                    scopes="api:read",
+                    expires_at=None,
+                    last_used_at=now,
+                    is_revoked=False,
+                    created_at=now,
+                ),
+            ]
+
+            with patch("shomer.routes.pat.PATService") as mock_cls:
+                mock_svc = AsyncMock()
+                mock_svc.list_for_user.return_value = mock_pats
+                mock_cls.return_value = mock_svc
+
+                resp = await list_pats(_mock_user(), AsyncMock())
+                assert resp.status_code == 200
+                data = json.loads(bytes(resp.body))
+                assert len(data["tokens"]) == 1
+                assert data["tokens"][0]["name"] == "key-1"
+                assert "token" not in data["tokens"][0]
+
+        asyncio.run(_run())
+
+    def test_list_empty(self) -> None:
+        async def _run() -> None:
+            with patch("shomer.routes.pat.PATService") as mock_cls:
+                mock_svc = AsyncMock()
+                mock_svc.list_for_user.return_value = []
+                mock_cls.return_value = mock_svc
+
+                resp = await list_pats(_mock_user(), AsyncMock())
+                data = json.loads(bytes(resp.body))
+                assert data["tokens"] == []
+
+        asyncio.run(_run())
+
+
+class TestRevokePAT:
+    """Unit tests for DELETE /api/pats/{id}."""
+
+    def test_revoke_success(self) -> None:
+        async def _run() -> None:
+            with patch("shomer.routes.pat.PATService") as mock_cls:
+                mock_svc = AsyncMock()
+                mock_cls.return_value = mock_svc
+
+                resp = await revoke_pat(uuid.uuid4(), _mock_user(), AsyncMock())
+                assert resp.status_code == 200
+                data = json.loads(bytes(resp.body))
+                assert "revoked" in data["message"].lower()
+
+        asyncio.run(_run())
+
+    def test_revoke_not_found_returns_404(self) -> None:
+        async def _run() -> None:
+            with patch("shomer.routes.pat.PATService") as mock_cls:
+                mock_svc = AsyncMock()
+                mock_svc.revoke.side_effect = PATError("Token not found")
+                mock_cls.return_value = mock_svc
+
+                with pytest.raises(HTTPException) as exc_info:
+                    await revoke_pat(uuid.uuid4(), _mock_user(), AsyncMock())
+                assert exc_info.value.status_code == 404
+
+        asyncio.run(_run())


### PR DESCRIPTION
## feat(pat): PAT API (POST create, GET list, DELETE revoke)

## Summary

API endpoints for PAT management: POST to create (returns token once), GET to list user's PATs (metadata only), DELETE to revoke.

## Changes

- [x] POST `/api/pats` - create PAT (name, scopes, expires_at), return token value
- [x] GET `/api/pats` - list user's PATs (metadata only)
- [x] DELETE `/api/pats/{id}` - revoke PAT
- [x] Requires authenticated session
- [x] Integration tests

## Dependencies

- #75 - PAT service
- #20 - session service

## Related Issue

Closes #76

## Test Plan

- [x] `make format` - code formatted
- [x] `make lint` - no linting errors
- [x] `make typecheck` - type checks pass
- [x] `make test` - all unit tests pass
- [x] `make bdd` - all BDD tests pass
- [x] `make check-license` - SPDX headers present
