### PR TITLE
feat(models): IdentityProvider and FederatedIdentity

### DIFF
--- a/alembic/versions/0022_add_identity_provider_tables.py
+++ b/alembic/versions/0022_add_identity_provider_tables.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Add identity_providers and federated_identities tables.
+
+Revision ID: 0022
+Revises: 0021
+Create Date: 2026-03-22
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0022"
+down_revision: Union[str, None] = "0021"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create identity_providers and federated_identities tables."""
+    op.create_table(
+        "identity_providers",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("tenant_id", sa.Uuid(), nullable=False),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("provider_type", sa.String(20), nullable=False),
+        # OIDC endpoints
+        sa.Column("discovery_url", sa.String(2048), nullable=True),
+        sa.Column("authorization_endpoint", sa.String(2048), nullable=True),
+        sa.Column("token_endpoint", sa.String(2048), nullable=True),
+        sa.Column("userinfo_endpoint", sa.String(2048), nullable=True),
+        sa.Column("jwks_uri", sa.String(2048), nullable=True),
+        # Client credentials
+        sa.Column("client_id", sa.String(255), nullable=False),
+        sa.Column("client_secret_encrypted", sa.LargeBinary(), nullable=True),
+        # Scopes and mapping
+        sa.Column(
+            "scopes",
+            sa.JSON(),
+            nullable=False,
+            server_default='["openid", "profile", "email"]',
+        ),
+        sa.Column("attribute_mapping", sa.JSON(), nullable=True),
+        sa.Column("allowed_domains", sa.JSON(), nullable=True),
+        # Settings
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default="true"),
+        sa.Column("is_default", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column(
+            "auto_provision", sa.Boolean(), nullable=False, server_default="false"
+        ),
+        sa.Column("allow_linking", sa.Boolean(), nullable=False, server_default="true"),
+        # UI display
+        sa.Column("icon_url", sa.String(2048), nullable=True),
+        sa.Column("button_text", sa.String(100), nullable=True),
+        sa.Column("display_order", sa.Integer(), nullable=False, server_default="0"),
+        # Timestamps
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+    )
+    op.create_index(
+        "ix_identity_providers_tenant_id", "identity_providers", ["tenant_id"]
+    )
+    op.create_index(
+        "ix_identity_providers_tenant_active",
+        "identity_providers",
+        ["tenant_id", "is_active"],
+    )
+
+    op.create_table(
+        "federated_identities",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("user_id", sa.Uuid(), nullable=False),
+        sa.Column("identity_provider_id", sa.Uuid(), nullable=False),
+        sa.Column("external_subject", sa.String(255), nullable=False),
+        sa.Column("external_email", sa.String(255), nullable=True),
+        sa.Column("external_username", sa.String(255), nullable=True),
+        sa.Column("raw_claims", sa.JSON(), nullable=True),
+        sa.Column("linked_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("last_login_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["identity_provider_id"],
+            ["identity_providers.id"],
+            ondelete="CASCADE",
+        ),
+        sa.UniqueConstraint(
+            "identity_provider_id",
+            "external_subject",
+            name="uq_federated_identities_idp_subject",
+        ),
+    )
+    op.create_index(
+        "ix_federated_identities_user_id", "federated_identities", ["user_id"]
+    )
+    op.create_index(
+        "ix_federated_identities_idp_id",
+        "federated_identities",
+        ["identity_provider_id"],
+    )
+    op.create_index(
+        "ix_federated_identities_user_idp",
+        "federated_identities",
+        ["user_id", "identity_provider_id"],
+    )
+
+
+def downgrade() -> None:
+    """Drop federation tables."""
+    op.drop_table("federated_identities")
+    op.drop_table("identity_providers")

--- a/src/shomer/models/__init__.py
+++ b/src/shomer/models/__init__.py
@@ -10,6 +10,8 @@ can resolve all relationships at configuration time.
 from shomer.models.access_token import AccessToken as AccessToken
 from shomer.models.authorization_code import AuthorizationCode as AuthorizationCode
 from shomer.models.device_code import DeviceCode as DeviceCode
+from shomer.models.federated_identity import FederatedIdentity as FederatedIdentity
+from shomer.models.identity_provider import IdentityProvider as IdentityProvider
 from shomer.models.jwk import JWK as JWK
 from shomer.models.mfa_backup_code import MFABackupCode as MFABackupCode
 from shomer.models.mfa_email_code import MFAEmailCode as MFAEmailCode

--- a/src/shomer/models/federated_identity.py
+++ b/src/shomer/models/federated_identity.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""FederatedIdentity model linking users to external identity providers."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import JSON, DateTime, ForeignKey, Index, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+if TYPE_CHECKING:
+    from shomer.models.identity_provider import IdentityProvider
+    from shomer.models.user import User
+
+from shomer.core.database import Base, TimestampMixin, UUIDMixin
+
+
+class FederatedIdentity(Base, UUIDMixin, TimestampMixin):
+    """Link between a local user and an external identity from an IdP.
+
+    Stores the external subject identifier, email, username, and the
+    raw claims from the IdP for audit purposes.
+
+    Attributes
+    ----------
+    id : uuid.UUID
+        Primary key (from UUIDMixin).
+    user_id : uuid.UUID
+        Foreign key to the local user.
+    identity_provider_id : uuid.UUID
+        Foreign key to the identity provider.
+    external_subject : str
+        The ``sub`` claim from the external IdP (unique per provider).
+    external_email : str or None
+        Email from the external IdP.
+    external_username : str or None
+        Username/display name from the external IdP.
+    raw_claims : dict or None
+        Full claims from the IdP token for debugging/audit.
+    linked_at : datetime
+        When the user linked their account to this IdP.
+    last_login_at : datetime or None
+        Last federated login timestamp.
+    user : User
+        The local user.
+    identity_provider : IdentityProvider
+        The external identity provider.
+    created_at : datetime
+        Row creation timestamp (from TimestampMixin).
+    updated_at : datetime
+        Last update timestamp (from TimestampMixin).
+    """
+
+    __tablename__ = "federated_identities"
+    __table_args__ = (
+        UniqueConstraint(
+            "identity_provider_id",
+            "external_subject",
+            name="uq_federated_identities_idp_subject",
+        ),
+        Index(
+            "ix_federated_identities_user_idp",
+            "user_id",
+            "identity_provider_id",
+        ),
+    )
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    identity_provider_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("identity_providers.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    # External identity
+    external_subject: Mapped[str] = mapped_column(String(255), nullable=False)
+    external_email: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    external_username: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    raw_claims: Mapped[dict | None] = mapped_column(  # type: ignore[type-arg]
+        JSON, nullable=True
+    )
+
+    # Timestamps
+    linked_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    last_login_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    # Relationships
+    user: Mapped[User] = relationship()
+    identity_provider: Mapped[IdentityProvider] = relationship(
+        back_populates="federated_identities"
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<FederatedIdentity user={self.user_id} "
+            f"provider={self.identity_provider_id} sub={self.external_subject}>"
+        )

--- a/src/shomer/models/identity_provider.py
+++ b/src/shomer/models/identity_provider.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""IdentityProvider model for federated SSO."""
+
+from __future__ import annotations
+
+import enum
+import uuid
+from typing import TYPE_CHECKING
+
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    Enum,
+    ForeignKey,
+    Index,
+    Integer,
+    LargeBinary,
+    String,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+if TYPE_CHECKING:
+    from shomer.models.federated_identity import FederatedIdentity
+    from shomer.models.tenant import Tenant
+
+from shomer.core.database import Base, TimestampMixin, UUIDMixin
+
+
+class IdentityProviderType(str, enum.Enum):
+    """Type of external identity provider.
+
+    Attributes
+    ----------
+    OIDC
+        Generic OIDC (Keycloak, Auth0, Okta, Azure AD).
+    SAML
+        SAML 2.0.
+    GOOGLE
+        Google OAuth2.
+    GITHUB
+        GitHub OAuth2.
+    MICROSOFT
+        Microsoft / Azure AD.
+    """
+
+    OIDC = "oidc"
+    SAML = "saml"
+    GOOGLE = "google"
+    GITHUB = "github"
+    MICROSOFT = "microsoft"
+
+
+class IdentityProvider(Base, UUIDMixin, TimestampMixin):
+    """External identity provider configuration for a tenant.
+
+    Stores OIDC/SAML endpoints, client credentials (encrypted),
+    attribute mapping, domain restrictions, and UI display settings.
+
+    Attributes
+    ----------
+    id : uuid.UUID
+        Primary key (from UUIDMixin).
+    tenant_id : uuid.UUID
+        Foreign key to the tenant.
+    name : str
+        Human-readable provider name (e.g. "Acme SSO").
+    provider_type : IdentityProviderType
+        Provider protocol type.
+    discovery_url : str or None
+        OIDC discovery endpoint (``/.well-known/openid-configuration``).
+    authorization_endpoint : str or None
+        OAuth2 authorization URL.
+    token_endpoint : str or None
+        OAuth2 token URL.
+    userinfo_endpoint : str or None
+        OIDC userinfo URL.
+    jwks_uri : str or None
+        JWKS endpoint for signature verification.
+    client_id : str
+        OAuth2 client identifier.
+    client_secret_encrypted : bytes or None
+        AES-256-GCM encrypted client secret.
+    scopes : list[str]
+        Scopes to request (default: openid, profile, email).
+    attribute_mapping : dict or None
+        External claim → internal field mapping.
+    allowed_domains : list[str] or None
+        Email domain restrictions for this IdP.
+    is_active : bool
+        Whether this IdP is enabled.
+    is_default : bool
+        Whether this is the default IdP for the tenant (auto-redirect).
+    auto_provision : bool
+        Auto-create user and add to tenant on first login.
+    allow_linking : bool
+        Allow linking existing accounts to this IdP.
+    icon_url : str or None
+        Icon URL for the login button.
+    button_text : str or None
+        Custom button text (e.g. "Sign in with Acme SSO").
+    display_order : int
+        Sort order on the login page.
+    tenant : Tenant
+        The associated tenant.
+    federated_identities : list[FederatedIdentity]
+        User identities linked via this provider.
+    created_at : datetime
+        Row creation timestamp (from TimestampMixin).
+    updated_at : datetime
+        Last update timestamp (from TimestampMixin).
+    """
+
+    __tablename__ = "identity_providers"
+    __table_args__ = (
+        Index("ix_identity_providers_tenant_active", "tenant_id", "is_active"),
+    )
+
+    tenant_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("tenants.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    provider_type: Mapped[IdentityProviderType] = mapped_column(
+        Enum(IdentityProviderType, name="identity_provider_type", native_enum=False),
+        nullable=False,
+    )
+
+    # OIDC configuration
+    discovery_url: Mapped[str | None] = mapped_column(String(2048), nullable=True)
+    authorization_endpoint: Mapped[str | None] = mapped_column(
+        String(2048), nullable=True
+    )
+    token_endpoint: Mapped[str | None] = mapped_column(String(2048), nullable=True)
+    userinfo_endpoint: Mapped[str | None] = mapped_column(String(2048), nullable=True)
+    jwks_uri: Mapped[str | None] = mapped_column(String(2048), nullable=True)
+
+    # Client credentials
+    client_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    client_secret_encrypted: Mapped[bytes | None] = mapped_column(
+        LargeBinary, nullable=True
+    )
+
+    # Scopes and mapping
+    scopes: Mapped[list] = mapped_column(  # type: ignore[type-arg]
+        JSON,
+        nullable=False,
+        default=lambda: ["openid", "profile", "email"],
+    )
+    attribute_mapping: Mapped[dict | None] = mapped_column(  # type: ignore[type-arg]
+        JSON, nullable=True, default=dict
+    )
+    allowed_domains: Mapped[list | None] = mapped_column(  # type: ignore[type-arg]
+        JSON, nullable=True
+    )
+
+    # Settings
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    is_default: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    auto_provision: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    allow_linking: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+
+    # UI display
+    icon_url: Mapped[str | None] = mapped_column(String(2048), nullable=True)
+    button_text: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    display_order: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+
+    # Relationships
+    tenant: Mapped[Tenant] = relationship(back_populates="identity_providers")
+    federated_identities: Mapped[list[FederatedIdentity]] = relationship(
+        back_populates="identity_provider",
+        cascade="all, delete-orphan",
+    )
+
+    def __repr__(self) -> str:
+        return f"<IdentityProvider name={self.name} type={self.provider_type.value}>"

