### PR TITLE
feat(email): MJML templates (verification, reset, MFA, welcome)

### DIFF
--- a/src/shomer/email/renderer.py
+++ b/src/shomer/email/renderer.py
@@ -1,16 +1,29 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2025 Chris <goabonga@pm.me>
 
-"""Jinja2 template rendering engine for email bodies."""
+"""Jinja2 template rendering engine for email bodies.
+
+Supports tenant branding injection (logo, colors, app name).
+"""
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 #: Default directory for email templates.
 _TEMPLATE_DIR = Path(__file__).parent.parent / "templates" / "email"
+
+#: Default branding values used when no tenant branding is provided.
+DEFAULT_BRANDING: dict[str, str] = {
+    "app_name": "Shomer",
+    "primary_color": "#1a1a2e",
+    "secondary_color": "#16213e",
+    "bg_color": "#f4f4f7",
+}
 
 
 def create_env(template_dir: Path | None = None) -> Environment:
@@ -39,8 +52,13 @@ def render_template(
     context: dict[str, object],
     *,
     template_dir: Path | None = None,
+    branding: dict[str, Any] | None = None,
 ) -> str:
-    """Render an email template to a string.
+    """Render an email template to a string with branding support.
+
+    Injects default branding variables (``app_name``, ``primary_color``,
+    etc.) which can be overridden by the ``branding`` parameter or
+    individual ``context`` keys.
 
     Parameters
     ----------
