### PR TITLE
feat(models): Tenant, TenantMember, TenantCustomRole

### DIFF
--- a/alembic/versions/0019_add_tenant_tables.py
+++ b/alembic/versions/0019_add_tenant_tables.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Add tenant tables: tenants, tenant_members, tenant_custom_roles.
+
+Revision ID: 0019
+Revises: 0018
+Create Date: 2026-03-22
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0019"
+down_revision: Union[str, None] = "0018"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create tenants, tenant_members, and tenant_custom_roles tables."""
+    op.create_table(
+        "tenants",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("slug", sa.String(255), nullable=False),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("custom_domain", sa.String(255), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default="true"),
+        sa.Column("settings", sa.JSON(), nullable=False, server_default="{}"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("slug"),
+        sa.UniqueConstraint("custom_domain"),
+    )
+    op.create_index("ix_tenants_slug", "tenants", ["slug"])
+    op.create_index("ix_tenants_custom_domain", "tenants", ["custom_domain"])
+
+    op.create_table(
+        "tenant_members",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("user_id", sa.Uuid(), nullable=False),
+        sa.Column("tenant_id", sa.Uuid(), nullable=False),
+        sa.Column("role", sa.String(50), nullable=False, server_default="member"),
+        sa.Column("joined_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint("user_id", "tenant_id", name="uq_tenant_member"),
+    )
+    op.create_index("ix_tenant_members_user_id", "tenant_members", ["user_id"])
+    op.create_index("ix_tenant_members_tenant_id", "tenant_members", ["tenant_id"])
+
+    op.create_table(
+        "tenant_custom_roles",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("tenant_id", sa.Uuid(), nullable=False),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("permissions", sa.JSON(), nullable=False, server_default="[]"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint("tenant_id", "name", name="uq_tenant_role_name"),
+    )
+    op.create_index(
+        "ix_tenant_custom_roles_tenant_id", "tenant_custom_roles", ["tenant_id"]
+    )
+
+
+def downgrade() -> None:
+    """Drop tenant tables."""
+    op.drop_table("tenant_custom_roles")
+    op.drop_table("tenant_members")
+    op.drop_table("tenants")

--- a/src/shomer/models/__init__.py
+++ b/src/shomer/models/__init__.py
@@ -24,6 +24,9 @@ from shomer.models.role import Role as Role
 from shomer.models.role_scope import RoleScope as RoleScope
 from shomer.models.scope import Scope as Scope
 from shomer.models.session import Session as Session
+from shomer.models.tenant import Tenant as Tenant
+from shomer.models.tenant_custom_role import TenantCustomRole as TenantCustomRole
+from shomer.models.tenant_member import TenantMember as TenantMember
 from shomer.models.user import User as User
 from shomer.models.user_email import UserEmail as UserEmail
 from shomer.models.user_mfa import UserMFA as UserMFA

--- a/src/shomer/models/tenant.py
+++ b/src/shomer/models/tenant.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Tenant model for multi-tenancy."""
+
+from __future__ import annotations
+
+from sqlalchemy import JSON, Boolean, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from shomer.core.database import Base, TimestampMixin, UUIDMixin
+
+
+class Tenant(Base, UUIDMixin, TimestampMixin):
+    """Organisation / workspace tenant.
+
+    Each tenant has a unique slug used in URLs and an optional
+    custom domain for white-label deployments.
+
+    Attributes
+    ----------
+    id : uuid.UUID
+        Primary key (from UUIDMixin).
+    slug : str
+        Unique URL-safe identifier (e.g. ``acme-corp``).
+    name : str
+        Human-readable display name.
+    custom_domain : str or None
+        Optional custom domain (e.g. ``auth.acme.com``).
+    is_active : bool
+        Whether the tenant is active.
+    settings : dict
+        Tenant-specific configuration (branding, features, etc.).
+    created_at : datetime
+        Row creation timestamp (from TimestampMixin).
+    updated_at : datetime
+        Last update timestamp (from TimestampMixin).
+    """
+
+    __tablename__ = "tenants"
+
+    slug: Mapped[str] = mapped_column(
+        String(255),
+        unique=True,
+        nullable=False,
+        index=True,
+    )
+    name: Mapped[str] = mapped_column(
+        String(255),
+        nullable=False,
+    )
+    custom_domain: Mapped[str | None] = mapped_column(
+        String(255),
+        unique=True,
+        nullable=True,
+        index=True,
+    )
+    is_active: Mapped[bool] = mapped_column(
+        Boolean,
+        default=True,
+        nullable=False,
+    )
+    settings: Mapped[dict] = mapped_column(  # type: ignore[type-arg]
+        JSON,
+        default=dict,
+        nullable=False,
+    )
+
+    def __repr__(self) -> str:
+        return f"<Tenant slug={self.slug} name={self.name}>"