--- a/src/shomer/models/tenant.py
+++ b/src/shomer/models/tenant.py
@@ -12,6 +12,7 @@ from sqlalchemy import JSON, Boolean, Enum, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 if TYPE_CHECKING:
+    from shomer.models.identity_provider import IdentityProvider
     from shomer.models.tenant_trusted_source import TenantTrustedSource
 
 from shomer.core.database import Base, TimestampMixin, UUIDMixin
@@ -119,6 +120,10 @@ class Tenant(Base, UUIDMixin, TimestampMixin):
     # Relationships
     trusted_sources: Mapped[list[TenantTrustedSource]] = relationship(
         foreign_keys="TenantTrustedSource.tenant_id",
+        cascade="all, delete-orphan",
+    )
+    identity_providers: Mapped[list[IdentityProvider]] = relationship(
+        back_populates="tenant",
         cascade="all, delete-orphan",
     )
 

--- a/tests/models/test_federated_identity.py
+++ b/tests/models/test_federated_identity.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Unit tests for FederatedIdentity model."""
+
+import uuid
+from datetime import datetime, timezone
+
+from shomer.models.federated_identity import FederatedIdentity
+
+
+class TestFederatedIdentityModel:
+    """Tests for FederatedIdentity SQLAlchemy model definition."""
+
+    def test_tablename(self) -> None:
+        assert FederatedIdentity.__tablename__ == "federated_identities"
+
+    def test_required_fields(self) -> None:
+        uid = uuid.uuid4()
+        pid = uuid.uuid4()
+        now = datetime.now(timezone.utc)
+        fi = FederatedIdentity(
+            user_id=uid,
+            identity_provider_id=pid,
+            external_subject="google-12345",
+            linked_at=now,
+        )
+        assert fi.user_id == uid
+        assert fi.identity_provider_id == pid
+        assert fi.external_subject == "google-12345"
+        assert fi.linked_at == now
+        assert fi.external_email is None
+        assert fi.external_username is None
+        assert fi.raw_claims is None
+        assert fi.last_login_at is None
+
+    def test_full_fields(self) -> None:
+        now = datetime.now(timezone.utc)
+        fi = FederatedIdentity(
+            user_id=uuid.uuid4(),
+            identity_provider_id=uuid.uuid4(),
+            external_subject="sub-abc",
+            external_email="user@acme.com",
+            external_username="johndoe",
+            raw_claims={"sub": "sub-abc", "email": "user@acme.com", "name": "John"},
+            linked_at=now,
+            last_login_at=now,
+        )
+        assert fi.external_email == "user@acme.com"
+        assert fi.external_username == "johndoe"
+        assert fi.raw_claims is not None
+        assert fi.raw_claims["name"] == "John"
+        assert fi.last_login_at == now
+
+    def test_unique_constraint(self) -> None:
+        names = [
+            c.name for c in getattr(FederatedIdentity.__table__, "constraints", [])
+        ]
+        assert "uq_federated_identities_idp_subject" in names
+
+    def test_user_id_indexed(self) -> None:
+        col = FederatedIdentity.__table__.c.user_id
+        assert col.index is True
+
+    def test_identity_provider_id_indexed(self) -> None:
+        col = FederatedIdentity.__table__.c.identity_provider_id
+        assert col.index is True
+
+    def test_repr(self) -> None:
+        uid = uuid.uuid4()
+        pid = uuid.uuid4()
+        fi = FederatedIdentity(
+            user_id=uid,
+            identity_provider_id=pid,
+            external_subject="ext-123",
+            linked_at=datetime.now(timezone.utc),
+        )
+        r = repr(fi)
+        assert str(uid) in r
+        assert str(pid) in r
+        assert "ext-123" in r

--- a/tests/models/test_identity_provider.py
+++ b/tests/models/test_identity_provider.py
@@ -1,0 +1,177 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Unit tests for IdentityProvider model."""
+
+import uuid
+
+from shomer.models.identity_provider import IdentityProvider, IdentityProviderType
+
+
+class TestIdentityProviderType:
+    """Tests for IdentityProviderType enum."""
+
+    def test_all_types(self) -> None:
+        assert IdentityProviderType.OIDC.value == "oidc"
+        assert IdentityProviderType.SAML.value == "saml"
+        assert IdentityProviderType.GOOGLE.value == "google"
+        assert IdentityProviderType.GITHUB.value == "github"
+        assert IdentityProviderType.MICROSOFT.value == "microsoft"
+
+    def test_enum_count(self) -> None:
+        assert len(IdentityProviderType) == 5
+
+
+class TestIdentityProviderModel:
+    """Tests for IdentityProvider SQLAlchemy model definition."""
+
+    def test_tablename(self) -> None:
+        assert IdentityProvider.__tablename__ == "identity_providers"
+
+    def test_core_fields(self) -> None:
+        tid = uuid.uuid4()
+        idp = IdentityProvider(
+            tenant_id=tid,
+            name="Acme SSO",
+            provider_type=IdentityProviderType.OIDC,
+            client_id="acme-client-id",
+            scopes=["openid", "profile", "email"],
+            is_active=True,
+            is_default=False,
+            auto_provision=False,
+            allow_linking=True,
+            display_order=0,
+        )
+        assert idp.tenant_id == tid
+        assert idp.name == "Acme SSO"
+        assert idp.provider_type == IdentityProviderType.OIDC
+        assert idp.client_id == "acme-client-id"
+
+    def test_oidc_endpoints(self) -> None:
+        idp = IdentityProvider(
+            tenant_id=uuid.uuid4(),
+            name="Test",
+            provider_type=IdentityProviderType.OIDC,
+            client_id="c",
+            discovery_url="https://idp.example.com/.well-known/openid-configuration",
+            authorization_endpoint="https://idp.example.com/authorize",
+            token_endpoint="https://idp.example.com/token",
+            userinfo_endpoint="https://idp.example.com/userinfo",
+            jwks_uri="https://idp.example.com/.well-known/jwks.json",
+            scopes=["openid"],
+            is_active=True,
+            is_default=False,
+            auto_provision=False,
+            allow_linking=True,
+            display_order=0,
+        )
+        assert idp.discovery_url is not None
+        assert idp.jwks_uri is not None
+        assert "jwks" in (idp.jwks_uri or "")
+
+    def test_encrypted_secret(self) -> None:
+        idp = IdentityProvider(
+            tenant_id=uuid.uuid4(),
+            name="Test",
+            provider_type=IdentityProviderType.GITHUB,
+            client_id="c",
+            client_secret_encrypted=b"\x00\x01\x02encrypted",
+            scopes=["openid"],
+            is_active=True,
+            is_default=False,
+            auto_provision=False,
+            allow_linking=True,
+            display_order=0,
+        )
+        assert isinstance(idp.client_secret_encrypted, bytes)
+
+    def test_attribute_mapping(self) -> None:
+        idp = IdentityProvider(
+            tenant_id=uuid.uuid4(),
+            name="Test",
+            provider_type=IdentityProviderType.OIDC,
+            client_id="c",
+            attribute_mapping={"email": "mail", "name": "displayName"},
+            scopes=["openid"],
+            is_active=True,
+            is_default=False,
+            auto_provision=False,
+            allow_linking=True,
+            display_order=0,
+        )
+        assert idp.attribute_mapping is not None
+        assert idp.attribute_mapping["email"] == "mail"
+
+    def test_allowed_domains(self) -> None:
+        idp = IdentityProvider(
+            tenant_id=uuid.uuid4(),
+            name="Test",
+            provider_type=IdentityProviderType.OIDC,
+            client_id="c",
+            allowed_domains=["acme.com", "acme.org"],
+            scopes=["openid"],
+            is_active=True,
+            is_default=False,
+            auto_provision=False,
+            allow_linking=True,
+            display_order=0,
+        )
+        assert idp.allowed_domains is not None
+        assert "acme.com" in idp.allowed_domains
+
+    def test_ui_display_fields(self) -> None:
+        idp = IdentityProvider(
+            tenant_id=uuid.uuid4(),
+            name="Google",
+            provider_type=IdentityProviderType.GOOGLE,
+            client_id="c",
+            icon_url="https://cdn.example.com/google.svg",
+            button_text="Sign in with Google",
+            display_order=1,
+            scopes=["openid"],
+            is_active=True,
+            is_default=False,
+            auto_provision=False,
+            allow_linking=True,
+        )
+        assert idp.icon_url == "https://cdn.example.com/google.svg"
+        assert idp.button_text == "Sign in with Google"
+        assert idp.display_order == 1
+
+    def test_settings_flags(self) -> None:
+        idp = IdentityProvider(
+            tenant_id=uuid.uuid4(),
+            name="Test",
+            provider_type=IdentityProviderType.OIDC,
+            client_id="c",
+            is_active=True,
+            is_default=True,
+            auto_provision=True,
+            allow_linking=False,
+            scopes=["openid"],
+            display_order=0,
+        )
+        assert idp.is_default is True
+        assert idp.auto_provision is True
+        assert idp.allow_linking is False
+
+    def test_tenant_id_indexed(self) -> None:
+        col = IdentityProvider.__table__.c.tenant_id
+        assert col.index is True
+
+    def test_repr(self) -> None:
+        idp = IdentityProvider(
+            tenant_id=uuid.uuid4(),
+            name="Okta",
+            provider_type=IdentityProviderType.OIDC,
+            client_id="c",
+            scopes=["openid"],
+            is_active=True,
+            is_default=False,
+            auto_provision=False,
+            allow_linking=True,
+            display_order=0,
+        )
+        r = repr(idp)
+        assert "Okta" in r
+        assert "oidc" in r