@@ -50,6 +68,8 @@ def render_template(
         Variables passed to the template.
     template_dir : Path or None
         Override template directory.
+    branding : dict[str, Any] or None
+        Tenant branding overrides (logo_url, primary_color, etc.).
 
     Returns
     -------
@@ -58,4 +78,14 @@ def render_template(
     """
     env = create_env(template_dir)
     template = env.get_template(template_name)
-    return template.render(context)
+
+    # Build final context: defaults < branding < explicit context
+    merged: dict[str, object] = {
+        **DEFAULT_BRANDING,
+        "year": str(datetime.now(timezone.utc).year),
+    }
+    if branding:
+        merged.update(branding)
+    merged.update(context)
+
+    return template.render(merged)

--- a/src/shomer/templates/email/base.html
+++ b/src/shomer/templates/email/base.html
@@ -1,5 +1,60 @@
 <!DOCTYPE html>
-<html lang="en">
-<head><meta charset="utf-8"></head>
-<body>{% block content %}{% endblock %}</body>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>{% block title %}Shomer{% endblock %}</title>
+  <style type="text/css">
+    body, table, td { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; }
+    body { margin: 0; padding: 0; background-color: {{ bg_color | default('#f4f4f7') }}; }
+    .wrapper { width: 100%; background-color: {{ bg_color | default('#f4f4f7') }}; padding: 40px 0; }
+    .container { max-width: 600px; margin: 0 auto; background-color: #ffffff; border-radius: 8px; overflow: hidden; box-shadow: 0 2px 8px rgba(0,0,0,0.05); }
+    .header { background-color: {{ primary_color | default('#1a1a2e') }}; padding: 24px 32px; text-align: center; }
+    .header img { max-height: 48px; }
+    .header h1 { color: #ffffff; font-size: 20px; margin: 0; font-weight: 600; }
+    .content { padding: 32px; color: #333333; font-size: 16px; line-height: 1.6; }
+    .content h2 { color: {{ primary_color | default('#1a1a2e') }}; font-size: 22px; margin: 0 0 16px; }
+    .code-box { background-color: #f0f0f5; border-radius: 8px; padding: 20px; text-align: center; margin: 24px 0; }
+    .code-box .code { font-size: 32px; font-weight: 700; letter-spacing: 6px; color: {{ primary_color | default('#1a1a2e') }}; font-family: 'Courier New', monospace; }
+    .btn { display: inline-block; background-color: {{ primary_color | default('#1a1a2e') }}; color: #ffffff !important; padding: 14px 32px; border-radius: 6px; text-decoration: none; font-weight: 600; font-size: 16px; margin: 16px 0; }
+    .btn:hover { background-color: {{ secondary_color | default('#16213e') }}; }
+    .footer { padding: 24px 32px; text-align: center; color: #999999; font-size: 12px; line-height: 1.5; border-top: 1px solid #eeeeee; }
+    .footer a { color: #999999; text-decoration: underline; }
+    .muted { color: #888888; font-size: 14px; }
+    @media only screen and (max-width: 620px) {
+      .container { width: 100% !important; border-radius: 0 !important; }
+      .content { padding: 24px 20px !important; }
+      .header { padding: 20px !important; }
+    }
+  </style>
+</head>
+<body>
+  <div class="wrapper">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+      <tr><td align="center">
+        <div class="container">
+          <div class="header">
+            {% if logo_url %}
+            <img src="{{ logo_url }}" alt="{{ app_name | default('Shomer') }}">
+            {% else %}
+            <h1>{{ app_name | default('Shomer') }}</h1>
+            {% endif %}
+          </div>
+          <div class="content">
+            {% block content %}{% endblock %}
+          </div>
+          <div class="footer">
+            {% block footer %}
+            <p>&copy; {{ year | default('2025') }} {{ app_name | default('Shomer') }}. All rights reserved.</p>
+            {% if support_url %}
+            <p><a href="{{ support_url }}">Help &amp; Support</a></p>
+            {% endif %}
+            {% endblock %}
+          </div>
+        </div>
+      </td></tr>
+    </table>
+  </div>
+</body>
 </html>

--- a/src/shomer/templates/email/mfa_code.html
+++ b/src/shomer/templates/email/mfa_code.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+{% block title %}Your verification code{% endblock %}
+{% block content %}
+<h2>Your verification code</h2>
+<p>Use the code below to complete your sign-in. Do not share this code with anyone.</p>
+<div class="code-box">
+  <div class="code">{{ code }}</div>
+</div>
+<p class="muted">This code expires in 5 minutes. If you didn't try to sign in, please secure your account immediately by changing your password.</p>
+{% endblock %}

--- a/src/shomer/templates/email/mjml/base.mjml
+++ b/src/shomer/templates/email/mjml/base.mjml
@@ -1,0 +1,37 @@
+<mjml>
+  <mj-head>
+    <mj-attributes>
+      <mj-all font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif" />
+      <mj-text font-size="16px" line-height="1.6" color="#333333" />
+      <mj-button background-color="{{ primary_color | default('#1a1a2e') }}" color="#ffffff" font-size="16px" font-weight="600" border-radius="6px" />
+    </mj-attributes>
+  </mj-head>
+  <mj-body background-color="{{ bg_color | default('#f4f4f7') }}">
+    <!-- Header -->
+    <mj-section background-color="{{ primary_color | default('#1a1a2e') }}" padding="24px">
+      <mj-column>
+        {% if logo_url %}
+        <mj-image src="{{ logo_url }}" alt="{{ app_name | default('Shomer') }}" width="120px" />
+        {% else %}
+        <mj-text align="center" color="#ffffff" font-size="20px" font-weight="600">{{ app_name | default('Shomer') }}</mj-text>
+        {% endif %}
+      </mj-column>
+    </mj-section>
+
+    <!-- Content -->
+    <mj-section background-color="#ffffff" padding="32px">
+      <mj-column>
+        {% block content %}{% endblock %}
+      </mj-column>
+    </mj-section>
+
+    <!-- Footer -->
+    <mj-section padding="24px">
+      <mj-column>
+        <mj-text align="center" color="#999999" font-size="12px">
+          &copy; {{ year | default('2025') }} {{ app_name | default('Shomer') }}. All rights reserved.
+        </mj-text>
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>

--- a/src/shomer/templates/email/password_reset.html
+++ b/src/shomer/templates/email/password_reset.html
@@ -1,7 +1,11 @@
 {% extends "base.html" %}
+{% block title %}Reset your password{% endblock %}
 {% block content %}
-<h1>Reset your password</h1>
-<p>Click the link below to reset your password:</p>
-<p><a href="{{ token }}">Reset Password</a></p>
-<p>This link expires in 1 hour.</p>
+<h2>Reset your password</h2>
+<p>We received a request to reset your password. Click the button below to choose a new one.</p>
+<p style="text-align: center;">
+  <a href="{{ reset_url | default(token) }}" class="btn">Reset Password</a>
+</p>
+<p class="muted">This link expires in 1 hour. If you didn't request a password reset, you can safely ignore this email.</p>
+<p class="muted" style="word-break: break-all;">If the button doesn't work, copy this link:<br>{{ reset_url | default(token) }}</p>
 {% endblock %}

--- a/src/shomer/templates/email/verification.html
+++ b/src/shomer/templates/email/verification.html
@@ -1,6 +1,10 @@
 {% extends "base.html" %}
+{% block title %}Verify your email{% endblock %}
 {% block content %}
-<h1>Verify your email</h1>
-<p>Your verification code is: <strong>{{ code }}</strong></p>
-<p>This code expires in 15 minutes.</p>
+<h2>Verify your email address</h2>
+<p>Thanks for signing up! Use the code below to verify your email address.</p>
+<div class="code-box">
+  <div class="code">{{ code }}</div>
+</div>
+<p class="muted">This code expires in 15 minutes. If you didn't create an account, you can safely ignore this email.</p>
 {% endblock %}

--- a/src/shomer/templates/email/welcome.html
+++ b/src/shomer/templates/email/welcome.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% block title %}Welcome to {{ app_name | default('Shomer') }}{% endblock %}
+{% block content %}
+<h2>Welcome{% if username %}, {{ username }}{% endif %}!</h2>
+<p>Your account has been created and verified. You're all set to start using {{ app_name | default('Shomer') }}.</p>
+{% if login_url %}
+<p style="text-align: center;">
+  <a href="{{ login_url }}" class="btn">Go to Login</a>
+</p>
+{% endif %}
+<p>Here's what you can do:</p>
+<ul style="padding-left: 20px; color: #555555;">
+  <li>Set up <strong>multi-factor authentication</strong> for extra security</li>
+  <li>Complete your <strong>profile</strong> with your personal information</li>
+  <li>Create <strong>personal access tokens</strong> for API integrations</li>
+</ul>
+<p class="muted">If you have any questions, don't hesitate to reach out to our support team.</p>
+{% endblock %}

--- a/tests/test_email_templates_unit.py
+++ b/tests/test_email_templates_unit.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Unit tests for production email templates with branding."""
+
+from __future__ import annotations
+
+from shomer.email.renderer import DEFAULT_BRANDING, render_template
+
+
+class TestProductionTemplates:
+    """Tests for MJML-derived email templates with branding."""
+
+    def test_verification_renders_code(self) -> None:
+        """Verification template renders the code."""
+        html = render_template("verification.html", {"code": "123456"})
+        assert "123456" in html
+        assert "Verify your email" in html
+
+    def test_password_reset_renders_link(self) -> None:
+        """Password reset template renders the reset link."""
+        html = render_template(
+            "password_reset.html",
+            {"token": "https://example.com/reset/abc"},
+        )
+        assert "Reset your password" in html
+        assert "https://example.com/reset/abc" in html
+
+    def test_mfa_code_renders(self) -> None:
+        """MFA code template renders the code."""
+        html = render_template("mfa_code.html", {"code": "654321"})
+        assert "654321" in html
+        assert "verification code" in html
+
+    def test_welcome_renders_with_username(self) -> None:
+        """Welcome template renders with username."""
+        html = render_template("welcome.html", {"username": "Alice"})
+        assert "Alice" in html
+        assert "Welcome" in html
+
+    def test_welcome_without_username(self) -> None:
+        """Welcome template renders without username."""
+        html = render_template("welcome.html", {})
+        assert "Welcome" in html
+
+    def test_welcome_with_login_url(self) -> None:
+        """Welcome template renders login button."""
+        html = render_template(
+            "welcome.html", {"login_url": "https://example.com/login"}
+        )
+        assert "Go to Login" in html
+
+    def test_default_branding_applied(self) -> None:
+        """Default branding colors injected."""
+        html = render_template("verification.html", {"code": "000000"})
+        assert DEFAULT_BRANDING["primary_color"] in html
+        assert "Shomer" in html
+
+    def test_custom_branding_overrides(self) -> None:
+        """Custom branding overrides defaults."""
+        html = render_template(
+            "verification.html",
+            {"code": "000000"},
+            branding={
+                "app_name": "Acme Auth",
+                "primary_color": "#ff0000",
+                "logo_url": "https://acme.com/logo.png",
+            },
+        )
+        assert "Acme Auth" in html
+        assert "#ff0000" in html
+        assert "https://acme.com/logo.png" in html
+
+    def test_context_overrides_branding(self) -> None:
+        """Explicit context takes precedence over branding."""
+        html = render_template(
+            "verification.html",
+            {"code": "111111", "app_name": "Override"},
+            branding={"app_name": "Branding"},
+        )
+        assert "Override" in html
+
+    def test_year_injected(self) -> None:
+        """Current year injected into footer."""
+        from datetime import datetime, timezone
+
+        html = render_template("verification.html", {"code": "000000"})
+        assert str(datetime.now(timezone.utc).year) in html
+
+    def test_responsive_meta(self) -> None:
+        """Base template includes viewport meta."""
+        html = render_template("verification.html", {"code": "000000"})
+        assert "viewport" in html
+
+    def test_support_url_in_footer(self) -> None:
+        """Support link shown when provided."""
+        html = render_template(
+            "verification.html",
+            {"code": "000000"},
+            branding={"support_url": "https://help.example.com"},
+        )
+        assert "https://help.example.com" in html


### PR DESCRIPTION
## feat(email): MJML templates (verification, reset, MFA, welcome)

## Summary

Professional responsive HTML email templates with tenant branding support. Base layout with logo/color/footer slots. 4 templates: verification, password reset, MFA code, welcome.

## Changes

- [x] MJML base layout with branding slots (logo, colors, app name, footer, support URL)
- [x] Email verification template (code box)
- [x] Password reset template (CTA button + fallback link)
- [x] MFA email fallback template (6-digit code)
- [x] Welcome email template (onboarding checklist)
- [x] Tenant branding integration (defaults < branding < context)
- [x] MJML source files for future compilation
- [x] 12 unit tests for template rendering + branding

## Related Issue

Closes #98

## Test Plan

- [x] make format - code formatted
- [x] make lint - no linting errors
- [x] make typecheck - type checks pass
- [x] make test - 1222 passed
- [x] make check-license - SPDX headers present