### PR TITLE
feat(federation): GET /federation/callback — IdP callback + JIT provisioning + linking

### DIFF
--- a/features/federation_callback.feature
+++ b/features/federation_callback.feature
@@ -1,0 +1,16 @@
+Feature: Federation callback endpoint
+
+  Scenario: Callback with IdP error redirects to login
+    When I send a GET request to "/federation/callback?error=access_denied&error_description=User+denied"
+    Then the response status code should be 200
+    And the response body should contain "Login"
+
+  Scenario: Callback without code or state redirects to login
+    When I send a GET request to "/federation/callback"
+    Then the response status code should be 200
+    And the response body should contain "Login"
+
+  Scenario: Callback with invalid state redirects to login
+    When I send a GET request to "/federation/callback?code=test&state=invalid!!!"
+    Then the response status code should be 200
+    And the response body should contain "Login"

--- a/src/shomer/routes/federation.py
+++ b/src/shomer/routes/federation.py
@@ -1,18 +1,21 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2025 Chris <goabonga@pm.me>
 
-"""Federation provider listing and authorization initiation endpoints."""
+"""Federation provider listing, authorization initiation, and callback endpoints."""
 
 from __future__ import annotations
 
 import base64
 import json
+import logging
 
 from fastapi import APIRouter, HTTPException, Query, Request, status
 from fastapi.responses import JSONResponse, RedirectResponse
 
 from shomer.deps import DbSession
 from shomer.services.federation_service import FederationService
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/federation", tags=["federation"])
 
@@ -178,3 +181,199 @@ async def initiate_federation(
     )
 
     return RedirectResponse(url=auth_url, status_code=status.HTTP_302_FOUND)