### PR DESCRIPTION
## feat(models): IdentityProvider and FederatedIdentity

## Summary

Federation models aligned with auth/: IdentityProvider (5 types, OIDC endpoints, discovery/JWKS, encrypted secret, scopes, attribute mapping, domain restrictions, auto_provision, allow_linking, UI display), FederatedIdentity (external_subject/email/username, raw_claims, linked_at, last_login_at).

## Changes

- [x] IdentityProviderType enum (OIDC/SAML/GOOGLE/GITHUB/MICROSOFT)
- [x] IdentityProvider: OIDC endpoints, client credentials, scopes, attribute mapping, allowed_domains
- [x] Settings: is_active, is_default, auto_provision, allow_linking
- [x] UI: icon_url, button_text, display_order
- [x] FederatedIdentity: external_subject/email/username, raw_claims, linked_at, last_login_at
- [x] Unique + composite indexes
- [x] Tenant.identity_providers relationship
- [x] Alembic migration
- [x] 19 unit tests

## Dependencies

- #79 - Tenant model
- #1 - encryption
- #4 - User model

## Related Issue

Closes #84

## Test Plan

- [x] `make format` - code formatted
- [x] `make lint` - no linting errors
- [x] `make typecheck` - type checks pass
- [x] `make test` - all unit tests pass
- [x] `make bdd` - all BDD tests pass
- [x] `make check-license` - SPDX headers present