--- a/src/shomer/models/tenant_custom_role.py
+++ b/src/shomer/models/tenant_custom_role.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""TenantCustomRole model for tenant-specific RBAC roles."""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+from sqlalchemy import JSON, ForeignKey, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+if TYPE_CHECKING:
+    from shomer.models.tenant import Tenant
+
+from shomer.core.database import Base, TimestampMixin, UUIDMixin
+
+
+class TenantCustomRole(Base, UUIDMixin, TimestampMixin):
+    """Tenant-specific custom role beyond system-level roles.
+
+    Allows each tenant to define their own roles with custom
+    permissions, independent of the global RBAC roles.
+
+    Attributes
+    ----------
+    id : uuid.UUID
+        Primary key (from UUIDMixin).
+    tenant_id : uuid.UUID
+        Foreign key to the tenant.
+    name : str
+        Role name, unique within the tenant.
+    permissions : list[str]
+        Permission strings granted by this role.
+    tenant : Tenant
+        The tenant that owns this role.
+    created_at : datetime
+        Row creation timestamp (from TimestampMixin).
+    updated_at : datetime
+        Last update timestamp (from TimestampMixin).
+    """
+
+    __tablename__ = "tenant_custom_roles"
+    __table_args__ = (
+        UniqueConstraint("tenant_id", "name", name="uq_tenant_role_name"),
+    )
+
+    tenant_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("tenants.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    name: Mapped[str] = mapped_column(
+        String(255),
+        nullable=False,
+    )
+    permissions: Mapped[list[str]] = mapped_column(
+        JSON,
+        default=list,
+        nullable=False,
+    )
+
+    # Relationships
+    tenant: Mapped[Tenant] = relationship()
+
+    def __repr__(self) -> str:
+        return f"<TenantCustomRole tenant={self.tenant_id} name={self.name}>"

--- a/src/shomer/models/tenant_member.py
+++ b/src/shomer/models/tenant_member.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""TenantMember model for multi-tenancy membership."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import DateTime, ForeignKey, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+if TYPE_CHECKING:
+    from shomer.models.tenant import Tenant
+    from shomer.models.user import User
+
+from shomer.core.database import Base, TimestampMixin, UUIDMixin
+
+
+class TenantMember(Base, UUIDMixin, TimestampMixin):
+    """Membership linking a user to a tenant with a role.
+
+    Attributes
+    ----------
+    id : uuid.UUID
+        Primary key (from UUIDMixin).
+    user_id : uuid.UUID
+        Foreign key to the user.
+    tenant_id : uuid.UUID
+        Foreign key to the tenant.
+    role : str
+        Member role within the tenant (e.g. ``owner``, ``admin``, ``member``).
+    joined_at : datetime
+        When the user joined the tenant.
+    user : User
+        The member user.
+    tenant : Tenant
+        The tenant.
+    created_at : datetime
+        Row creation timestamp (from TimestampMixin).
+    updated_at : datetime
+        Last update timestamp (from TimestampMixin).
+    """
+
+    __tablename__ = "tenant_members"
+    __table_args__ = (
+        UniqueConstraint("user_id", "tenant_id", name="uq_tenant_member"),
+    )
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    tenant_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("tenants.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    role: Mapped[str] = mapped_column(
+        String(50),
+        nullable=False,
+        default="member",
+    )
+    joined_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+    )
+
+    # Relationships
+    user: Mapped[User] = relationship()
+    tenant: Mapped[Tenant] = relationship()
+
+    def __repr__(self) -> str:
+        return f"<TenantMember user={self.user_id} tenant={self.tenant_id} role={self.role}>"

--- a/tests/models/test_tenant.py
+++ b/tests/models/test_tenant.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Unit tests for Tenant model."""
+
+from shomer.models.tenant import Tenant
+
+
+class TestTenantModel:
+    """Tests for Tenant SQLAlchemy model definition."""
+
+    def test_tablename(self) -> None:
+        assert Tenant.__tablename__ == "tenants"
+
+    def test_required_fields(self) -> None:
+        t = Tenant(slug="acme-corp", name="Acme Corp", is_active=True, settings={})
+        assert t.slug == "acme-corp"
+        assert t.name == "Acme Corp"
+        assert t.is_active is True
+        assert t.settings == {}
+        assert t.custom_domain is None
+
+    def test_with_custom_domain(self) -> None:
+        t = Tenant(
+            slug="acme",
+            name="Acme",
+            custom_domain="auth.acme.com",
+            is_active=True,
+            settings={},
+        )
+        assert t.custom_domain == "auth.acme.com"
+
+    def test_slug_unique(self) -> None:
+        col = Tenant.__table__.c.slug
+        assert col.unique is True
+
+    def test_slug_indexed(self) -> None:
+        col = Tenant.__table__.c.slug
+        assert col.index is True
+
+    def test_custom_domain_unique(self) -> None:
+        col = Tenant.__table__.c.custom_domain
+        assert col.unique is True
+
+    def test_custom_domain_indexed(self) -> None:
+        col = Tenant.__table__.c.custom_domain
+        assert col.index is True
+
+    def test_settings_json(self) -> None:
+        t = Tenant(
+            slug="test",
+            name="Test",
+            settings={"theme": "dark", "features": ["sso"]},
+            is_active=True,
+        )
+        assert t.settings["theme"] == "dark"
+
+    def test_repr(self) -> None:
+        t = Tenant(slug="acme", name="Acme Corp", is_active=True, settings={})
+        r = repr(t)
+        assert "acme" in r
+        assert "Acme Corp" in r

