### PR TITLE
feat(ui): display otpauth: provisioning URI on MFA setup page

### DIFF
--- a/features/ui_mfa.feature
+++ b/features/ui_mfa.feature
@@ -22,7 +22,7 @@ Feature: MFA UI pages
     And the page should contain "Set Up MFA"
     And I take a screenshot named "mfa_setup_page"
 
-  Scenario: MFA setup generates QR code and secret
+  Scenario: MFA setup generates QR code, secret and otpauth URI
     Given I register and verify "mfa-ui-qr@example.com" with password "securepassword123"
     When I open the page "/ui/login"
     And I fill "input[name='email']" with "mfa-ui-qr@example.com"
@@ -34,6 +34,8 @@ Feature: MFA UI pages
     Then the page should contain "authenticator app"
     And the page should contain "Verify"
     And the page should have an element "img.qr-code"
+    And the page should contain "provisioning URI"
+    And the page should have an element "#otpauth-uri"
     And I take a screenshot named "mfa_setup_qr"
 
   Scenario: MFA challenge page renders with token

--- a/src/shomer/templates/mfa/setup.html
+++ b/src/shomer/templates/mfa/setup.html
@@ -19,6 +19,14 @@
     <p class="secret-display"><code>{{ secret }}</code></p>
 </details>
 
+<details class="secret-details">
+    <summary>Copy provisioning URI</summary>
+    <div class="uri-display">
+        <input type="text" id="otpauth-uri" value="{{ provisioning_uri }}" readonly onclick="this.select()">
+        <button type="button" class="copy-btn" onclick="navigator.clipboard.writeText(document.getElementById('otpauth-uri').value)">Copy</button>
+    </div>
+</details>
+
 <form method="post" action="/ui/mfa/setup">
     <input type="hidden" name="step" value="verify">
     <input type="text" name="code" placeholder="Enter 6-digit code" maxlength="6" pattern="[0-9]{6}" required>
@@ -47,5 +55,8 @@
     .secret-details { margin: 12px 0; }
     .secret-details summary { cursor: pointer; color: #666; font-size: 0.9em; }
     .secret-display { padding: 12px; background: #f8f8f8; border-radius: 8px; word-break: break-all; margin-top: 8px; }
+    .uri-display { display: flex; gap: 8px; margin-top: 8px; }
+    .uri-display input { flex: 1; padding: 8px; font-family: monospace; font-size: 0.85em; border: 1px solid #ccc; border-radius: 4px; background: #f8f8f8; }
+    .copy-btn { padding: 8px 16px; cursor: pointer; border: 1px solid #ccc; border-radius: 4px; background: #eee; }
 </style>
 {% endblock %}

--- a/tests/routes/test_mfa_ui_unit.py
+++ b/tests/routes/test_mfa_ui_unit.py
@@ -103,6 +103,7 @@ class TestMFASetupSubmit:
                 ctx = call_args[0][2] if len(call_args[0]) > 2 else call_args[1]
                 assert "secret" in ctx
                 assert "provisioning_uri" in ctx
+                assert ctx["provisioning_uri"].startswith("otpauth://totp/")
 
         asyncio.run(_run())
 


### PR DESCRIPTION
## feat(ui): display otpauth: provisioning URI on MFA setup page

## Summary

- Add collapsible "Copy provisioning URI" section with read-only input and copy button on MFA setup page
- Users can copy-paste the full `otpauth://totp/...` URI into CLI tools or authenticator apps

## Changes

- [x] Add otpauth: URI display in a copyable field on the MFA setup template
- [x] Unit test for provisioning URI in template context (asserts `otpauth://totp/` prefix)
- [x] BDD happy path: MFA setup page shows otpauth URI element

## Dependencies

- #70 — MFA UI pages

## Related Issue

Closes #261

## Test Plan

- [x] `make format` - code formatted
- [x] `make lint` - no linting errors
- [x] `make typecheck` - type checks pass
- [x] `make test` - all unit tests pass (1137 passed)
- [x] `make bdd` - all 209 scenarios pass (0 failures)
- [x] `make check-license` - SPDX headers present