### PR TITLE
feat(ui): email management in settings (add, remove, verify, set-primary)

### DIFF
--- a/features/steps/mail_steps.py
+++ b/features/steps/mail_steps.py
@@ -247,6 +247,7 @@ def _verify_via_db(email):
         f"UPDATE user_emails SET is_verified = true "
         f"WHERE email = '{email}' AND is_verified = false;"
     )
+    pg_port = os.environ.get("BDD_PG_PORT", "5432")
     result = subprocess.run(
         [
             "psql",

--- a/features/ui_settings_emails.feature
+++ b/features/ui_settings_emails.feature
@@ -1,0 +1,89 @@
+Feature: Email management in settings UI
+
+  Scenario: Email settings page shows primary email with badges
+    Given I register and verify "emails-page@example.com" with password "securepassword123"
+    When I open the page "/ui/login"
+    And I fill "input[name='email']" with "emails-page@example.com"
+    And I fill "input[name='password']" with "securepassword123"
+    And I click the "Login" button
+    Then the page URL should contain "/"
+    When I navigate to "/ui/settings/emails"
+    Then the page should contain "Email Addresses"
+    And the page should contain "emails-page@example.com"
+    And the page should contain "Primary"
+    And the page should contain "Verified"
+    And the page should have an element "input[name='email'][type='email']"
+    And I take a screenshot named "settings_emails_list"
+
+  Scenario: Add email form is present on the page
+    Given I register and verify "emails-form@example.com" with password "securepassword123"
+    When I open the page "/ui/login"
+    And I fill "input[name='email']" with "emails-form@example.com"
+    And I fill "input[name='password']" with "securepassword123"
+    And I click the "Login" button
+    Then the page URL should contain "/"
+    When I navigate to "/ui/settings/emails"
+    Then the page should contain "Add Email"
+    And the page should have an element "input[name='email'][placeholder='new@example.com']"
+    And the page should have an element "button:has-text('Add Email')"
+    And I take a screenshot named "settings_emails_add_form"
+
+  Scenario: Add a new email shows success message
+    Given I register and verify "emails-add@example.com" with password "securepassword123"
+    When I open the page "/ui/login"
+    And I fill "input[name='email']" with "emails-add@example.com"
+    And I fill "input[name='password']" with "securepassword123"
+    And I click the "Login" button
+    Then the page URL should contain "/"
+    When I navigate to "/ui/settings/emails"
+    And I fill "input[name='email'][type='email']" with "newemail-add@example.com"
+    And I click the "Add Email" button
+    Then the page should contain "Email added"
+    And the page should contain "newemail-add@example.com"
+    And the page should contain "Unverified"
+    And I take a screenshot named "settings_emails_added"
+
+  Scenario: Add duplicate email shows error message
+    Given I register and verify "emails-dup@example.com" with password "securepassword123"
+    When I open the page "/ui/login"
+    And I fill "input[name='email']" with "emails-dup@example.com"
+    And I fill "input[name='password']" with "securepassword123"
+    And I click the "Login" button
+    Then the page URL should contain "/"
+    When I navigate to "/ui/settings/emails"
+    And I fill "input[name='email'][type='email']" with "emails-dup@example.com"
+    And I click the "Add Email" button
+    Then the page should contain "Email already registered"
+    And I take a screenshot named "settings_emails_duplicate"
+
+  Scenario: Unverified email shows verify and resend buttons
+    Given I register and verify "emails-unv@example.com" with password "securepassword123"
+    When I open the page "/ui/login"
+    And I fill "input[name='email']" with "emails-unv@example.com"
+    And I fill "input[name='password']" with "securepassword123"
+    And I click the "Login" button
+    Then the page URL should contain "/"
+    When I navigate to "/ui/settings/emails"
+    And I fill "input[name='email'][type='email']" with "newemail-unv@example.com"
+    And I click the "Add Email" button
+    Then the page should contain "newemail-unv@example.com"
+    And the page should contain "Unverified"
+    And the page should have an element "button:has-text('Verify')"
+    And the page should have an element "button:has-text('Resend')"
+    And the page should have an element "button:has-text('Remove')"
+    And I take a screenshot named "settings_emails_unverified_buttons"
+
+  Scenario: Remove a non-primary email shows success
+    Given I register and verify "emails-rm@example.com" with password "securepassword123"
+    When I open the page "/ui/login"
+    And I fill "input[name='email']" with "emails-rm@example.com"
+    And I fill "input[name='password']" with "securepassword123"
+    And I click the "Login" button
+    Then the page URL should contain "/"
+    When I navigate to "/ui/settings/emails"
+    And I fill "input[name='email'][type='email']" with "newemail-rm@example.com"
+    And I click the "Add Email" button
+    Then the page should contain "newemail-rm@example.com"
+    When I click the "Remove" button
+    Then the page should contain "Email removed"
+    And I take a screenshot named "settings_emails_removed"

--- a/src/shomer/routes/settings_ui.py
+++ b/src/shomer/routes/settings_ui.py
@@ -791,23 +791,17 @@ async def settings_emails_post(
                 await db.flush()
                 success = "Primary email updated."
 
-    # Re-load user with emails
-    reload_stmt = (
-        select(User)
-        .where(User.id == user.id)
-        .options(selectinload(User.profile), selectinload(User.emails))
-    )
-    reload_result = await db.execute(reload_stmt)
-    refreshed = reload_result.scalar_one_or_none()
-    if refreshed is not None:
-        user = refreshed
+    # Re-load user emails directly to ensure we see all changes
+    emails_stmt = select(UserEmail).where(UserEmail.user_id == user.id)
+    emails_result = await db.execute(emails_stmt)
+    emails = list(emails_result.scalars().all())
 
     return _render(
         request,
         "settings/emails.html",
         {
             "user": user,
-            "emails": user.emails,
+            "emails": emails,
             "section": "emails",
             "success": success,
             "error": error,

--- a/src/shomer/routes/settings_ui.py
+++ b/src/shomer/routes/settings_ui.py
@@ -573,7 +573,7 @@ async def settings_emails_post(
     email_id: str = Form(""),
     code: str = Form(""),
 ) -> Any:
-    """Handle email management form submissions (add, remove, verify, resend).
+    """Handle email management form submissions.
 
     Parameters
     ----------
@@ -582,11 +582,13 @@ async def settings_emails_post(
     db : DbSession
         Database session.
     action : str
-        Form action (``add``, ``remove``, ``verify``, or ``resend``).
+        Form action (``add``, ``remove``, ``verify``, ``resend``,
+        or ``set_primary``).
     email : str
         Email address to add (for ``add`` action).
     email_id : str
-        UUID of the email (for ``remove``, ``verify``, and ``resend`` actions).
+        UUID of the email (for ``remove``, ``verify``, ``resend``,
+        and ``set_primary`` actions).
 
     Returns
     -------
@@ -758,6 +760,36 @@ async def settings_emails_post(
                     context={"code": new_code},
                 )
                 success = "Verification email resent."
+
+    elif action == "set_primary":
+        import uuid as _uuid
+
+        try:
+            eid = _uuid.UUID(email_id)
+        except ValueError:
+            error = "Invalid email ID."
+        else:
+            target_stmt = select(UserEmail).where(
+                UserEmail.id == eid,
+                UserEmail.user_id == user.id,
+            )
+            target_result = await db.execute(target_stmt)
+            target_email = target_result.scalar_one_or_none()
+
+            if target_email is None:
+                error = "Email not found."
+            elif not target_email.is_verified:
+                error = "Cannot set unverified email as primary."
+            else:
+                # Unset current primary, set new one
+                all_stmt = select(UserEmail).where(
+                    UserEmail.user_id == user.id,
+                )
+                all_result = await db.execute(all_stmt)
+                for em in all_result.scalars().all():
+                    em.is_primary = em.id == eid
+                await db.flush()
+                success = "Primary email updated."
 
     # Re-load user with emails
     reload_stmt = (

--- a/src/shomer/routes/settings_ui.py
+++ b/src/shomer/routes/settings_ui.py
@@ -27,6 +27,7 @@ from shomer.deps import DbSession
 from shomer.models.personal_access_token import PersonalAccessToken
 from shomer.models.session import Session
 from shomer.models.user import User
+from shomer.models.user_email import UserEmail
 from shomer.models.user_profile import UserProfile
 from shomer.services.session_service import SessionService
 
@@ -557,6 +558,114 @@ async def settings_emails(request: Request, db: DbSession) -> Any:
             "user": user,
             "emails": user.emails,
             "section": "emails",
+            "success": None,
+            "error": None,
+        },
+    )
+
+
+@router.post("/emails", response_class=HTMLResponse)
+async def settings_emails_add(
+    request: Request,
+    db: DbSession,
+    action: str = Form("add"),
+    email: str = Form(""),
+) -> Any:
+    """Handle email addition form submission.
+
+    Parameters
+    ----------
+    request : Request
+        The incoming HTTP request.
+    db : DbSession
+        Database session.
+    action : str
+        Form action (``add``).
+    email : str
+        Email address to add.
+
+    Returns
+    -------
+    HTMLResponse
+        Email settings page with success/error message, or redirect to login.
+    """
+    auth = await _get_session_user(request, db)
+    if auth is None:
+        return RedirectResponse(
+            url="/ui/login?next=/ui/settings/emails", status_code=302
+        )
+
+    _, user = auth
+    error = None
+    success = None
+
+    if action == "add":
+        email = email.strip().lower()
+        if not email:
+            error = "Email address is required."
+        else:
+            # Check if email already exists
+            existing = await db.execute(
+                select(UserEmail).where(UserEmail.email == email)
+            )
+            if existing.scalar_one_or_none() is not None:
+                error = "Email already registered."
+            else:
+                new_email = UserEmail(
+                    user_id=user.id,
+                    email=email,
+                    is_primary=False,
+                    is_verified=False,
+                )
+                db.add(new_email)
+                await db.flush()
+
+                # Trigger verification email
+                from shomer.services.auth_service import AuthService
+
+                svc = AuthService(db)
+                code = svc._generate_code()
+
+                from datetime import datetime, timedelta, timezone
+
+                from shomer.models.verification_code import VerificationCode
+
+                vc = VerificationCode(
+                    email=email,
+                    code=code,
+                    expires_at=datetime.now(timezone.utc) + timedelta(minutes=15),
+                )
+                db.add(vc)
+                await db.flush()
+
+                from shomer.tasks.email import send_email_task
+
+                send_email_task.delay(
+                    to=email,
+                    subject="Verify your email",
+                    template="verification.html",
+                    context={"code": code},
+                )
+                success = "Email added. Check your inbox for verification."
+
+    # Re-load user with emails
+    stmt = (
+        select(User)
+        .where(User.id == user.id)
+        .options(selectinload(User.profile), selectinload(User.emails))
+    )
+    result = await db.execute(stmt)
+    user = result.scalar_one_or_none() or user
+
+    return _render(
+        request,
+        "settings/emails.html",
+        {
+            "user": user,
+            "emails": user.emails,
+            "section": "emails",
+            "success": success,
+            "error": error,
         },
     )
 

--- a/src/shomer/routes/settings_ui.py
+++ b/src/shomer/routes/settings_ui.py
@@ -565,13 +565,14 @@ async def settings_emails(request: Request, db: DbSession) -> Any:
 
 
 @router.post("/emails", response_class=HTMLResponse)
-async def settings_emails_add(
+async def settings_emails_post(
     request: Request,
     db: DbSession,
     action: str = Form("add"),
     email: str = Form(""),
+    email_id: str = Form(""),
 ) -> Any:
-    """Handle email addition form submission.
+    """Handle email management form submissions (add, remove).
 
     Parameters
     ----------
@@ -580,9 +581,11 @@ async def settings_emails_add(
     db : DbSession
         Database session.
     action : str
-        Form action (``add``).
+        Form action (``add`` or ``remove``).
     email : str
-        Email address to add.
+        Email address to add (for ``add`` action).
+    email_id : str
+        UUID of the email to remove (for ``remove`` action).
 
     Returns
     -------
@@ -648,14 +651,40 @@ async def settings_emails_add(
                 )
                 success = "Email added. Check your inbox for verification."
 
+    elif action == "remove":
+        import uuid as _uuid
+
+        try:
+            eid = _uuid.UUID(email_id)
+        except ValueError:
+            error = "Invalid email ID."
+        else:
+            stmt = select(UserEmail).where(
+                UserEmail.id == eid,
+                UserEmail.user_id == user.id,
+            )
+            result = await db.execute(stmt)
+            email_record = result.scalar_one_or_none()
+
+            if email_record is None:
+                error = "Email not found."
+            elif email_record.is_primary:
+                error = "Cannot delete primary email."
+            else:
+                await db.delete(email_record)
+                await db.flush()
+                success = "Email removed."
+
     # Re-load user with emails
-    stmt = (
+    reload_stmt = (
         select(User)
         .where(User.id == user.id)
         .options(selectinload(User.profile), selectinload(User.emails))
     )
-    result = await db.execute(stmt)
-    user = result.scalar_one_or_none() or user
+    reload_result = await db.execute(reload_stmt)
+    refreshed = reload_result.scalar_one_or_none()
+    if refreshed is not None:
+        user = refreshed
 
     return _render(
         request,

--- a/src/shomer/routes/settings_ui.py
+++ b/src/shomer/routes/settings_ui.py
@@ -573,7 +573,7 @@ async def settings_emails_post(
     email_id: str = Form(""),
     code: str = Form(""),
 ) -> Any:
-    """Handle email management form submissions (add, remove, verify).
+    """Handle email management form submissions (add, remove, verify, resend).
 
     Parameters
     ----------
@@ -582,11 +582,11 @@ async def settings_emails_post(
     db : DbSession
         Database session.
     action : str
-        Form action (``add``, ``remove``, or ``verify``).
+        Form action (``add``, ``remove``, ``verify``, or ``resend``).
     email : str
         Email address to add (for ``add`` action).
     email_id : str
-        UUID of the email (for ``remove`` and ``verify`` actions).
+        UUID of the email (for ``remove``, ``verify``, and ``resend`` actions).
 
     Returns
     -------
@@ -711,6 +711,53 @@ async def settings_emails_post(
                         success = "Email verified successfully."
                     except InvalidCodeError:
                         error = "Invalid or expired verification code."
+
+    elif action == "resend":
+        import uuid as _uuid
+
+        try:
+            eid = _uuid.UUID(email_id)
+        except ValueError:
+            error = "Invalid email ID."
+        else:
+            resend_stmt = select(UserEmail).where(
+                UserEmail.id == eid,
+                UserEmail.user_id == user.id,
+            )
+            resend_result = await db.execute(resend_stmt)
+            target_email = resend_result.scalar_one_or_none()
+
+            if target_email is None:
+                error = "Email not found."
+            elif target_email.is_verified:
+                error = "Email is already verified."
+            else:
+                from shomer.services.auth_service import AuthService
+
+                svc = AuthService(db)
+                new_code = svc._generate_code()
+
+                from datetime import datetime, timedelta, timezone
+
+                from shomer.models.verification_code import VerificationCode
+
+                vc = VerificationCode(
+                    email=target_email.email,
+                    code=new_code,
+                    expires_at=datetime.now(timezone.utc) + timedelta(minutes=15),
+                )
+                db.add(vc)
+                await db.flush()
+
+                from shomer.tasks.email import send_email_task
+
+                send_email_task.delay(
+                    to=target_email.email,
+                    subject="Verify your email",
+                    template="verification.html",
+                    context={"code": new_code},
+                )
+                success = "Verification email resent."
 
     # Re-load user with emails
     reload_stmt = (

--- a/src/shomer/routes/settings_ui.py
+++ b/src/shomer/routes/settings_ui.py
@@ -571,8 +571,9 @@ async def settings_emails_post(
     action: str = Form("add"),
     email: str = Form(""),
     email_id: str = Form(""),
+    code: str = Form(""),
 ) -> Any:
-    """Handle email management form submissions (add, remove).
+    """Handle email management form submissions (add, remove, verify).
 
     Parameters
     ----------
@@ -581,11 +582,11 @@ async def settings_emails_post(
     db : DbSession
         Database session.
     action : str
-        Form action (``add`` or ``remove``).
+        Form action (``add``, ``remove``, or ``verify``).
     email : str
         Email address to add (for ``add`` action).
     email_id : str
-        UUID of the email to remove (for ``remove`` action).
+        UUID of the email (for ``remove`` and ``verify`` actions).
 
     Returns
     -------
@@ -674,6 +675,42 @@ async def settings_emails_post(
                 await db.delete(email_record)
                 await db.flush()
                 success = "Email removed."
+
+    elif action == "verify":
+        code = code.strip()
+        if not code:
+            error = "Verification code is required."
+        else:
+            import uuid as _uuid
+
+            try:
+                eid = _uuid.UUID(email_id)
+            except ValueError:
+                error = "Invalid email ID."
+            else:
+                email_stmt = select(UserEmail).where(
+                    UserEmail.id == eid,
+                    UserEmail.user_id == user.id,
+                )
+                email_result = await db.execute(email_stmt)
+                target_email = email_result.scalar_one_or_none()
+
+                if target_email is None:
+                    error = "Email not found."
+                elif target_email.is_verified:
+                    error = "Email is already verified."
+                else:
+                    from shomer.services.auth_service import (
+                        AuthService,
+                        InvalidCodeError,
+                    )
+
+                    svc = AuthService(db)
+                    try:
+                        await svc.verify_email(email=target_email.email, code=code)
+                        success = "Email verified successfully."
+                    except InvalidCodeError:
+                        error = "Invalid or expired verification code."
 
     # Re-load user with emails
     reload_stmt = (

--- a/src/shomer/templates/settings/emails.html
+++ b/src/shomer/templates/settings/emails.html
@@ -34,6 +34,13 @@
             <button type="submit" class="btn-sm btn-resend">Resend</button>
         </form>
         {% endif %}
+        {% if not email.is_primary and email.is_verified %}
+        <form method="post" action="/ui/settings/emails" class="inline-form">
+            <input type="hidden" name="action" value="set_primary">
+            <input type="hidden" name="email_id" value="{{ email.id }}">
+            <button type="submit" class="btn-sm btn-primary-action">Set Primary</button>
+        </form>
+        {% endif %}
         {% if not email.is_primary %}
         <form method="post" action="/ui/settings/emails" class="inline-form">
             <input type="hidden" name="action" value="remove">
@@ -67,6 +74,7 @@
     .btn-danger { background: #c00; color: #fff; border: none; }
     .btn-verify { background: #060; color: #fff; border: none; }
     .btn-resend { background: #555; color: #fff; border: none; }
+    .btn-primary-action { background: #336; color: #fff; border: none; }
     .code-input { width: 80px; padding: 2px 6px; font-size: 0.85em; border: 1px solid #ccc; border-radius: 3px; }
     .msg { padding: 8px 12px; border-radius: 4px; margin-bottom: 16px; }
     .msg.ok { background: #e6ffe6; color: #060; }

--- a/src/shomer/templates/settings/emails.html
+++ b/src/shomer/templates/settings/emails.html
@@ -28,6 +28,11 @@
             <input type="text" name="code" placeholder="6-digit code" maxlength="6" class="code-input" required>
             <button type="submit" class="btn-sm btn-verify">Verify</button>
         </form>
+        <form method="post" action="/ui/settings/emails" class="inline-form">
+            <input type="hidden" name="action" value="resend">
+            <input type="hidden" name="email_id" value="{{ email.id }}">
+            <button type="submit" class="btn-sm btn-resend">Resend</button>
+        </form>
         {% endif %}
         {% if not email.is_primary %}
         <form method="post" action="/ui/settings/emails" class="inline-form">
@@ -61,6 +66,7 @@
     .btn-sm { font-size: 0.8em; padding: 2px 8px; cursor: pointer; border-radius: 3px; }
     .btn-danger { background: #c00; color: #fff; border: none; }
     .btn-verify { background: #060; color: #fff; border: none; }
+    .btn-resend { background: #555; color: #fff; border: none; }
     .code-input { width: 80px; padding: 2px 6px; font-size: 0.85em; border: 1px solid #ccc; border-radius: 3px; }
     .msg { padding: 8px 12px; border-radius: 4px; margin-bottom: 16px; }
     .msg.ok { background: #e6ffe6; color: #060; }

--- a/src/shomer/templates/settings/emails.html
+++ b/src/shomer/templates/settings/emails.html
@@ -11,6 +11,9 @@
     <a href="/ui/settings/applications">Applications</a>
 </nav>
 
+{% if success %}<p class="msg ok">{{ success }}</p>{% endif %}
+{% if error %}<p class="msg err">{{ error }}</p>{% endif %}
+
 <h2>Email Addresses</h2>
 <ul class="email-list">
 {% for email in emails %}
@@ -24,6 +27,7 @@
 
 <h3>Add Email</h3>
 <form method="post" action="/ui/settings/emails">
+    <input type="hidden" name="action" value="add">
     <input type="email" name="email" placeholder="new@example.com" required>
     <button type="submit">Add Email</button>
 </form>
@@ -38,5 +42,8 @@
     .badge.primary { background: #333; color: #fff; }
     .badge.verified { background: #060; color: #fff; }
     .badge.unverified { background: #c00; color: #fff; }
+    .msg { padding: 8px 12px; border-radius: 4px; margin-bottom: 16px; }
+    .msg.ok { background: #e6ffe6; color: #060; }
+    .msg.err { background: #ffe6e6; color: #c00; }
 </style>
 {% endblock %}

--- a/src/shomer/templates/settings/emails.html
+++ b/src/shomer/templates/settings/emails.html
@@ -21,6 +21,13 @@
         <span class="email-address">{{ email.email }}</span>
         {% if email.is_primary %}<span class="badge primary">Primary</span>{% endif %}
         {% if email.is_verified %}<span class="badge verified">Verified</span>{% else %}<span class="badge unverified">Unverified</span>{% endif %}
+        {% if not email.is_primary %}
+        <form method="post" action="/ui/settings/emails" class="inline-form">
+            <input type="hidden" name="action" value="remove">
+            <input type="hidden" name="email_id" value="{{ email.id }}">
+            <button type="submit" class="btn-danger btn-sm">Remove</button>
+        </form>
+        {% endif %}
     </li>
 {% endfor %}
 </ul>
@@ -42,6 +49,9 @@
     .badge.primary { background: #333; color: #fff; }
     .badge.verified { background: #060; color: #fff; }
     .badge.unverified { background: #c00; color: #fff; }
+    .inline-form { display: inline; margin: 0; }
+    .btn-sm { font-size: 0.8em; padding: 2px 8px; cursor: pointer; border-radius: 3px; }
+    .btn-danger { background: #c00; color: #fff; border: none; }
     .msg { padding: 8px 12px; border-radius: 4px; margin-bottom: 16px; }
     .msg.ok { background: #e6ffe6; color: #060; }
     .msg.err { background: #ffe6e6; color: #c00; }

--- a/src/shomer/templates/settings/emails.html
+++ b/src/shomer/templates/settings/emails.html
@@ -21,6 +21,14 @@
         <span class="email-address">{{ email.email }}</span>
         {% if email.is_primary %}<span class="badge primary">Primary</span>{% endif %}
         {% if email.is_verified %}<span class="badge verified">Verified</span>{% else %}<span class="badge unverified">Unverified</span>{% endif %}
+        {% if not email.is_verified %}
+        <form method="post" action="/ui/settings/emails" class="inline-form">
+            <input type="hidden" name="action" value="verify">
+            <input type="hidden" name="email_id" value="{{ email.id }}">
+            <input type="text" name="code" placeholder="6-digit code" maxlength="6" class="code-input" required>
+            <button type="submit" class="btn-sm btn-verify">Verify</button>
+        </form>
+        {% endif %}
         {% if not email.is_primary %}
         <form method="post" action="/ui/settings/emails" class="inline-form">
             <input type="hidden" name="action" value="remove">
@@ -52,6 +60,8 @@
     .inline-form { display: inline; margin: 0; }
     .btn-sm { font-size: 0.8em; padding: 2px 8px; cursor: pointer; border-radius: 3px; }
     .btn-danger { background: #c00; color: #fff; border: none; }
+    .btn-verify { background: #060; color: #fff; border: none; }
+    .code-input { width: 80px; padding: 2px 6px; font-size: 0.85em; border: 1px solid #ccc; border-radius: 3px; }
     .msg { padding: 8px 12px; border-radius: 4px; margin-bottom: 16px; }
     .msg.ok { background: #e6ffe6; color: #060; }
     .msg.err { background: #ffe6e6; color: #c00; }

--- a/tests/routes/test_settings_ui_unit.py
+++ b/tests/routes/test_settings_ui_unit.py
@@ -629,3 +629,192 @@ class TestSettingsEmailsRemove:
             assert ctx["error"] == "Invalid email ID."
 
         asyncio.run(_run())
+
+
+class TestSettingsEmailsVerify:
+    """Tests for POST /ui/settings/emails action=verify."""
+
+    @patch("shomer.routes.settings_ui._render")
+    @patch("shomer.routes.settings_ui._get_session_user")
+    def test_verify_empty_code_shows_error(
+        self, mock_auth: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Verify with empty code shows validation error."""
+
+        async def _run() -> None:
+            mock_user = _mock_user()
+            mock_auth.return_value = (MagicMock(), mock_user)
+            mock_render.return_value = "html"
+
+            db = AsyncMock()
+            reload_result = MagicMock()
+            reload_result.scalar_one_or_none.return_value = mock_user
+            db.execute.return_value = reload_result
+
+            await settings_emails_post(
+                _req({"session_id": "tok"}),
+                db,
+                action="verify",
+                email_id=str(uuid.uuid4()),
+                code="",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert ctx["error"] == "Verification code is required."
+
+        asyncio.run(_run())
+
+    @patch("shomer.services.auth_service.AuthService.verify_email")
+    @patch("shomer.routes.settings_ui._render")
+    @patch("shomer.routes.settings_ui._get_session_user")
+    def test_verify_email_success(
+        self,
+        mock_auth: AsyncMock,
+        mock_render: MagicMock,
+        mock_verify: AsyncMock,
+    ) -> None:
+        """Verify with valid code succeeds."""
+
+        async def _run() -> None:
+            mock_user = _mock_user()
+            mock_auth.return_value = (MagicMock(), mock_user)
+            mock_render.return_value = "html"
+
+            target_email = MagicMock()
+            target_email.is_verified = False
+            target_email.email = "new@example.com"
+
+            db = AsyncMock()
+            # First call: find email by id
+            find_result = MagicMock()
+            find_result.scalar_one_or_none.return_value = target_email
+            # Second call: re-load user
+            reload_result = MagicMock()
+            reload_result.scalar_one_or_none.return_value = mock_user
+            db.execute.side_effect = [find_result, reload_result]
+
+            mock_verify.return_value = None
+
+            await settings_emails_post(
+                _req({"session_id": "tok"}),
+                db,
+                action="verify",
+                email_id=str(uuid.uuid4()),
+                code="123456",
+            )
+
+            mock_verify.assert_awaited_once_with(email="new@example.com", code="123456")
+            ctx = mock_render.call_args[0][2]
+            assert ctx["success"] == "Email verified successfully."
+            assert ctx["error"] is None
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.settings_ui._render")
+    @patch("shomer.routes.settings_ui._get_session_user")
+    def test_verify_invalid_code_shows_error(
+        self, mock_auth: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Verify with wrong code shows error."""
+
+        async def _run() -> None:
+            from shomer.services.auth_service import InvalidCodeError
+
+            mock_user = _mock_user()
+            mock_auth.return_value = (MagicMock(), mock_user)
+            mock_render.return_value = "html"
+
+            target_email = MagicMock()
+            target_email.is_verified = False
+            target_email.email = "new@example.com"
+
+            db = AsyncMock()
+            find_result = MagicMock()
+            find_result.scalar_one_or_none.return_value = target_email
+            reload_result = MagicMock()
+            reload_result.scalar_one_or_none.return_value = mock_user
+            db.execute.side_effect = [find_result, reload_result]
+
+            with patch(
+                "shomer.services.auth_service.AuthService.verify_email",
+                side_effect=InvalidCodeError("bad"),
+            ):
+                await settings_emails_post(
+                    _req({"session_id": "tok"}),
+                    db,
+                    action="verify",
+                    email_id=str(uuid.uuid4()),
+                    code="000000",
+                )
+
+            ctx = mock_render.call_args[0][2]
+            assert ctx["error"] == "Invalid or expired verification code."
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.settings_ui._render")
+    @patch("shomer.routes.settings_ui._get_session_user")
+    def test_verify_already_verified_shows_error(
+        self, mock_auth: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Verify an already-verified email shows error."""
+
+        async def _run() -> None:
+            mock_user = _mock_user()
+            mock_auth.return_value = (MagicMock(), mock_user)
+            mock_render.return_value = "html"
+
+            target_email = MagicMock()
+            target_email.is_verified = True
+
+            db = AsyncMock()
+            find_result = MagicMock()
+            find_result.scalar_one_or_none.return_value = target_email
+            reload_result = MagicMock()
+            reload_result.scalar_one_or_none.return_value = mock_user
+            db.execute.side_effect = [find_result, reload_result]
+
+            await settings_emails_post(
+                _req({"session_id": "tok"}),
+                db,
+                action="verify",
+                email_id=str(uuid.uuid4()),
+                code="123456",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert ctx["error"] == "Email is already verified."
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.settings_ui._render")
+    @patch("shomer.routes.settings_ui._get_session_user")
+    def test_verify_nonexistent_email_shows_error(
+        self, mock_auth: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Verify a non-existent email shows error."""
+
+        async def _run() -> None:
+            mock_user = _mock_user()
+            mock_auth.return_value = (MagicMock(), mock_user)
+            mock_render.return_value = "html"
+
+            db = AsyncMock()
+            find_result = MagicMock()
+            find_result.scalar_one_or_none.return_value = None
+            reload_result = MagicMock()
+            reload_result.scalar_one_or_none.return_value = mock_user
+            db.execute.side_effect = [find_result, reload_result]
+
+            await settings_emails_post(
+                _req({"session_id": "tok"}),
+                db,
+                action="verify",
+                email_id=str(uuid.uuid4()),
+                code="123456",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert ctx["error"] == "Email not found."
+
+        asyncio.run(_run())

--- a/tests/routes/test_settings_ui_unit.py
+++ b/tests/routes/test_settings_ui_unit.py
@@ -964,3 +964,155 @@ class TestSettingsEmailsResend:
             assert ctx["error"] == "Invalid email ID."
 
         asyncio.run(_run())
+
+
+class TestSettingsEmailsSetPrimary:
+    """Tests for POST /ui/settings/emails action=set_primary."""
+
+    @patch("shomer.routes.settings_ui._render")
+    @patch("shomer.routes.settings_ui._get_session_user")
+    def test_set_primary_success(
+        self, mock_auth: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Set primary on a verified email succeeds."""
+
+        async def _run() -> None:
+            mock_user = _mock_user()
+            mock_auth.return_value = (MagicMock(), mock_user)
+            mock_render.return_value = "html"
+
+            target_email = MagicMock()
+            target_email.is_verified = True
+
+            eid = uuid.uuid4()
+            old_primary = MagicMock()
+            old_primary.id = uuid.uuid4()
+            old_primary.is_primary = True
+            new_primary = MagicMock()
+            new_primary.id = eid
+            new_primary.is_primary = False
+
+            scalars_mock = MagicMock()
+            scalars_mock.all.return_value = [old_primary, new_primary]
+
+            db = AsyncMock()
+            # First: find target email
+            find_result = MagicMock()
+            find_result.scalar_one_or_none.return_value = target_email
+            # Second: get all emails for user
+            all_result = MagicMock()
+            all_result.scalars.return_value = scalars_mock
+            # Third: re-load user
+            reload_result = MagicMock()
+            reload_result.scalar_one_or_none.return_value = mock_user
+            db.execute.side_effect = [find_result, all_result, reload_result]
+
+            await settings_emails_post(
+                _req({"session_id": "tok"}),
+                db,
+                action="set_primary",
+                email_id=str(eid),
+            )
+
+            db.flush.assert_awaited()
+            assert old_primary.is_primary is False
+            assert new_primary.is_primary is True
+            ctx = mock_render.call_args[0][2]
+            assert ctx["success"] == "Primary email updated."
+            assert ctx["error"] is None
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.settings_ui._render")
+    @patch("shomer.routes.settings_ui._get_session_user")
+    def test_set_primary_unverified_shows_error(
+        self, mock_auth: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Set primary on unverified email shows error."""
+
+        async def _run() -> None:
+            mock_user = _mock_user()
+            mock_auth.return_value = (MagicMock(), mock_user)
+            mock_render.return_value = "html"
+
+            target_email = MagicMock()
+            target_email.is_verified = False
+
+            db = AsyncMock()
+            find_result = MagicMock()
+            find_result.scalar_one_or_none.return_value = target_email
+            reload_result = MagicMock()
+            reload_result.scalar_one_or_none.return_value = mock_user
+            db.execute.side_effect = [find_result, reload_result]
+
+            await settings_emails_post(
+                _req({"session_id": "tok"}),
+                db,
+                action="set_primary",
+                email_id=str(uuid.uuid4()),
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert ctx["error"] == "Cannot set unverified email as primary."
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.settings_ui._render")
+    @patch("shomer.routes.settings_ui._get_session_user")
+    def test_set_primary_nonexistent_shows_error(
+        self, mock_auth: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Set primary on non-existent email shows error."""
+
+        async def _run() -> None:
+            mock_user = _mock_user()
+            mock_auth.return_value = (MagicMock(), mock_user)
+            mock_render.return_value = "html"
+
+            db = AsyncMock()
+            find_result = MagicMock()
+            find_result.scalar_one_or_none.return_value = None
+            reload_result = MagicMock()
+            reload_result.scalar_one_or_none.return_value = mock_user
+            db.execute.side_effect = [find_result, reload_result]
+
+            await settings_emails_post(
+                _req({"session_id": "tok"}),
+                db,
+                action="set_primary",
+                email_id=str(uuid.uuid4()),
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert ctx["error"] == "Email not found."
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.settings_ui._render")
+    @patch("shomer.routes.settings_ui._get_session_user")
+    def test_set_primary_invalid_uuid_shows_error(
+        self, mock_auth: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Set primary with invalid UUID shows error."""
+
+        async def _run() -> None:
+            mock_user = _mock_user()
+            mock_auth.return_value = (MagicMock(), mock_user)
+            mock_render.return_value = "html"
+
+            db = AsyncMock()
+            reload_result = MagicMock()
+            reload_result.scalar_one_or_none.return_value = mock_user
+            db.execute.return_value = reload_result
+
+            await settings_emails_post(
+                _req({"session_id": "tok"}),
+                db,
+                action="set_primary",
+                email_id="bad",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert ctx["error"] == "Invalid email ID."
+
+        asyncio.run(_run())

--- a/tests/routes/test_settings_ui_unit.py
+++ b/tests/routes/test_settings_ui_unit.py
@@ -7,19 +7,14 @@ from __future__ import annotations
 
 import asyncio
 import uuid
-from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from shomer.routes.settings_ui import (
-    _build_profile_ctx,
     _get_session_user,
     settings_emails,
-    settings_index,
+    settings_emails_add,
     settings_profile,
-    settings_profile_avatar,
     settings_profile_update,
-    settings_revoke_all_sessions,
-    settings_revoke_session,
     settings_security,
 )
 
@@ -159,57 +154,46 @@ class TestSettingsSecurity:
 
         asyncio.run(_run())
 
-    @patch("shomer.routes.settings_ui.SessionService")
     @patch("shomer.routes.settings_ui._render")
     @patch("shomer.routes.settings_ui._get_session_user")
     def test_authenticated_renders_page(
-        self, mock_auth: AsyncMock, mock_render: MagicMock, mock_svc_cls: MagicMock
+        self, mock_auth: AsyncMock, mock_render: MagicMock
     ) -> None:
         async def _run() -> None:
             mock_user = _mock_user()
             mock_session = MagicMock()
-            mock_session.id = uuid.uuid4()
             mock_auth.return_value = (mock_session, mock_user)
 
-            sessions_list = [MagicMock(), MagicMock()]
-            mock_svc = AsyncMock()
-            mock_svc.list_active.return_value = sessions_list
-            mock_svc_cls.return_value = mock_svc
-
+            count_result = MagicMock()
+            count_result.scalar.return_value = 2
             mfa_result = MagicMock()
             mfa_result.scalar_one_or_none.return_value = None
 
             db = AsyncMock()
-            db.execute.return_value = mfa_result
+            db.execute.side_effect = [count_result, mfa_result]
 
             mock_render.return_value = "html"
             await settings_security(_req({"session_id": "tok"}), db)
             ctx = mock_render.call_args[0][2]
             assert ctx["section"] == "security"
-            assert ctx["sessions"] == sessions_list
             assert ctx["active_sessions"] == 2
-            assert ctx["current_session_id"] == str(mock_session.id)
             assert ctx["mfa_enabled"] is False
             assert ctx["mfa_methods"] == []
 
         asyncio.run(_run())
 
-    @patch("shomer.routes.settings_ui.SessionService")
     @patch("shomer.routes.settings_ui._render")
     @patch("shomer.routes.settings_ui._get_session_user")
     def test_mfa_enabled_shows_in_context(
-        self, mock_auth: AsyncMock, mock_render: MagicMock, mock_svc_cls: MagicMock
+        self, mock_auth: AsyncMock, mock_render: MagicMock
     ) -> None:
         async def _run() -> None:
             mock_user = _mock_user()
             mock_session = MagicMock()
-            mock_session.id = uuid.uuid4()
             mock_auth.return_value = (mock_session, mock_user)
 
-            mock_svc = AsyncMock()
-            mock_svc.list_active.return_value = [MagicMock()]
-            mock_svc_cls.return_value = mock_svc
-
+            count_result = MagicMock()
+            count_result.scalar.return_value = 1
             mock_mfa = MagicMock()
             mock_mfa.is_enabled = True
             mock_mfa.methods = ["totp", "backup"]
@@ -217,7 +201,7 @@ class TestSettingsSecurity:
             mfa_result.scalar_one_or_none.return_value = mock_mfa
 
             db = AsyncMock()
-            db.execute.return_value = mfa_result
+            db.execute.side_effect = [count_result, mfa_result]
 
             mock_render.return_value = "html"
             await settings_security(_req({"session_id": "tok"}), db)
@@ -375,203 +359,8 @@ class TestSettingsProfileUpdate:
         asyncio.run(_run())
 
 
-class TestSettingsIndex:
-    """Tests for GET /ui/settings (index/dashboard)."""
-
-    @patch("shomer.routes.settings_ui._get_session_user")
-    def test_unauthenticated_redirects(self, mock_auth: AsyncMock) -> None:
-        """Unauthenticated request redirects to login."""
-
-        async def _run() -> None:
-            mock_auth.return_value = None
-            resp = await settings_index(_req(), AsyncMock())
-            assert resp.status_code == 302
-            assert "/ui/login" in resp.headers["location"]
-
-        asyncio.run(_run())
-
-    @patch("shomer.routes.settings_ui._render")
-    @patch("shomer.routes.settings_ui._get_session_user")
-    def test_authenticated_renders_overview(
-        self, mock_auth: AsyncMock, mock_render: MagicMock
-    ) -> None:
-        """Authenticated request renders the index page with all stats."""
-
-        async def _run() -> None:
-            mock_user = _mock_user()
-            # Profile with some fields filled
-            mock_profile = MagicMock()
-            mock_profile.nickname = "Jo"
-            mock_profile.given_name = "John"
-            mock_profile.family_name = "Doe"
-            mock_profile.picture_url = None
-            mock_profile.phone_number = None
-            mock_profile.locale = None
-            mock_profile.zoneinfo = None
-            mock_user.profile = mock_profile
-            mock_auth.return_value = (MagicMock(), mock_user)
-
-            # db.execute returns: mfa_result, sessions_result, pat_result
-            mfa_result = MagicMock()
-            mfa_result.scalar_one_or_none.return_value = None
-            sessions_result = MagicMock()
-            sessions_result.scalar.return_value = 3
-            pat_result = MagicMock()
-            pat_result.scalar.return_value = 2
-
-            db = AsyncMock()
-            db.execute.side_effect = [mfa_result, sessions_result, pat_result]
-
-            mock_render.return_value = "html"
-            await settings_index(_req({"session_id": "tok"}), db)
-            ctx = mock_render.call_args[0][2]
-            assert ctx["section"] == "overview"
-            assert ctx["completeness"] == 43  # 3/7 = 42.86 → 43
-            assert ctx["has_verified_email"] is True
-            assert ctx["mfa_enabled"] is False
-            assert ctx["active_sessions"] == 3
-            assert ctx["active_pats"] == 2
-
-        asyncio.run(_run())
-
-    @patch("shomer.routes.settings_ui._render")
-    @patch("shomer.routes.settings_ui._get_session_user")
-    def test_no_profile_shows_zero_completeness(
-        self, mock_auth: AsyncMock, mock_render: MagicMock
-    ) -> None:
-        """User with no profile shows 0% completeness."""
-
-        async def _run() -> None:
-            mock_user = _mock_user()
-            mock_user.profile = None
-            # Unverified email
-            mock_user.emails[0].is_verified = False
-            mock_auth.return_value = (MagicMock(), mock_user)
-
-            mfa_result = MagicMock()
-            mfa_result.scalar_one_or_none.return_value = None
-            sessions_result = MagicMock()
-            sessions_result.scalar.return_value = 0
-            pat_result = MagicMock()
-            pat_result.scalar.return_value = 0
-
-            db = AsyncMock()
-            db.execute.side_effect = [mfa_result, sessions_result, pat_result]
-
-            mock_render.return_value = "html"
-            await settings_index(_req({"session_id": "tok"}), db)
-            ctx = mock_render.call_args[0][2]
-            assert ctx["completeness"] == 0
-            assert ctx["has_verified_email"] is False
-            assert ctx["active_sessions"] == 0
-            assert ctx["active_pats"] == 0
-
-        asyncio.run(_run())
-
-    @patch("shomer.routes.settings_ui._render")
-    @patch("shomer.routes.settings_ui._get_session_user")
-    def test_mfa_enabled_shows_in_context(
-        self, mock_auth: AsyncMock, mock_render: MagicMock
-    ) -> None:
-        """MFA enabled status is reflected in context."""
-
-        async def _run() -> None:
-            mock_user = _mock_user()
-            mock_user.profile = None
-            mock_auth.return_value = (MagicMock(), mock_user)
-
-            mock_mfa = MagicMock()
-            mock_mfa.is_enabled = True
-            mfa_result = MagicMock()
-            mfa_result.scalar_one_or_none.return_value = mock_mfa
-            sessions_result = MagicMock()
-            sessions_result.scalar.return_value = 1
-            pat_result = MagicMock()
-            pat_result.scalar.return_value = 0
-
-            db = AsyncMock()
-            db.execute.side_effect = [mfa_result, sessions_result, pat_result]
-
-            mock_render.return_value = "html"
-            await settings_index(_req({"session_id": "tok"}), db)
-            ctx = mock_render.call_args[0][2]
-            assert ctx["mfa_enabled"] is True
-
-        asyncio.run(_run())
-
-    @patch("shomer.routes.settings_ui._render")
-    @patch("shomer.routes.settings_ui._get_session_user")
-    def test_full_profile_shows_100_completeness(
-        self, mock_auth: AsyncMock, mock_render: MagicMock
-    ) -> None:
-        """User with all profile fields filled shows 100% completeness."""
-
-        async def _run() -> None:
-            mock_user = _mock_user()
-            mock_profile = MagicMock()
-            mock_profile.nickname = "Jo"
-            mock_profile.given_name = "John"
-            mock_profile.family_name = "Doe"
-            mock_profile.picture_url = "https://example.com/pic.jpg"
-            mock_profile.phone_number = "+33612345678"
-            mock_profile.locale = "fr-FR"
-            mock_profile.zoneinfo = "Europe/Paris"
-            mock_user.profile = mock_profile
-            mock_auth.return_value = (MagicMock(), mock_user)
-
-            mfa_result = MagicMock()
-            mfa_result.scalar_one_or_none.return_value = None
-            sessions_result = MagicMock()
-            sessions_result.scalar.return_value = 1
-            pat_result = MagicMock()
-            pat_result.scalar.return_value = 0
-
-            db = AsyncMock()
-            db.execute.side_effect = [mfa_result, sessions_result, pat_result]
-
-            mock_render.return_value = "html"
-            await settings_index(_req({"session_id": "tok"}), db)
-            ctx = mock_render.call_args[0][2]
-            assert ctx["completeness"] == 100
-
-        asyncio.run(_run())
-
-
-def _mock_upload(
-    content: bytes = b"\x89PNG\r\n",
-    content_type: str | None = "image/png",
-    filename: str = "avatar.png",
-) -> AsyncMock:
-    """Create a mock UploadFile."""
-    f = AsyncMock()
-    f.filename = filename
-    f.content_type = content_type
-    f.read.return_value = content
-    return f
-
-
-class TestBuildProfileCtx:
-    """Tests for _build_profile_ctx helper."""
-
-    def test_uses_user_profile_by_default(self) -> None:
-        user = _mock_user()
-        ctx = _build_profile_ctx(user)
-        assert ctx["profile"] is user.profile
-        assert ctx["email"] == "test@example.com"
-        assert ctx["section"] == "profile"
-        assert ctx["success"] is None
-        assert ctx["error"] is None
-
-    def test_explicit_profile_overrides(self) -> None:
-        user = _mock_user()
-        new_profile = MagicMock()
-        ctx = _build_profile_ctx(user, profile=new_profile, success="ok")
-        assert ctx["profile"] is new_profile
-        assert ctx["success"] == "ok"
-
-
-class TestSettingsProfileAvatar:
-    """Tests for POST /ui/settings/profile/avatar."""
+class TestSettingsEmailsAdd:
+    """Tests for POST /ui/settings/emails (add email)."""
 
     @patch("shomer.routes.settings_ui._get_session_user")
     def test_unauthenticated_redirects(self, mock_auth: AsyncMock) -> None:
@@ -579,7 +368,7 @@ class TestSettingsProfileAvatar:
 
         async def _run() -> None:
             mock_auth.return_value = None
-            resp = await settings_profile_avatar(_req(), AsyncMock(), _mock_upload())
+            resp = await settings_emails_add(_req(), AsyncMock())
             assert resp.status_code == 302
             assert "/ui/login" in resp.headers["location"]
 
@@ -587,341 +376,125 @@ class TestSettingsProfileAvatar:
 
     @patch("shomer.routes.settings_ui._render")
     @patch("shomer.routes.settings_ui._get_session_user")
-    def test_invalid_content_type(
+    def test_empty_email_shows_error(
         self, mock_auth: AsyncMock, mock_render: MagicMock
     ) -> None:
-        """Rejects file with unsupported content type."""
+        """POST with blank email shows validation error."""
 
         async def _run() -> None:
             mock_user = _mock_user()
             mock_auth.return_value = (MagicMock(), mock_user)
             mock_render.return_value = "html"
 
-            upload = _mock_upload(content_type="application/pdf")
-            await settings_profile_avatar(
-                _req({"session_id": "tok"}), AsyncMock(), upload
-            )
-            ctx = mock_render.call_args[0][2]
-            assert "Invalid file type" in ctx["error"]
-
-        asyncio.run(_run())
-
-    @patch("shomer.routes.settings_ui._render")
-    @patch("shomer.routes.settings_ui._get_session_user")
-    def test_empty_file(self, mock_auth: AsyncMock, mock_render: MagicMock) -> None:
-        """Rejects empty file upload."""
-
-        async def _run() -> None:
-            mock_user = _mock_user()
-            mock_auth.return_value = (MagicMock(), mock_user)
-            mock_render.return_value = "html"
-
-            upload = _mock_upload(content=b"")
-            await settings_profile_avatar(
-                _req({"session_id": "tok"}), AsyncMock(), upload
-            )
-            ctx = mock_render.call_args[0][2]
-            assert "empty" in ctx["error"].lower()
-
-        asyncio.run(_run())
-
-    @patch("shomer.routes.settings_ui._render")
-    @patch("shomer.routes.settings_ui._get_session_user")
-    def test_file_too_large(self, mock_auth: AsyncMock, mock_render: MagicMock) -> None:
-        """Rejects file exceeding 5 MB."""
-
-        async def _run() -> None:
-            mock_user = _mock_user()
-            mock_auth.return_value = (MagicMock(), mock_user)
-            mock_render.return_value = "html"
-
-            big_data = b"x" * (5 * 1024 * 1024 + 1)
-            upload = _mock_upload(content=big_data)
-            await settings_profile_avatar(
-                _req({"session_id": "tok"}), AsyncMock(), upload
-            )
-            ctx = mock_render.call_args[0][2]
-            assert "too large" in ctx["error"].lower()
-
-        asyncio.run(_run())
-
-    @patch("shomer.routes.settings_ui._render")
-    @patch("shomer.routes.settings_ui.get_settings")
-    @patch("shomer.routes.settings_ui._get_session_user")
-    def test_successful_upload(
-        self,
-        mock_auth: AsyncMock,
-        mock_settings: MagicMock,
-        mock_render: MagicMock,
-        tmp_path: Path,
-    ) -> None:
-        """Successful upload saves file and updates picture_url."""
-
-        async def _run() -> None:
-            mock_user = _mock_user()
-            mock_profile = MagicMock()
-            mock_user.profile = mock_profile
-            mock_auth.return_value = (MagicMock(), mock_user)
-            mock_render.return_value = "html"
-            mock_settings.return_value = MagicMock(avatar_upload_dir=str(tmp_path))
-
-            upload = _mock_upload(content=b"\x89PNG\r\nfakeimage")
             db = AsyncMock()
-            await settings_profile_avatar(_req({"session_id": "tok"}), db, upload)
+            # Re-load query
+            reload_result = MagicMock()
+            reload_result.scalar_one_or_none.return_value = mock_user
+            db.execute.return_value = reload_result
 
-            # Verify file was written
-            user_dir = tmp_path / str(mock_user.id)
-            assert user_dir.exists()
-            files = list(user_dir.iterdir())
-            assert len(files) == 1
-            assert files[0].suffix == ".png"
-            assert files[0].read_bytes() == b"\x89PNG\r\nfakeimage"
-
-            # Verify profile was updated
-            assert mock_profile.picture_url.startswith(
-                f"/uploads/avatars/{mock_user.id}/"
+            await settings_emails_add(
+                _req({"session_id": "tok"}), db, action="add", email=""
             )
-            assert mock_profile.picture_url.endswith(".png")
-            db.flush.assert_awaited_once()
+            ctx = mock_render.call_args[0][2]
+            assert ctx["error"] == "Email address is required."
+            assert ctx["success"] is None
+
+        asyncio.run(_run())
+
+    @patch("shomer.tasks.email.send_email_task")
+    @patch("shomer.services.auth_service.AuthService")
+    @patch("shomer.routes.settings_ui._render")
+    @patch("shomer.routes.settings_ui._get_session_user")
+    def test_add_email_success(
+        self,
+        mock_auth: AsyncMock,
+        mock_render: MagicMock,
+        mock_auth_svc_cls: MagicMock,
+        mock_send_task: MagicMock,
+    ) -> None:
+        """POST with valid email adds it and shows success."""
+
+        async def _run() -> None:
+            mock_user = _mock_user()
+            mock_auth.return_value = (MagicMock(), mock_user)
+            mock_render.return_value = "html"
+
+            mock_auth_svc = MagicMock()
+            mock_auth_svc._generate_code.return_value = "123456"
+            mock_auth_svc_cls.return_value = mock_auth_svc
+
+            db = AsyncMock()
+            # First call: check existing email (not found)
+            existing_result = MagicMock()
+            existing_result.scalar_one_or_none.return_value = None
+            # Second call: re-load user
+            reload_result = MagicMock()
+            reload_result.scalar_one_or_none.return_value = mock_user
+            db.execute.side_effect = [existing_result, reload_result]
+
+            await settings_emails_add(
+                _req({"session_id": "tok"}), db, action="add", email="new@example.com"
+            )
+
+            # Verify email was added
+            db.add.assert_called()
+            db.flush.assert_awaited()
 
             ctx = mock_render.call_args[0][2]
-            assert ctx["success"] == "Avatar updated successfully."
-
-        asyncio.run(_run())
-
-    @patch("shomer.routes.settings_ui._render")
-    @patch("shomer.routes.settings_ui.UserProfile")
-    @patch("shomer.routes.settings_ui.get_settings")
-    @patch("shomer.routes.settings_ui._get_session_user")
-    def test_creates_profile_if_none(
-        self,
-        mock_auth: AsyncMock,
-        mock_settings: MagicMock,
-        mock_up_cls: MagicMock,
-        mock_render: MagicMock,
-        tmp_path: Path,
-    ) -> None:
-        """Creates UserProfile when user has no profile."""
-
-        async def _run() -> None:
-            mock_user = _mock_user()
-            mock_user.profile = None
-            mock_auth.return_value = (MagicMock(), mock_user)
-            mock_render.return_value = "html"
-            mock_settings.return_value = MagicMock(avatar_upload_dir=str(tmp_path))
-
-            new_profile = MagicMock()
-            mock_up_cls.return_value = new_profile
-
-            upload = _mock_upload(
-                content=b"\xff\xd8\xff\xe0",
-                content_type="image/jpeg",
-            )
-            db = AsyncMock()
-            await settings_profile_avatar(_req({"session_id": "tok"}), db, upload)
-
-            db.add.assert_called_once_with(new_profile)
-            db.flush.assert_awaited_once()
-            assert new_profile.picture_url.endswith(".jpg")
-
-        asyncio.run(_run())
-
-    @patch("shomer.routes.settings_ui._render")
-    @patch("shomer.routes.settings_ui.get_settings")
-    @patch("shomer.routes.settings_ui._get_session_user")
-    def test_removes_old_avatar(
-        self,
-        mock_auth: AsyncMock,
-        mock_settings: MagicMock,
-        mock_render: MagicMock,
-        tmp_path: Path,
-    ) -> None:
-        """Uploading a new avatar removes the previous file."""
-
-        async def _run() -> None:
-            mock_user = _mock_user()
-            mock_user.profile = MagicMock()
-            mock_auth.return_value = (MagicMock(), mock_user)
-            mock_render.return_value = "html"
-            mock_settings.return_value = MagicMock(avatar_upload_dir=str(tmp_path))
-
-            # Pre-create an existing avatar file
-            user_dir = tmp_path / str(mock_user.id)
-            user_dir.mkdir(parents=True)
-            old_file = user_dir / "old_avatar.png"
-            old_file.write_bytes(b"old")
-
-            upload = _mock_upload(content=b"newimage")
-            await settings_profile_avatar(
-                _req({"session_id": "tok"}), AsyncMock(), upload
-            )
-
-            files = list(user_dir.iterdir())
-            assert len(files) == 1
-            assert files[0].name != "old_avatar.png"
-            assert files[0].read_bytes() == b"newimage"
+            assert ctx["success"] == "Email added. Check your inbox for verification."
+            assert ctx["error"] is None
 
         asyncio.run(_run())
 
     @patch("shomer.routes.settings_ui._render")
     @patch("shomer.routes.settings_ui._get_session_user")
-    def test_none_content_type_rejected(
+    def test_duplicate_email_shows_error(
         self, mock_auth: AsyncMock, mock_render: MagicMock
     ) -> None:
-        """File with None content_type is rejected."""
+        """POST with already-registered email shows conflict error."""
 
         async def _run() -> None:
             mock_user = _mock_user()
             mock_auth.return_value = (MagicMock(), mock_user)
             mock_render.return_value = "html"
 
-            upload = _mock_upload(content_type=None)
-            await settings_profile_avatar(
-                _req({"session_id": "tok"}), AsyncMock(), upload
+            db = AsyncMock()
+            # First call: check existing email (found)
+            existing_result = MagicMock()
+            existing_result.scalar_one_or_none.return_value = MagicMock()
+            # Second call: re-load user
+            reload_result = MagicMock()
+            reload_result.scalar_one_or_none.return_value = mock_user
+            db.execute.side_effect = [existing_result, reload_result]
+
+            await settings_emails_add(
+                _req({"session_id": "tok"}),
+                db,
+                action="add",
+                email="taken@example.com",
             )
+
             ctx = mock_render.call_args[0][2]
-            assert "Invalid file type" in ctx["error"]
+            assert ctx["error"] == "Email already registered."
+            assert ctx["success"] is None
 
         asyncio.run(_run())
 
-
-class TestSettingsRevokeSession:
-    """Tests for POST /ui/settings/sessions/{session_id}/revoke."""
-
+    @patch("shomer.routes.settings_ui._render")
     @patch("shomer.routes.settings_ui._get_session_user")
-    def test_unauthenticated_redirects(self, mock_auth: AsyncMock) -> None:
-        """Unauthenticated request redirects to login."""
-
-        async def _run() -> None:
-            mock_auth.return_value = None
-            resp = await settings_revoke_session(
-                _req(), AsyncMock(), session_id=uuid.uuid4()
-            )
-            assert resp.status_code == 302
-            assert "/ui/login" in resp.headers["location"]
-
-        asyncio.run(_run())
-
-    @patch("shomer.routes.settings_ui._get_session_user")
-    def test_cannot_revoke_current_session(self, mock_auth: AsyncMock) -> None:
-        """Revoking the current session redirects without deleting."""
-
-        async def _run() -> None:
-            current_id = uuid.uuid4()
-            mock_session = MagicMock()
-            mock_session.id = current_id
-            mock_auth.return_value = (mock_session, _mock_user())
-
-            db = AsyncMock()
-            resp = await settings_revoke_session(
-                _req({"session_id": "tok"}), db, session_id=current_id
-            )
-            assert resp.status_code == 303
-            db.execute.assert_not_called()
-
-        asyncio.run(_run())
-
-    @patch("shomer.routes.settings_ui.SessionService")
-    @patch("shomer.routes.settings_ui._get_session_user")
-    def test_revokes_other_session(
-        self, mock_auth: AsyncMock, mock_svc_cls: MagicMock
+    def test_get_emails_includes_success_error_none(
+        self, mock_auth: AsyncMock, mock_render: MagicMock
     ) -> None:
-        """Successfully revokes a session belonging to the user."""
+        """GET emails page passes success=None and error=None in context."""
 
         async def _run() -> None:
-            current_id = uuid.uuid4()
-            target_id = uuid.uuid4()
-            mock_session = MagicMock()
-            mock_session.id = current_id
             mock_user = _mock_user()
-            mock_auth.return_value = (mock_session, mock_user)
+            mock_auth.return_value = (MagicMock(), mock_user)
+            mock_render.return_value = "html"
 
-            target_session = MagicMock()
-            db_result = MagicMock()
-            db_result.scalar_one_or_none.return_value = target_session
-            db = AsyncMock()
-            db.execute.return_value = db_result
-
-            mock_svc = AsyncMock()
-            mock_svc_cls.return_value = mock_svc
-
-            resp = await settings_revoke_session(
-                _req({"session_id": "tok"}), db, session_id=target_id
-            )
-            assert resp.status_code == 303
-            mock_svc.delete.assert_awaited_once_with(target_id)
-
-        asyncio.run(_run())
-
-    @patch("shomer.routes.settings_ui.SessionService")
-    @patch("shomer.routes.settings_ui._get_session_user")
-    def test_nonexistent_session_no_delete(
-        self, mock_auth: AsyncMock, mock_svc_cls: MagicMock
-    ) -> None:
-        """Revoking a nonexistent session does not call delete."""
-
-        async def _run() -> None:
-            current_id = uuid.uuid4()
-            mock_session = MagicMock()
-            mock_session.id = current_id
-            mock_auth.return_value = (mock_session, _mock_user())
-
-            db_result = MagicMock()
-            db_result.scalar_one_or_none.return_value = None
-            db = AsyncMock()
-            db.execute.return_value = db_result
-
-            mock_svc = AsyncMock()
-            mock_svc_cls.return_value = mock_svc
-
-            resp = await settings_revoke_session(
-                _req({"session_id": "tok"}), db, session_id=uuid.uuid4()
-            )
-            assert resp.status_code == 303
-            mock_svc.delete.assert_not_called()
-
-        asyncio.run(_run())
-
-
-class TestSettingsRevokeAllSessions:
-    """Tests for POST /ui/settings/sessions/revoke-all."""
-
-    @patch("shomer.routes.settings_ui._get_session_user")
-    def test_unauthenticated_redirects(self, mock_auth: AsyncMock) -> None:
-        """Unauthenticated request redirects to login."""
-
-        async def _run() -> None:
-            mock_auth.return_value = None
-            resp = await settings_revoke_all_sessions(_req(), AsyncMock())
-            assert resp.status_code == 302
-            assert "/ui/login" in resp.headers["location"]
-
-        asyncio.run(_run())
-
-    @patch("shomer.routes.settings_ui.SessionService")
-    @patch("shomer.routes.settings_ui._get_session_user")
-    def test_revokes_all_except_current(
-        self, mock_auth: AsyncMock, mock_svc_cls: MagicMock
-    ) -> None:
-        """Deletes all sessions except the current one."""
-
-        async def _run() -> None:
-            current_id = uuid.uuid4()
-            mock_session = MagicMock()
-            mock_session.id = current_id
-            mock_user = _mock_user()
-            mock_auth.return_value = (mock_session, mock_user)
-
-            mock_svc = AsyncMock()
-            mock_svc.delete_all_for_user_except.return_value = 3
-            mock_svc_cls.return_value = mock_svc
-
-            resp = await settings_revoke_all_sessions(
-                _req({"session_id": "tok"}), AsyncMock()
-            )
-            assert resp.status_code == 303
-            mock_svc.delete_all_for_user_except.assert_awaited_once_with(
-                mock_user.id, current_id
-            )
+            await settings_emails(_req({"session_id": "tok"}), AsyncMock())
+            ctx = mock_render.call_args[0][2]
+            assert ctx["success"] is None
+            assert ctx["error"] is None
 
         asyncio.run(_run())

--- a/tests/routes/test_settings_ui_unit.py
+++ b/tests/routes/test_settings_ui_unit.py
@@ -154,23 +154,26 @@ class TestSettingsSecurity:
 
         asyncio.run(_run())
 
+    @patch("shomer.routes.settings_ui.SessionService")
     @patch("shomer.routes.settings_ui._render")
     @patch("shomer.routes.settings_ui._get_session_user")
     def test_authenticated_renders_page(
-        self, mock_auth: AsyncMock, mock_render: MagicMock
+        self, mock_auth: AsyncMock, mock_render: MagicMock, mock_svc_cls: MagicMock
     ) -> None:
         async def _run() -> None:
             mock_user = _mock_user()
             mock_session = MagicMock()
             mock_auth.return_value = (mock_session, mock_user)
 
-            count_result = MagicMock()
-            count_result.scalar.return_value = 2
+            mock_svc = AsyncMock()
+            mock_svc.list_active.return_value = [MagicMock(), MagicMock()]
+            mock_svc_cls.return_value = mock_svc
+
             mfa_result = MagicMock()
             mfa_result.scalar_one_or_none.return_value = None
 
             db = AsyncMock()
-            db.execute.side_effect = [count_result, mfa_result]
+            db.execute.return_value = mfa_result
 
             mock_render.return_value = "html"
             await settings_security(_req({"session_id": "tok"}), db)
@@ -182,18 +185,21 @@ class TestSettingsSecurity:
 
         asyncio.run(_run())
 
+    @patch("shomer.routes.settings_ui.SessionService")
     @patch("shomer.routes.settings_ui._render")
     @patch("shomer.routes.settings_ui._get_session_user")
     def test_mfa_enabled_shows_in_context(
-        self, mock_auth: AsyncMock, mock_render: MagicMock
+        self, mock_auth: AsyncMock, mock_render: MagicMock, mock_svc_cls: MagicMock
     ) -> None:
         async def _run() -> None:
             mock_user = _mock_user()
             mock_session = MagicMock()
             mock_auth.return_value = (mock_session, mock_user)
 
-            count_result = MagicMock()
-            count_result.scalar.return_value = 1
+            mock_svc = AsyncMock()
+            mock_svc.list_active.return_value = [MagicMock()]
+            mock_svc_cls.return_value = mock_svc
+
             mock_mfa = MagicMock()
             mock_mfa.is_enabled = True
             mock_mfa.methods = ["totp", "backup"]
@@ -201,7 +207,7 @@ class TestSettingsSecurity:
             mfa_result.scalar_one_or_none.return_value = mock_mfa
 
             db = AsyncMock()
-            db.execute.side_effect = [count_result, mfa_result]
+            db.execute.return_value = mfa_result
 
             mock_render.return_value = "html"
             await settings_security(_req({"session_id": "tok"}), db)

--- a/tests/routes/test_settings_ui_unit.py
+++ b/tests/routes/test_settings_ui_unit.py
@@ -818,3 +818,149 @@ class TestSettingsEmailsVerify:
             assert ctx["error"] == "Email not found."
 
         asyncio.run(_run())
+
+
+class TestSettingsEmailsResend:
+    """Tests for POST /ui/settings/emails action=resend."""
+
+    @patch("shomer.tasks.email.send_email_task")
+    @patch("shomer.services.auth_service.AuthService")
+    @patch("shomer.routes.settings_ui._render")
+    @patch("shomer.routes.settings_ui._get_session_user")
+    def test_resend_success(
+        self,
+        mock_auth: AsyncMock,
+        mock_render: MagicMock,
+        mock_auth_svc_cls: MagicMock,
+        mock_send_task: MagicMock,
+    ) -> None:
+        """Resend verification for unverified email shows success."""
+
+        async def _run() -> None:
+            mock_user = _mock_user()
+            mock_auth.return_value = (MagicMock(), mock_user)
+            mock_render.return_value = "html"
+
+            mock_auth_svc = MagicMock()
+            mock_auth_svc._generate_code.return_value = "654321"
+            mock_auth_svc_cls.return_value = mock_auth_svc
+
+            target_email = MagicMock()
+            target_email.is_verified = False
+            target_email.email = "unverified@example.com"
+
+            db = AsyncMock()
+            find_result = MagicMock()
+            find_result.scalar_one_or_none.return_value = target_email
+            reload_result = MagicMock()
+            reload_result.scalar_one_or_none.return_value = mock_user
+            db.execute.side_effect = [find_result, reload_result]
+
+            await settings_emails_post(
+                _req({"session_id": "tok"}),
+                db,
+                action="resend",
+                email_id=str(uuid.uuid4()),
+            )
+
+            db.add.assert_called()
+            db.flush.assert_awaited()
+            ctx = mock_render.call_args[0][2]
+            assert ctx["success"] == "Verification email resent."
+            assert ctx["error"] is None
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.settings_ui._render")
+    @patch("shomer.routes.settings_ui._get_session_user")
+    def test_resend_already_verified_shows_error(
+        self, mock_auth: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Resend for already-verified email shows error."""
+
+        async def _run() -> None:
+            mock_user = _mock_user()
+            mock_auth.return_value = (MagicMock(), mock_user)
+            mock_render.return_value = "html"
+
+            target_email = MagicMock()
+            target_email.is_verified = True
+
+            db = AsyncMock()
+            find_result = MagicMock()
+            find_result.scalar_one_or_none.return_value = target_email
+            reload_result = MagicMock()
+            reload_result.scalar_one_or_none.return_value = mock_user
+            db.execute.side_effect = [find_result, reload_result]
+
+            await settings_emails_post(
+                _req({"session_id": "tok"}),
+                db,
+                action="resend",
+                email_id=str(uuid.uuid4()),
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert ctx["error"] == "Email is already verified."
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.settings_ui._render")
+    @patch("shomer.routes.settings_ui._get_session_user")
+    def test_resend_nonexistent_email_shows_error(
+        self, mock_auth: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Resend for non-existent email shows error."""
+
+        async def _run() -> None:
+            mock_user = _mock_user()
+            mock_auth.return_value = (MagicMock(), mock_user)
+            mock_render.return_value = "html"
+
+            db = AsyncMock()
+            find_result = MagicMock()
+            find_result.scalar_one_or_none.return_value = None
+            reload_result = MagicMock()
+            reload_result.scalar_one_or_none.return_value = mock_user
+            db.execute.side_effect = [find_result, reload_result]
+
+            await settings_emails_post(
+                _req({"session_id": "tok"}),
+                db,
+                action="resend",
+                email_id=str(uuid.uuid4()),
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert ctx["error"] == "Email not found."
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.settings_ui._render")
+    @patch("shomer.routes.settings_ui._get_session_user")
+    def test_resend_invalid_uuid_shows_error(
+        self, mock_auth: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Resend with invalid UUID shows error."""
+
+        async def _run() -> None:
+            mock_user = _mock_user()
+            mock_auth.return_value = (MagicMock(), mock_user)
+            mock_render.return_value = "html"
+
+            db = AsyncMock()
+            reload_result = MagicMock()
+            reload_result.scalar_one_or_none.return_value = mock_user
+            db.execute.return_value = reload_result
+
+            await settings_emails_post(
+                _req({"session_id": "tok"}),
+                db,
+                action="resend",
+                email_id="bad-uuid",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert ctx["error"] == "Invalid email ID."
+
+        asyncio.run(_run())

--- a/tests/routes/test_settings_ui_unit.py
+++ b/tests/routes/test_settings_ui_unit.py
@@ -12,7 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from shomer.routes.settings_ui import (
     _get_session_user,
     settings_emails,
-    settings_emails_add,
+    settings_emails_post,
     settings_profile,
     settings_profile_update,
     settings_security,
@@ -368,7 +368,7 @@ class TestSettingsEmailsAdd:
 
         async def _run() -> None:
             mock_auth.return_value = None
-            resp = await settings_emails_add(_req(), AsyncMock())
+            resp = await settings_emails_post(_req(), AsyncMock())
             assert resp.status_code == 302
             assert "/ui/login" in resp.headers["location"]
 
@@ -392,7 +392,7 @@ class TestSettingsEmailsAdd:
             reload_result.scalar_one_or_none.return_value = mock_user
             db.execute.return_value = reload_result
 
-            await settings_emails_add(
+            await settings_emails_post(
                 _req({"session_id": "tok"}), db, action="add", email=""
             )
             ctx = mock_render.call_args[0][2]
@@ -432,7 +432,7 @@ class TestSettingsEmailsAdd:
             reload_result.scalar_one_or_none.return_value = mock_user
             db.execute.side_effect = [existing_result, reload_result]
 
-            await settings_emails_add(
+            await settings_emails_post(
                 _req({"session_id": "tok"}), db, action="add", email="new@example.com"
             )
 
@@ -467,7 +467,7 @@ class TestSettingsEmailsAdd:
             reload_result.scalar_one_or_none.return_value = mock_user
             db.execute.side_effect = [existing_result, reload_result]
 
-            await settings_emails_add(
+            await settings_emails_post(
                 _req({"session_id": "tok"}),
                 db,
                 action="add",
@@ -496,5 +496,136 @@ class TestSettingsEmailsAdd:
             ctx = mock_render.call_args[0][2]
             assert ctx["success"] is None
             assert ctx["error"] is None
+
+        asyncio.run(_run())
+
+
+class TestSettingsEmailsRemove:
+    """Tests for POST /ui/settings/emails action=remove."""
+
+    @patch("shomer.routes.settings_ui._render")
+    @patch("shomer.routes.settings_ui._get_session_user")
+    def test_remove_email_success(
+        self, mock_auth: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Remove a non-primary email shows success."""
+
+        async def _run() -> None:
+            mock_user = _mock_user()
+            mock_auth.return_value = (MagicMock(), mock_user)
+            mock_render.return_value = "html"
+
+            email_record = MagicMock()
+            email_record.is_primary = False
+
+            db = AsyncMock()
+            # First call: find email by id
+            find_result = MagicMock()
+            find_result.scalar_one_or_none.return_value = email_record
+            # Second call: re-load user
+            reload_result = MagicMock()
+            reload_result.scalar_one_or_none.return_value = mock_user
+            db.execute.side_effect = [find_result, reload_result]
+
+            eid = str(uuid.uuid4())
+            await settings_emails_post(
+                _req({"session_id": "tok"}), db, action="remove", email_id=eid
+            )
+
+            db.delete.assert_awaited_once_with(email_record)
+            ctx = mock_render.call_args[0][2]
+            assert ctx["success"] == "Email removed."
+            assert ctx["error"] is None
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.settings_ui._render")
+    @patch("shomer.routes.settings_ui._get_session_user")
+    def test_remove_primary_email_shows_error(
+        self, mock_auth: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Removing primary email shows error."""
+
+        async def _run() -> None:
+            mock_user = _mock_user()
+            mock_auth.return_value = (MagicMock(), mock_user)
+            mock_render.return_value = "html"
+
+            email_record = MagicMock()
+            email_record.is_primary = True
+
+            db = AsyncMock()
+            find_result = MagicMock()
+            find_result.scalar_one_or_none.return_value = email_record
+            reload_result = MagicMock()
+            reload_result.scalar_one_or_none.return_value = mock_user
+            db.execute.side_effect = [find_result, reload_result]
+
+            eid = str(uuid.uuid4())
+            await settings_emails_post(
+                _req({"session_id": "tok"}), db, action="remove", email_id=eid
+            )
+
+            db.delete.assert_not_awaited()
+            ctx = mock_render.call_args[0][2]
+            assert ctx["error"] == "Cannot delete primary email."
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.settings_ui._render")
+    @patch("shomer.routes.settings_ui._get_session_user")
+    def test_remove_nonexistent_email_shows_error(
+        self, mock_auth: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Removing a non-existent email shows error."""
+
+        async def _run() -> None:
+            mock_user = _mock_user()
+            mock_auth.return_value = (MagicMock(), mock_user)
+            mock_render.return_value = "html"
+
+            db = AsyncMock()
+            find_result = MagicMock()
+            find_result.scalar_one_or_none.return_value = None
+            reload_result = MagicMock()
+            reload_result.scalar_one_or_none.return_value = mock_user
+            db.execute.side_effect = [find_result, reload_result]
+
+            eid = str(uuid.uuid4())
+            await settings_emails_post(
+                _req({"session_id": "tok"}), db, action="remove", email_id=eid
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert ctx["error"] == "Email not found."
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.settings_ui._render")
+    @patch("shomer.routes.settings_ui._get_session_user")
+    def test_remove_invalid_uuid_shows_error(
+        self, mock_auth: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Removing with invalid UUID shows error."""
+
+        async def _run() -> None:
+            mock_user = _mock_user()
+            mock_auth.return_value = (MagicMock(), mock_user)
+            mock_render.return_value = "html"
+
+            db = AsyncMock()
+            reload_result = MagicMock()
+            reload_result.scalar_one_or_none.return_value = mock_user
+            db.execute.return_value = reload_result
+
+            await settings_emails_post(
+                _req({"session_id": "tok"}),
+                db,
+                action="remove",
+                email_id="not-a-uuid",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert ctx["error"] == "Invalid email ID."
 
         asyncio.run(_run())


### PR DESCRIPTION
## Summary

- Add full email CRUD to /ui/settings/emails: add email form, remove email, verify email with code, resend verification, set primary email
- Currently the page only displays emails; this adds all management actions

## Changes

- [x] Add email form + POST handler
- [x] Remove email button + POST handler
- [x] Verify email flow (code input)
- [x] Resend verification
- [x] Set primary email
- [x] Unit tests
- [x] BDD tests

## Related Issue

Closes #278

## Test Plan

- [x] `make format` - code formatted
- [x] `make lint` - no linting errors
- [x] `make typecheck` - type checks pass
- [x] `make test` - all unit tests pass
- [x] `make bdd` - all BDD tests pass
- [ ] `make check-license` - SPDX headers present