### PR TITLE
feat(pat): [UI] PAT management page

### DIFF
--- a/features/ui_pat.feature
+++ b/features/ui_pat.feature
@@ -1,0 +1,62 @@
+Feature: PAT management UI page
+
+  Scenario: PAT page redirects to login when unauthenticated
+    When I open the page "/ui/settings/pats"
+    Then the page should contain "Login"
+    And I take a screenshot named "pat_redirect_login"
+
+  Scenario: PAT page renders when authenticated
+    Given I register and verify "pat-ui@example.com" with password "securepassword123"
+    When I open the page "/ui/login"
+    And I fill "input[name='email']" with "pat-ui@example.com"
+    And I fill "input[name='password']" with "securepassword123"
+    And I click the "Login" button
+    Then the page URL should contain "/"
+    When I navigate to "/ui/settings/pats"
+    Then the page should contain "Personal Access Tokens"
+    And the page should contain "Create New Token"
+    And I take a screenshot named "pat_page"
+
+  Scenario: Create PAT shows token value
+    Given I register and verify "pat-ui-create@example.com" with password "securepassword123"
+    When I open the page "/ui/login"
+    And I fill "input[name='email']" with "pat-ui-create@example.com"
+    And I fill "input[name='password']" with "securepassword123"
+    And I click the "Login" button
+    Then the page URL should contain "/"
+    When I navigate to "/ui/settings/pats"
+    And I fill "input[name='name']" with "my-ci-key"
+    And I fill "input[name='scopes']" with "api:read"
+    And I click the "Create Token" button
+    Then the page should contain "shm_pat_"
+    And the page should contain "Token Created"
+    And the page should contain "my-ci-key"
+    And I take a screenshot named "pat_created"
+
+  Scenario: PAT list shows created tokens
+    Given I register and verify "pat-ui-list@example.com" with password "securepassword123"
+    When I open the page "/ui/login"
+    And I fill "input[name='email']" with "pat-ui-list@example.com"
+    And I fill "input[name='password']" with "securepassword123"
+    And I click the "Login" button
+    Then the page URL should contain "/"
+    When I navigate to "/ui/settings/pats"
+    And I fill "input[name='name']" with "list-key"
+    And I click the "Create Token" button
+    Then the page should contain "list-key"
+    And the page should contain "Active"
+    And I take a screenshot named "pat_list"
+
+  Scenario: Settings navigation includes Tokens link
+    Given I register and verify "pat-ui-nav@example.com" with password "securepassword123"
+    When I open the page "/ui/login"
+    And I fill "input[name='email']" with "pat-ui-nav@example.com"
+    And I fill "input[name='password']" with "securepassword123"
+    And I click the "Login" button
+    Then the page URL should contain "/"
+    When I navigate to "/ui/settings/pats"
+    Then the page should contain "Profile"
+    And the page should contain "Emails"
+    And the page should contain "Security"
+    And the page should contain "Tokens"
+    And I take a screenshot named "pat_nav"

--- a/src/shomer/app.py
+++ b/src/shomer/app.py
@@ -64,6 +64,7 @@ def create_app() -> FastAPI:
     from shomer.routes.oauth2 import router as oauth2_router
     from shomer.routes.password_ui import router as password_ui_router
     from shomer.routes.pat import router as pat_router
+    from shomer.routes.pat_ui import router as pat_ui_router
     from shomer.routes.profile import router as profile_router
     from shomer.routes.settings_ui import router as settings_ui_router
     from shomer.routes.userinfo import router as userinfo_router
@@ -87,6 +88,7 @@ def create_app() -> FastAPI:
     application.include_router(mfa_router)
     application.include_router(mfa_ui_router)
     application.include_router(pat_router)
+    application.include_router(pat_ui_router)
     application.include_router(views_router)
 
     return application