--- a/tests/models/test_tenant_custom_role.py
+++ b/tests/models/test_tenant_custom_role.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Unit tests for TenantCustomRole model."""
+
+import uuid
+
+from shomer.models.tenant_custom_role import TenantCustomRole
+
+
+class TestTenantCustomRoleModel:
+    """Tests for TenantCustomRole SQLAlchemy model definition."""
+
+    def test_tablename(self) -> None:
+        assert TenantCustomRole.__tablename__ == "tenant_custom_roles"
+
+    def test_required_fields(self) -> None:
+        tid = uuid.uuid4()
+        r = TenantCustomRole(
+            tenant_id=tid,
+            name="editor",
+            permissions=["posts:read", "posts:write"],
+        )
+        assert r.tenant_id == tid
+        assert r.name == "editor"
+        assert r.permissions == ["posts:read", "posts:write"]
+
+    def test_tenant_id_indexed(self) -> None:
+        col = TenantCustomRole.__table__.c.tenant_id
+        assert col.index is True
+
+    def test_unique_constraint(self) -> None:
+        names = [c.name for c in getattr(TenantCustomRole.__table__, "constraints", [])]
+        assert "uq_tenant_role_name" in names
+
+    def test_empty_permissions(self) -> None:
+        r = TenantCustomRole(
+            tenant_id=uuid.uuid4(),
+            name="viewer",
+            permissions=[],
+        )
+        assert r.permissions == []
+
+    def test_repr(self) -> None:
+        tid = uuid.uuid4()
+        r = TenantCustomRole(tenant_id=tid, name="admin", permissions=[])
+        rep = repr(r)
+        assert str(tid) in rep
+        assert "admin" in rep

--- a/tests/models/test_tenant_member.py
+++ b/tests/models/test_tenant_member.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Unit tests for TenantMember model."""
+
+import uuid
+from datetime import datetime, timezone
+
+from shomer.models.tenant_member import TenantMember
+
+
+class TestTenantMemberModel:
+    """Tests for TenantMember SQLAlchemy model definition."""
+
+    def test_tablename(self) -> None:
+        assert TenantMember.__tablename__ == "tenant_members"
+
+    def test_required_fields(self) -> None:
+        uid = uuid.uuid4()
+        tid = uuid.uuid4()
+        now = datetime.now(timezone.utc)
+        tm = TenantMember(
+            user_id=uid,
+            tenant_id=tid,
+            role="admin",
+            joined_at=now,
+        )
+        assert tm.user_id == uid
+        assert tm.tenant_id == tid
+        assert tm.role == "admin"
+        assert tm.joined_at == now
+
+    def test_user_id_indexed(self) -> None:
+        col = TenantMember.__table__.c.user_id
+        assert col.index is True
+
+    def test_tenant_id_indexed(self) -> None:
+        col = TenantMember.__table__.c.tenant_id
+        assert col.index is True
+
+    def test_unique_constraint(self) -> None:
+        names = [c.name for c in getattr(TenantMember.__table__, "constraints", [])]
+        assert "uq_tenant_member" in names
+
+    def test_repr(self) -> None:
+        uid = uuid.uuid4()
+        tid = uuid.uuid4()
+        tm = TenantMember(
+            user_id=uid,
+            tenant_id=tid,
+            role="member",
+            joined_at=datetime.now(timezone.utc),
+        )
+        r = repr(tm)
+        assert str(uid) in r
+        assert str(tid) in r
+        assert "member" in r


### PR DESCRIPTION
## feat(models): Tenant, TenantMember, TenantCustomRole

## Summary

Multi-tenancy models: Tenant (slug, name, domain, settings), TenantMember (user_id, tenant_id, role), TenantCustomRole (tenant-specific roles beyond system roles).

## Changes

- [x] Tenant model (slug, name, custom_domain, is_active, settings JSON)
- [x] TenantMember model (user_id, tenant_id, role, joined_at)
- [x] TenantCustomRole model (tenant_id, name, permissions)
- [x] Unique constraints (slug, custom_domain)
- [x] Relationships and indexes
- [x] Alembic migration

## Dependencies

- #3 - declarative base
- #4 - User model

## Related Issue

Closes #79

## Test Plan

- [x] `make format` - code formatted
- [x] `make lint` - no linting errors
- [x] `make typecheck` - type checks pass
- [x] `make test` - all unit tests pass
- [x] `make bdd` - all BDD tests pass
- [x] `make check-license` - SPDX headers present