+
+
+@router.get("/callback")
+async def federation_callback(
+    request: Request,
+    db: DbSession,
+    code: str | None = Query(None),
+    state: str | None = Query(None),
+    error: str | None = Query(None),
+    error_description: str | None = Query(None),
+) -> RedirectResponse:
+    """Handle callback from external identity provider.
+
+    Receives the authorization code, exchanges it for tokens,
+    extracts user info, performs JIT provisioning or account linking,
+    creates a session, and redirects to the original URI.
+
+    All errors redirect gracefully to the login page — never returns 500.
+
+    Parameters
+    ----------
+    request : Request
+        HTTP request.
+    db : DbSession
+        Database session.
+    code : str or None
+        Authorization code from IdP.
+    state : str or None
+        Encoded state parameter.
+    error : str or None
+        Error code from IdP.
+    error_description : str or None
+        Error description from IdP.
+
+    Returns
+    -------
+    RedirectResponse
+        Redirect to the original URI or login page.
+    """
+    # 1. Handle IdP error responses
+    if error:
+        logger.warning(
+            "Federation error from IdP: error=%s, description=%s",
+            error,
+            error_description,
+        )
+        msg = error_description or error
+        return RedirectResponse(
+            url=f"/ui/login?error=federation_failed&message={msg}",
+            status_code=status.HTTP_302_FOUND,
+        )
+
+    # 2. Validate required parameters
+    if not code or not state:
+        return RedirectResponse(
+            url="/ui/login?error=federation_failed&message=Missing+code+or+state",
+            status_code=status.HTTP_302_FOUND,
+        )
+
+    # 3. Decode state
+    try:
+        state_data = json.loads(base64.urlsafe_b64decode(state).decode())
+    except (ValueError, json.JSONDecodeError) as exc:
+        logger.error("Failed to decode federation state: %s", exc)
+        return RedirectResponse(
+            url="/ui/login?error=federation_failed&message=Invalid+state",
+            status_code=status.HTTP_302_FOUND,
+        )
+
+    tenant_slug = state_data.get("tenant_slug")
+    idp_id = state_data.get("idp_id")
+    code_verifier = state_data.get("code_verifier")
+    original_state = state_data.get("original_state")
+    redirect_uri = state_data.get("redirect_uri")
+
+    if not tenant_slug or not idp_id:
+        return RedirectResponse(
+            url="/ui/login?error=federation_failed&message=Invalid+state+data",
+            status_code=status.HTTP_302_FOUND,
+        )
+
+    # 4. Look up IdP
+    svc = FederationService(db)
+    idp = await svc.get_identity_provider(idp_id)
+    if not idp:
+        return RedirectResponse(
+            url="/ui/login?error=federation_failed&message=Provider+not+found",
+            status_code=status.HTTP_302_FOUND,
+        )
+
+    # 5. Build callback URL (must match authorization request)
+    scheme = request.headers.get("x-forwarded-proto", request.url.scheme)
+    host = request.headers.get("x-forwarded-host", request.url.netloc)
+    callback_url = f"{scheme}://{host}/federation/callback"
+
+    try:
+        # 6. Exchange code for tokens
+        logger.info("Exchanging authorization code: idp=%s", idp.name)
+        token_response = await svc.exchange_code_for_tokens(
+            idp=idp,
+            code=code,
+            callback_url=callback_url,
+            code_verifier=code_verifier,
+        )
+
+        access_token = token_response.get("access_token")
+        id_token_value = token_response.get("id_token")
+        if not access_token:
+            raise ValueError("No access token in IdP response")
+
+        # 7. Get user info
+        logger.info("Fetching user info: idp=%s", idp.name)
+        user_info = await svc.get_user_info(
+            idp=idp,
+            access_token=access_token,
+            id_token=id_token_value,
+        )
+        logger.info(
+            "User info received: subject=%s, email=%s",
+            user_info.subject,
+            user_info.email,
+        )
+
+        # 8. JIT provisioning / account linking
+        user, _fed_id, is_new = await svc.find_or_create_user(
+            idp=idp,
+            user_info=user_info,
+            tenant_slug=tenant_slug,
+        )
+        logger.info(
+            "User authenticated via federation: user_id=%s, new=%s, idp=%s",
+            user.id,
+            is_new,
+            idp.name,
+        )
+
+        # 9. Create session
+        from shomer.middleware.cookies import get_cookie_policy
+        from shomer.services.session_service import SessionService
+
+        session_svc = SessionService(db)
+        session, raw_token = await session_svc.create(
+            user_id=user.id,
+            user_agent=request.headers.get("user-agent"),
+            ip_address=request.client.host if request.client else None,
+        )
+        await db.flush()
+
+        # 10. Determine redirect
+        if redirect_uri:
+            final_redirect = redirect_uri
+            if original_state:
+                sep = "&" if "?" in final_redirect else "?"
+                final_redirect = f"{final_redirect}{sep}state={original_state}"
+        else:
+            final_redirect = "/ui/settings/profile"
+
+        # 11. Set cookies and redirect
+        from shomer.core.settings import get_settings
+
+        policy = get_cookie_policy(get_settings())
+        response = RedirectResponse(
+            url=final_redirect, status_code=status.HTTP_302_FOUND
+        )
+        response.set_cookie(
+            key="session_id",
+            value=raw_token,
+            httponly=policy.httponly,
+            secure=policy.secure,
+            samesite=policy.samesite,
+            domain=policy.domain or None,
+            max_age=86400,
+        )
+        response.set_cookie(
+            key="csrf_token",
+            value=session.csrf_token,
+            httponly=False,
+            secure=policy.secure,
+            samesite=policy.samesite,
+            domain=policy.domain or None,
+            max_age=86400,
+        )
+        return response
+
+    except ValueError as exc:
+        logger.error("Federation failed: %s", exc)
+        return RedirectResponse(
+            url=f"/ui/login?error=federation_failed&message={exc}",
+            status_code=status.HTTP_302_FOUND,
+        )
+    except Exception as exc:
+        logger.exception("Unexpected error during federation: %s", exc)
+        return RedirectResponse(
+            url="/ui/login?error=federation_failed&message=An+unexpected+error+occurred",
+            status_code=status.HTTP_302_FOUND,
+        )