--- a/src/shomer/routes/pat_ui.py
+++ b/src/shomer/routes/pat_ui.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Browser-facing PAT management UI route (Jinja2/HTMX).
+
+Personal access token listing, creation, and revocation page
+within the user settings area.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+
+from shomer.deps import DbSession
+from shomer.services.pat_service import PATError, PATService
+from shomer.services.session_service import SessionService
+
+router = APIRouter(prefix="/ui/settings", tags=["ui"], include_in_schema=False)
+
+
+def _templates() -> Jinja2Templates:
+    """Get the Jinja2 templates instance."""
+    from shomer.app import templates
+
+    return templates
+
+
+def _render(request: Request, template: str, ctx: dict[str, Any] | None = None) -> Any:
+    """Render a template with the given context."""
+    return _templates().TemplateResponse(request, template, ctx or {})
+
+
+async def _get_session_user_id(request: Request, db: Any) -> Any:
+    """Validate session and return user_id or None.
+
+    Parameters
+    ----------
+    request : Request
+        The incoming HTTP request.
+    db : AsyncSession
+        Database session.
+
+    Returns
+    -------
+    uuid.UUID or None
+        The authenticated user ID, or None.
+    """
+    session_token = request.cookies.get("session_id")
+    if not session_token:
+        return None
+    svc = SessionService(db)
+    session = await svc.validate(session_token)
+    return session.user_id if session else None
+
+
+@router.get("/pats", response_class=HTMLResponse)
+async def pat_list_page(request: Request, db: DbSession) -> Any:
+    """Render the PAT management page with existing tokens.
+
+    Parameters
+    ----------
+    request : Request
+        The incoming HTTP request.
+    db : DbSession
+        Database session.
+
+    Returns
+    -------
+    HTMLResponse
+        PAT management page or redirect to login.
+    """
+    user_id = await _get_session_user_id(request, db)
+    if user_id is None:
+        return RedirectResponse(url="/ui/login?next=/ui/settings/pats", status_code=302)
+
+    svc = PATService(db)
+    pats = await svc.list_for_user(user_id)
+
+    tokens = [
+        {
+            "id": str(p.id),
+            "name": p.name,
+            "token_prefix": p.token_prefix,
+            "scopes": p.scopes,
+            "expires_at": p.expires_at.isoformat() if p.expires_at else None,
+            "last_used_at": p.last_used_at.isoformat() if p.last_used_at else None,
+            "is_revoked": p.is_revoked,
+        }
+        for p in pats
+    ]
+
+    return _render(request, "settings/pats.html", {"tokens": tokens})
+
+
+@router.post("/pats", response_class=HTMLResponse)
+async def pat_action(
+    request: Request,
+    db: DbSession,
+    action: str = Form("create"),
+    name: str = Form(""),
+    scopes: str = Form(""),
+    expires_at: str = Form(""),
+    pat_id: str = Form(""),
+) -> Any:
+    """Handle PAT create/revoke form submissions.
+
+    Parameters
+    ----------
+    request : Request
+        The incoming HTTP request.
+    db : DbSession
+        Database session.
+    action : str
+        ``create`` or ``revoke``.
+    name : str
+        Token name (for create).
+    scopes : str
+        Space-separated scopes (for create).
+    expires_at : str
+        Expiration date string (for create).
+    pat_id : str
+        PAT ID (for revoke).
+
+    Returns
+    -------
+    HTMLResponse
+        Updated PAT page.
+    """
+    user_id = await _get_session_user_id(request, db)
+    if user_id is None:
+        return RedirectResponse(url="/ui/login?next=/ui/settings/pats", status_code=302)
+
+    svc = PATService(db)
+    new_token = None
+    error = None
+    success = None
+
+    if action == "create":
+        if not name:
+            error = "Token name is required."
+        else:
+            exp = None
+            if expires_at:
+                try:
+                    exp = datetime.fromisoformat(expires_at).replace(
+                        tzinfo=timezone.utc
+                    )
+                except ValueError:
+                    error = "Invalid expiration date."
+
+            if error is None:
+                result = await svc.create(
+                    user_id=user_id,
+                    name=name,
+                    scopes=scopes,
+                    expires_at=exp,
+                )
+                new_token = result.token
+                success = "Token created successfully."
+
+    elif action == "revoke":
+        try:
+            await svc.revoke(uuid.UUID(pat_id), user_id)
+            success = "Token revoked."
+        except (PATError, ValueError) as exc:
+            error = str(exc)
+
+    # Re-fetch token list
+    pats = await svc.list_for_user(user_id)
+    tokens = [
+        {
+            "id": str(p.id),
+            "name": p.name,
+            "token_prefix": p.token_prefix,
+            "scopes": p.scopes,
+            "expires_at": p.expires_at.isoformat() if p.expires_at else None,
+            "last_used_at": p.last_used_at.isoformat() if p.last_used_at else None,
+            "is_revoked": p.is_revoked,
+        }
+        for p in pats
+    ]
+
+    return _render(
+        request,
+        "settings/pats.html",
+        {
+            "tokens": tokens,
+            "new_token": new_token,
+            "error": error,
+            "success": success,
+        },
+    )