--- a/tests/routes/test_federation_callback_unit.py
+++ b/tests/routes/test_federation_callback_unit.py
@@ -1,0 +1,421 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Pure unit tests for federation callback route handler."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from shomer.routes.federation import federation_callback
+
+
+class TestFederationCallbackIdPError:
+    """Tests for IdP error handling."""
+
+    def test_idp_error_redirects_to_login(self) -> None:
+        async def _run() -> None:
+            req = MagicMock()
+            db = AsyncMock()
+            resp = await federation_callback(
+                req,
+                db,
+                code=None,
+                state=None,
+                error="access_denied",
+                error_description="User denied access",
+            )
+            assert resp.status_code == 302
+            assert "federation_failed" in resp.headers["location"]
+            assert "denied" in resp.headers["location"]
+
+        asyncio.run(_run())
+
+    def test_idp_error_without_description(self) -> None:
+        async def _run() -> None:
+            req = MagicMock()
+            db = AsyncMock()
+            resp = await federation_callback(
+                req,
+                db,
+                code=None,
+                state=None,
+                error="server_error",
+                error_description=None,
+            )
+            assert resp.status_code == 302
+            assert "server_error" in resp.headers["location"]
+
+        asyncio.run(_run())
+
+
+class TestFederationCallbackMissingParams:
+    """Tests for missing required parameters."""
+
+    def test_missing_code_redirects(self) -> None:
+        async def _run() -> None:
+            req = MagicMock()
+            db = AsyncMock()
+            resp = await federation_callback(
+                req,
+                db,
+                code=None,
+                state="some-state",
+                error=None,
+                error_description=None,
+            )
+            assert resp.status_code == 302
+            assert "Missing" in resp.headers["location"]
+
+        asyncio.run(_run())
+
+    def test_missing_state_redirects(self) -> None:
+        async def _run() -> None:
+            req = MagicMock()
+            db = AsyncMock()
+            resp = await federation_callback(
+                req,
+                db,
+                code="auth-code",
+                state=None,
+                error=None,
+                error_description=None,
+            )
+            assert resp.status_code == 302
+            assert "Missing" in resp.headers["location"]
+
+        asyncio.run(_run())
+
+
+class TestFederationCallbackStateDecoding:
+    """Tests for state parameter decoding."""
+
+    def test_invalid_state_redirects(self) -> None:
+        async def _run() -> None:
+            req = MagicMock()
+            db = AsyncMock()
+            resp = await federation_callback(
+                req,
+                db,
+                code="code",
+                state="not-valid-base64!!!",
+                error=None,
+                error_description=None,
+            )
+            assert resp.status_code == 302
+            assert "Invalid" in resp.headers["location"]
+
+        asyncio.run(_run())
+
+    def test_state_missing_tenant_redirects(self) -> None:
+        async def _run() -> None:
+            state = base64.urlsafe_b64encode(
+                json.dumps({"idp_id": "123"}).encode()
+            ).decode()
+            req = MagicMock()
+            db = AsyncMock()
+            resp = await federation_callback(
+                req,
+                db,
+                code="code",
+                state=state,
+                error=None,
+                error_description=None,
+            )
+            assert resp.status_code == 302
+            assert "Invalid+state" in resp.headers["location"]
+
+        asyncio.run(_run())
+
+    def test_state_missing_idp_redirects(self) -> None:
+        async def _run() -> None:
+            state = base64.urlsafe_b64encode(
+                json.dumps({"tenant_slug": "acme"}).encode()
+            ).decode()
+            req = MagicMock()
+            db = AsyncMock()
+            resp = await federation_callback(
+                req,
+                db,
+                code="code",
+                state=state,
+                error=None,
+                error_description=None,
+            )
+            assert resp.status_code == 302
+            assert "Invalid+state" in resp.headers["location"]
+
+        asyncio.run(_run())
+
+
+class TestFederationCallbackIdPLookup:
+    """Tests for IdP lookup."""
+
+    def test_idp_not_found_redirects(self) -> None:
+        async def _run() -> None:
+            state = base64.urlsafe_b64encode(
+                json.dumps({"tenant_slug": "acme", "idp_id": "unknown"}).encode()
+            ).decode()
+
+            with patch("shomer.routes.federation.FederationService") as mock_cls:
+                mock_svc = AsyncMock()
+                mock_svc.get_identity_provider.return_value = None
+                mock_cls.return_value = mock_svc
+
+                req = MagicMock()
+                db = AsyncMock()
+                resp = await federation_callback(
+                    req,
+                    db,
+                    code="code",
+                    state=state,
+                    error=None,
+                    error_description=None,
+                )
+                assert resp.status_code == 302
+                assert "not+found" in resp.headers["location"]
+
+        asyncio.run(_run())
+
+
+class TestFederationCallbackSuccess:
+    """Tests for successful callback flow."""
+
+    def test_success_creates_session_and_redirects(self) -> None:
+        async def _run() -> None:
+            idp_id = str(uuid.uuid4())
+            state_data = {
+                "tenant_slug": "acme",
+                "idp_id": idp_id,
+                "code_verifier": "verifier",
+                "redirect_uri": "/dashboard",
+                "original_state": "orig-state",
+            }
+            state = base64.urlsafe_b64encode(json.dumps(state_data).encode()).decode()
+
+            mock_idp = MagicMock()
+            mock_idp.name = "Google"
+            mock_user = MagicMock()
+            mock_user.id = uuid.uuid4()
+            mock_fed_id = MagicMock()
+            mock_user_info = MagicMock()
+            mock_user_info.subject = "google-123"
+            mock_user_info.email = "user@acme.com"
+
+            mock_session = MagicMock()
+            mock_session.csrf_token = "csrf-tok"
+
+            mock_policy = MagicMock()
+            mock_policy.httponly = True
+            mock_policy.secure = False
+            mock_policy.samesite = "lax"
+            mock_policy.domain = None
+
+            with (
+                patch("shomer.routes.federation.FederationService") as mock_fed_cls,
+                patch("shomer.services.session_service.SessionService") as mock_sess_cls,
+                patch(
+                    "shomer.middleware.cookies.get_cookie_policy",
+                    return_value=mock_policy,
+                ),
+            ):
+                mock_svc = AsyncMock()
+                mock_svc.get_identity_provider.return_value = mock_idp
+                mock_svc.exchange_code_for_tokens.return_value = {
+                    "access_token": "at",
+                    "id_token": "idt",
+                }
+                mock_svc.get_user_info.return_value = mock_user_info
+                mock_svc.find_or_create_user.return_value = (
+                    mock_user,
+                    mock_fed_id,
+                    True,
+                )
+                mock_fed_cls.return_value = mock_svc
+
+                mock_sess_svc = AsyncMock()
+                mock_sess_svc.create.return_value = (mock_session, "raw-tok")
+                mock_sess_cls.return_value = mock_sess_svc
+
+                req = MagicMock()
+                req.headers = MagicMock()
+                req.headers.get = MagicMock(side_effect=lambda k, d="": d)
+                req.url = MagicMock()
+                req.url.scheme = "https"
+                req.url.netloc = "acme.shomer.io"
+                req.client.host = "127.0.0.1"
+                db = AsyncMock()
+
+                resp = await federation_callback(
+                    req,
+                    db,
+                    code="auth-code",
+                    state=state,
+                    error=None,
+                    error_description=None,
+                )
+                assert resp.status_code == 302
+                assert "/dashboard" in resp.headers["location"]
+                assert "state=orig-state" in resp.headers["location"]
+
+        asyncio.run(_run())
+
+    def test_success_without_redirect_uri_goes_to_profile(self) -> None:
+        async def _run() -> None:
+            state_data = {
+                "tenant_slug": "acme",
+                "idp_id": str(uuid.uuid4()),
+            }
+            state = base64.urlsafe_b64encode(json.dumps(state_data).encode()).decode()
+
+            mock_idp = MagicMock()
+            mock_idp.name = "Google"
+            mock_user = MagicMock()
+            mock_user.id = uuid.uuid4()
+            mock_user_info = MagicMock()
+            mock_user_info.subject = "sub"
+            mock_user_info.email = "u@b.com"
+
+            mock_session = MagicMock()
+            mock_session.csrf_token = "csrf"
+
+            mock_policy = MagicMock()
+            mock_policy.httponly = True
+            mock_policy.secure = False
+            mock_policy.samesite = "lax"
+            mock_policy.domain = None
+
+            with (
+                patch("shomer.routes.federation.FederationService") as mock_fed_cls,
+                patch("shomer.services.session_service.SessionService") as mock_sess_cls,
+                patch(
+                    "shomer.middleware.cookies.get_cookie_policy",
+                    return_value=mock_policy,
+                ),
+            ):
+                mock_svc = AsyncMock()
+                mock_svc.get_identity_provider.return_value = mock_idp
+                mock_svc.exchange_code_for_tokens.return_value = {"access_token": "at"}
+                mock_svc.get_user_info.return_value = mock_user_info
+                mock_svc.find_or_create_user.return_value = (
+                    mock_user,
+                    MagicMock(),
+                    False,
+                )
+                mock_fed_cls.return_value = mock_svc
+
+                mock_sess_svc = AsyncMock()
+                mock_sess_svc.create.return_value = (mock_session, "tok")
+                mock_sess_cls.return_value = mock_sess_svc
+
+                req = MagicMock()
+                req.headers = MagicMock()
+                req.headers.get = MagicMock(side_effect=lambda k, d="": d)
+                req.url = MagicMock()
+                req.url.scheme = "https"
+                req.url.netloc = "shomer.io"
+                req.client.host = "127.0.0.1"
+                db = AsyncMock()
+
+                resp = await federation_callback(
+                    req,
+                    db,
+                    code="code",
+                    state=state,
+                    error=None,
+                    error_description=None,
+                )
+                assert resp.status_code == 302
+                assert "/ui/settings/profile" in resp.headers["location"]
+
+        asyncio.run(_run())
+
+
+class TestFederationCallbackErrorRecovery:
+    """Tests for graceful error recovery."""
+
+    def test_value_error_redirects_to_login(self) -> None:
+        async def _run() -> None:
+            state_data = {
+                "tenant_slug": "acme",
+                "idp_id": str(uuid.uuid4()),
+            }
+            state = base64.urlsafe_b64encode(json.dumps(state_data).encode()).decode()
+
+            mock_idp = MagicMock()
+            mock_idp.name = "Test"
+
+            with patch("shomer.routes.federation.FederationService") as mock_cls:
+                mock_svc = AsyncMock()
+                mock_svc.get_identity_provider.return_value = mock_idp
+                mock_svc.exchange_code_for_tokens.return_value = {"access_token": "at"}
+                mock_svc.get_user_info.side_effect = ValueError("Bad token")
+                mock_cls.return_value = mock_svc
+
+                req = MagicMock()
+                req.headers = MagicMock()
+                req.headers.get = MagicMock(side_effect=lambda k, d="": d)
+                req.url = MagicMock()
+                req.url.scheme = "https"
+                req.url.netloc = "shomer.io"
+                db = AsyncMock()
+
+                resp = await federation_callback(
+                    req,
+                    db,
+                    code="code",
+                    state=state,
+                    error=None,
+                    error_description=None,
+                )
+                assert resp.status_code == 302
+                assert (
+                    "Bad+token" in resp.headers["location"]
+                    or "Bad" in resp.headers["location"]
+                )
+
+        asyncio.run(_run())
+
+    def test_generic_exception_redirects_to_login(self) -> None:
+        async def _run() -> None:
+            state_data = {
+                "tenant_slug": "acme",
+                "idp_id": str(uuid.uuid4()),
+            }
+            state = base64.urlsafe_b64encode(json.dumps(state_data).encode()).decode()
+
+            mock_idp = MagicMock()
+            mock_idp.name = "Test"
+
+            with patch("shomer.routes.federation.FederationService") as mock_cls:
+                mock_svc = AsyncMock()
+                mock_svc.get_identity_provider.return_value = mock_idp
+                mock_svc.exchange_code_for_tokens.side_effect = RuntimeError(
+                    "Connection failed"
+                )
+                mock_cls.return_value = mock_svc
+
+                req = MagicMock()
+                req.headers = MagicMock()
+                req.headers.get = MagicMock(side_effect=lambda k, d="": d)
+                req.url = MagicMock()
+                req.url.scheme = "https"
+                req.url.netloc = "shomer.io"
+                db = AsyncMock()
+
+                resp = await federation_callback(
+                    req,
+                    db,
+                    code="code",
+                    state=state,
+                    error=None,
+                    error_description=None,
+                )
+                assert resp.status_code == 302
+                assert "unexpected" in resp.headers["location"].lower()
+
+        asyncio.run(_run())


### PR DESCRIPTION
## feat(federation): GET /federation/callback — IdP callback + JIT provisioning + linking

## Summary

Federation callback aligned with auth/: handle IdP errors, decode state, exchange code, fetch user info, JIT provisioning/linking, create session with cookies, redirect to original URI. All errors redirect gracefully.

## Changes

- [x] GET /federation/callback (code, state, error params)
- [x] IdP error → redirect to login
- [x] State decode (base64 JSON)
- [x] Token exchange + user info
- [x] JIT provisioning + account linking
- [x] Session + cookies via get_cookie_policy
- [x] Redirect to redirect_uri or fallback /ui/settings/profile
- [x] ValueError + Exception → graceful redirect
- [x] 12 unit tests + 3 BDD scenarios

## Dependencies

- #85 - Federation service
- #84 - IdentityProvider model
- #20 - session service

## Related Issue

Closes #86

## Test Plan

- [x] `make format` - code formatted
- [x] `make lint` - no linting errors
- [x] `make typecheck` - type checks pass
- [x] `make test` - all unit tests pass
- [x] `make bdd` - all BDD tests pass
- [x] `make check-license` - SPDX headers present