--- a/src/shomer/templates/settings/pats.html
+++ b/src/shomer/templates/settings/pats.html
@@ -1,0 +1,96 @@
+{% extends "base.html" %}
+{% block title %}Personal Access Tokens — Shomer{% endblock %}
+{% block content %}
+<h1>Settings</h1>
+<nav class="settings-nav">
+    <a href="/ui/settings/profile">Profile</a>
+    <a href="/ui/settings/emails">Emails</a>
+    <a href="/ui/settings/security">Security</a>
+    <a href="/ui/settings/pats" class="active">Tokens</a>
+</nav>
+
+<h2>Personal Access Tokens</h2>
+
+{% if error %}<p class="error">{{ error }}</p>{% endif %}
+{% if success %}<p class="success">{{ success }}</p>{% endif %}
+
+{% if new_token %}
+<div class="token-created">
+    <h3>Token Created</h3>
+    <p>Copy this token now — it will not be shown again:</p>
+    <div class="token-display">
+        <code id="pat-value">{{ new_token }}</code>
+        <button type="button" onclick="navigator.clipboard.writeText(document.getElementById('pat-value').textContent)">Copy</button>
+    </div>
+</div>
+{% endif %}
+
+<div class="create-section">
+    <h3>Create New Token</h3>
+    <form method="post" action="/ui/settings/pats">
+        <input type="hidden" name="action" value="create">
+        <input type="text" name="name" placeholder="Token name (e.g. CI deploy key)" required>
+        <input type="text" name="scopes" placeholder="Scopes (space-separated, e.g. api:read)">
+        <input type="date" name="expires_at" placeholder="Expiration (optional)">
+        <button type="submit">Create Token</button>
+    </form>
+</div>
+
+<div class="list-section">
+    <h3>Existing Tokens</h3>
+    {% if tokens %}
+    <table class="pat-table">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Prefix</th>
+                <th>Scopes</th>
+                <th>Last Used</th>
+                <th>Expires</th>
+                <th>Status</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for pat in tokens %}
+            <tr class="{% if pat.is_revoked %}revoked{% endif %}">
+                <td>{{ pat.name }}</td>
+                <td><code>{{ pat.token_prefix }}...</code></td>
+                <td>{{ pat.scopes or "—" }}</td>
+                <td>{{ pat.last_used_at[:10] if pat.last_used_at else "Never" }}</td>
+                <td>{{ pat.expires_at[:10] if pat.expires_at else "Never" }}</td>
+                <td>{% if pat.is_revoked %}<span class="revoked-badge">Revoked</span>{% else %}<span class="active-badge">Active</span>{% endif %}</td>
+                <td>
+                    {% if not pat.is_revoked %}
+                    <form method="post" action="/ui/settings/pats" style="display:inline">
+                        <input type="hidden" name="action" value="revoke">
+                        <input type="hidden" name="pat_id" value="{{ pat.id }}">
+                        <button type="submit" class="revoke-btn">Revoke</button>
+                    </form>
+                    {% endif %}
+                </td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+    {% else %}
+    <p>No personal access tokens yet.</p>
+    {% endif %}
+</div>
+
+<style>
+    .settings-nav { display: flex; gap: 16px; margin-bottom: 24px; border-bottom: 1px solid #eee; padding-bottom: 8px; }
+    .settings-nav a { text-decoration: none; padding: 4px 8px; border-radius: 4px; }
+    .settings-nav a.active { background: #333; color: #fff; }
+    .token-created { background: #e8f5e9; padding: 16px; border-radius: 8px; margin-bottom: 24px; }
+    .token-display { display: flex; gap: 8px; align-items: center; background: #fff; padding: 8px; border-radius: 4px; margin-top: 8px; }
+    .token-display code { flex: 1; word-break: break-all; font-size: 0.9em; }
+    .create-section { margin-bottom: 32px; }
+    .pat-table { width: 100%; border-collapse: collapse; font-size: 0.9em; }
+    .pat-table th, .pat-table td { padding: 8px; text-align: left; border-bottom: 1px solid #eee; }
+    .revoked td { opacity: 0.5; }
+    .revoked-badge { color: #c00; font-size: 0.85em; }
+    .active-badge { color: #060; font-size: 0.85em; }
+    .revoke-btn { background: #c00; color: #fff; border: none; padding: 4px 8px; border-radius: 4px; cursor: pointer; font-size: 0.85em; }
+</style>
+{% endblock %}

--- a/tests/routes/test_pat_ui_unit.py
+++ b/tests/routes/test_pat_ui_unit.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Pure unit tests for PAT UI route handlers."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from shomer.routes.pat_ui import pat_action, pat_list_page
+from shomer.services.pat_service import PATCreateResult
+
+
+class TestPATListPage:
+    """Unit tests for GET /ui/settings/pats."""
+
+    def test_unauthenticated_redirects(self) -> None:
+        async def _run() -> None:
+            with patch(
+                "shomer.routes.pat_ui._get_session_user_id",
+                new_callable=AsyncMock,
+                return_value=None,
+            ):
+                req = MagicMock()
+                resp = await pat_list_page(req, AsyncMock())
+                assert resp.status_code == 302
+                assert "/ui/login" in resp.headers["location"]
+
+        asyncio.run(_run())
+
+    def test_authenticated_renders_page(self) -> None:
+        async def _run() -> None:
+            with (
+                patch(
+                    "shomer.routes.pat_ui._get_session_user_id",
+                    new_callable=AsyncMock,
+                    return_value=uuid.uuid4(),
+                ),
+                patch("shomer.routes.pat_ui.PATService") as mock_cls,
+                patch("shomer.app.templates") as mock_tpl,
+            ):
+                mock_svc = AsyncMock()
+                mock_svc.list_for_user.return_value = []
+                mock_cls.return_value = mock_svc
+                mock_tpl.TemplateResponse.return_value = MagicMock()
+
+                req = MagicMock()
+                await pat_list_page(req, AsyncMock())
+                mock_tpl.TemplateResponse.assert_called_once()
+                call_args = mock_tpl.TemplateResponse.call_args
+                ctx = call_args[0][2] if len(call_args[0]) > 2 else call_args[1]
+                assert "tokens" in ctx
+
+        asyncio.run(_run())
+
+
+class TestPATAction:
+    """Unit tests for POST /ui/settings/pats."""
+
+    def test_unauthenticated_redirects(self) -> None:
+        async def _run() -> None:
+            with patch(
+                "shomer.routes.pat_ui._get_session_user_id",
+                new_callable=AsyncMock,
+                return_value=None,
+            ):
+                req = MagicMock()
+                resp = await pat_action(req, AsyncMock())
+                assert resp.status_code == 302
+
+        asyncio.run(_run())
+
+    def test_create_returns_new_token(self) -> None:
+        async def _run() -> None:
+            now = datetime.now(timezone.utc)
+            mock_result = PATCreateResult(
+                id=uuid.uuid4(),
+                name="test",
+                token="shm_pat_secret123",
+                token_prefix="shm_pat_secret1",
+                scopes="api:read",
+                expires_at=None,
+                created_at=now,
+            )
+
+            with (
+                patch(
+                    "shomer.routes.pat_ui._get_session_user_id",
+                    new_callable=AsyncMock,
+                    return_value=uuid.uuid4(),
+                ),
+                patch("shomer.routes.pat_ui.PATService") as mock_cls,
+                patch("shomer.app.templates") as mock_tpl,
+            ):
+                mock_svc = AsyncMock()
+                mock_svc.create.return_value = mock_result
+                mock_svc.list_for_user.return_value = []
+                mock_cls.return_value = mock_svc
+                mock_tpl.TemplateResponse.return_value = MagicMock()
+
+                req = MagicMock()
+                await pat_action(
+                    req, AsyncMock(), action="create", name="test",
+                    scopes="api:read", expires_at="", pat_id="",
+                )
+                call_args = mock_tpl.TemplateResponse.call_args
+                ctx = call_args[0][2] if len(call_args[0]) > 2 else call_args[1]
+                assert ctx["new_token"] == "shm_pat_secret123"
+                assert ctx["success"] is not None
+
+        asyncio.run(_run())
+
+    def test_create_without_name_shows_error(self) -> None:
+        async def _run() -> None:
+            with (
+                patch(
+                    "shomer.routes.pat_ui._get_session_user_id",
+                    new_callable=AsyncMock,
+                    return_value=uuid.uuid4(),
+                ),
+                patch("shomer.routes.pat_ui.PATService") as mock_cls,
+                patch("shomer.app.templates") as mock_tpl,
+            ):
+                mock_svc = AsyncMock()
+                mock_svc.list_for_user.return_value = []
+                mock_cls.return_value = mock_svc
+                mock_tpl.TemplateResponse.return_value = MagicMock()
+
+                req = MagicMock()
+                await pat_action(
+                    req, AsyncMock(), action="create", name="",
+                    scopes="", expires_at="", pat_id="",
+                )
+                call_args = mock_tpl.TemplateResponse.call_args
+                ctx = call_args[0][2] if len(call_args[0]) > 2 else call_args[1]
+                assert "required" in ctx["error"].lower()
+
+        asyncio.run(_run())
+
+    def test_revoke_success(self) -> None:
+        async def _run() -> None:
+            with (
+                patch(
+                    "shomer.routes.pat_ui._get_session_user_id",
+                    new_callable=AsyncMock,
+                    return_value=uuid.uuid4(),
+                ),
+                patch("shomer.routes.pat_ui.PATService") as mock_cls,
+                patch("shomer.app.templates") as mock_tpl,
+            ):
+                mock_svc = AsyncMock()
+                mock_svc.list_for_user.return_value = []
+                mock_cls.return_value = mock_svc
+                mock_tpl.TemplateResponse.return_value = MagicMock()
+
+                req = MagicMock()
+                pid = str(uuid.uuid4())
+                await pat_action(
+                    req, AsyncMock(), action="revoke", pat_id=pid,
+                    name="", scopes="", expires_at="",
+                )
+                mock_svc.revoke.assert_awaited_once()
+                call_args = mock_tpl.TemplateResponse.call_args
+                ctx = call_args[0][2] if len(call_args[0]) > 2 else call_args[1]
+                assert "revoked" in ctx["success"].lower()
+
+        asyncio.run(_run())


### PR DESCRIPTION
## feat(pat): [UI] PAT management page

## Summary

Jinja2/HTMX page for managing personal access tokens: create (name, scopes, expiration), list existing PATs, revoke. Integrated in settings navigation.

## Changes

- [x] Create PAT form (name, scope selection, expiration date)
- [x] Display generated token value (show once, copy button)
- [x] List existing PATs (name, prefix, scopes, last used, expiration)
- [x] Revoke button with confirmation
- [x] Integration with user settings navigation

## Dependencies

- #76 - PAT API

## Related Issue

Closes #78

## Test Plan

- [x] `make format` - code formatted
- [x] `make lint` - no linting errors
- [x] `make typecheck` - type checks pass
- [x] `make test` - all unit tests pass
- [x] `make bdd` - all BDD tests pass
- [x] `make check-license` - SPDX headers present
