### PR TITLE
feat(ui): organisation/tenant self-service management in settings

### DIFF
--- a/features/steps/admin_steps.py
+++ b/features/steps/admin_steps.py
@@ -17,7 +17,19 @@ def _psql(sql):
     env["PGPASSWORD"] = "shomer"
     pg_port = os.getenv("BDD_PG_PORT", "5432")
     result = subprocess.run(
-        ["psql", "-h", "localhost", "-p", pg_port, "-U", "shomer", "-d", "shomer", "-tAc", sql],
+        [
+            "psql",
+            "-h",
+            "localhost",
+            "-p",
+            pg_port,
+            "-U",
+            "shomer",
+            "-d",
+            "shomer",
+            "-tAc",
+            sql,
+        ],
         capture_output=True,
         text=True,
         timeout=10,

--- a/features/steps/federation_steps.py
+++ b/features/steps/federation_steps.py
@@ -15,7 +15,19 @@ def _psql(sql):
     env["PGPASSWORD"] = "shomer"
     pg_port = os.getenv("BDD_PG_PORT", "5432")
     result = subprocess.run(
-        ["psql", "-h", "localhost", "-p", pg_port, "-U", "shomer", "-d", "shomer", "-tAc", sql],
+        [
+            "psql",
+            "-h",
+            "localhost",
+            "-p",
+            pg_port,
+            "-U",
+            "shomer",
+            "-d",
+            "shomer",
+            "-tAc",
+            sql,
+        ],
         capture_output=True,
         text=True,
         timeout=10,

--- a/features/steps/mail_steps.py
+++ b/features/steps/mail_steps.py
@@ -248,7 +248,19 @@ def _verify_via_db(email):
         f"WHERE email = '{email}' AND is_verified = false;"
     )
     result = subprocess.run(
-        ["psql", "-h", "localhost", "-p", pg_port, "-U", "shomer", "-d", "shomer", "-tAc", sql],
+        [
+            "psql",
+            "-h",
+            "localhost",
+            "-p",
+            pg_port,
+            "-U",
+            "shomer",
+            "-d",
+            "shomer",
+            "-tAc",
+            sql,
+        ],
         capture_output=True,
         text=True,
         timeout=10,

--- a/features/steps/oauth2_steps.py
+++ b/features/steps/oauth2_steps.py
@@ -16,7 +16,19 @@ def _psql(sql):
     env["PGPASSWORD"] = "shomer"
     pg_port = os.getenv("BDD_PG_PORT", "5432")
     result = subprocess.run(
-        ["psql", "-h", "localhost", "-p", pg_port, "-U", "shomer", "-d", "shomer", "-tAc", sql],
+        [
+            "psql",
+            "-h",
+            "localhost",
+            "-p",
+            pg_port,
+            "-U",
+            "shomer",
+            "-d",
+            "shomer",
+            "-tAc",
+            sql,
+        ],
         capture_output=True,
         text=True,
         timeout=10,

--- a/features/ui_settings_organisations.feature
+++ b/features/ui_settings_organisations.feature
@@ -1,0 +1,248 @@
+Feature: Organisation settings UI pages
+
+  Scenario: Organisations list redirects to login when unauthenticated
+    When I open the page "/ui/settings/organisations"
+    Then the page should contain "Login"
+    And I take a screenshot named "settings_orgs_redirect"
+
+  Scenario: Organisations list shows empty state when authenticated
+    Given I register and verify "org-list@example.com" with password "securepassword123"
+    When I open the page "/ui/login"
+    And I fill "input[name='email']" with "org-list@example.com"
+    And I fill "input[name='password']" with "securepassword123"
+    And I click the "Login" button
+    Then the page URL should contain "/"
+    When I navigate to "/ui/settings/organisations"
+    Then the page should contain "Organisations"
+    And the page should contain "Create Organisation"
+    And I take a screenshot named "settings_orgs_empty"
+
+  Scenario: Create organisation form renders correctly
+    Given I register and verify "org-new@example.com" with password "securepassword123"
+    When I open the page "/ui/login"
+    And I fill "input[name='email']" with "org-new@example.com"
+    And I fill "input[name='password']" with "securepassword123"
+    And I click the "Login" button
+    Then the page URL should contain "/"
+    When I navigate to "/ui/settings/organisations/new"
+    Then the page should contain "Create Organisation"
+    And the page should have an element "input[name='slug']"
+    And the page should have an element "input[name='name']"
+    And the page should have an element "input[name='display_name']"
+    And I take a screenshot named "settings_org_new_form"
+
+  Scenario: Create organisation and view detail page
+    Given I register and verify "org-create@example.com" with password "securepassword123"
+    When I open the page "/ui/login"
+    And I fill "input[name='email']" with "org-create@example.com"
+    And I fill "input[name='password']" with "securepassword123"
+    And I click the "Login" button
+    Then the page URL should contain "/"
+    When I navigate to "/ui/settings/organisations/new"
+    And I fill "input[name='slug']" with "test-org-bdd"
+    And I fill "input[name='name']" with "Test Org BDD"
+    And I fill "input[name='display_name']" with "Test Organisation BDD"
+    And I click the "Create" button
+    Then the page should contain "Test Organisation BDD"
+    And the page should contain "General"
+    And the page should contain "Members"
+    And the page should contain "Roles"
+    And the page should contain "Identity Providers"
+    And the page should contain "Branding"
+    And the page should contain "Trust Policies"
+    And the page should contain "Domains"
+    And the page should contain "Templates"
+    And I take a screenshot named "settings_org_detail"
+
+  Scenario: Edit organisation details
+    Given I register and verify "org-edit@example.com" with password "securepassword123"
+    When I open the page "/ui/login"
+    And I fill "input[name='email']" with "org-edit@example.com"
+    And I fill "input[name='password']" with "securepassword123"
+    And I click the "Login" button
+    Then the page URL should contain "/"
+    When I navigate to "/ui/settings/organisations/new"
+    And I fill "input[name='slug']" with "edit-org-bdd"
+    And I fill "input[name='name']" with "Edit Org"
+    And I fill "input[name='display_name']" with "Edit Organisation"
+    And I click the "Create" button
+    Then the page should contain "Edit Organisation"
+    When I fill "input[name='display_name']" with "Updated Organisation"
+    And I click the "Save" button
+    Then the page should contain "updated successfully"
+    And I take a screenshot named "settings_org_edited"
+
+  Scenario: Members page shows current user as owner
+    Given I register and verify "org-mem@example.com" with password "securepassword123"
+    When I open the page "/ui/login"
+    And I fill "input[name='email']" with "org-mem@example.com"
+    And I fill "input[name='password']" with "securepassword123"
+    And I click the "Login" button
+    Then the page URL should contain "/"
+    When I navigate to "/ui/settings/organisations/new"
+    And I fill "input[name='slug']" with "mem-org-bdd"
+    And I fill "input[name='name']" with "Mem Org"
+    And I fill "input[name='display_name']" with "Member Org"
+    And I click the "Create" button
+    Then the page should contain "Member Org"
+    When I click the "Members" link
+    Then the page should contain "Members"
+    And the page should contain "owner"
+    And I take a screenshot named "settings_org_members"
+
+  Scenario: Roles page shows empty state and create form
+    Given I register and verify "org-roles@example.com" with password "securepassword123"
+    When I open the page "/ui/login"
+    And I fill "input[name='email']" with "org-roles@example.com"
+    And I fill "input[name='password']" with "securepassword123"
+    And I click the "Login" button
+    Then the page URL should contain "/"
+    When I navigate to "/ui/settings/organisations/new"
+    And I fill "input[name='slug']" with "roles-org-bdd"
+    And I fill "input[name='name']" with "Roles Org"
+    And I fill "input[name='display_name']" with "Roles Org"
+    And I click the "Create" button
+    Then the page should contain "Roles Org"
+    When I click the "Roles" link
+    Then the page should contain "Roles"
+    And the page should contain "Create Role"
+    And the page should contain "No custom roles defined yet"
+    And I take a screenshot named "settings_org_roles_empty"
+
+  Scenario: Create a custom role
+    Given I register and verify "org-role-c@example.com" with password "securepassword123"
+    When I open the page "/ui/login"
+    And I fill "input[name='email']" with "org-role-c@example.com"
+    And I fill "input[name='password']" with "securepassword123"
+    And I click the "Login" button
+    Then the page URL should contain "/"
+    When I navigate to "/ui/settings/organisations/new"
+    And I fill "input[name='slug']" with "rolec-org-bdd"
+    And I fill "input[name='name']" with "RoleC Org"
+    And I fill "input[name='display_name']" with "RoleC Org"
+    And I click the "Create" button
+    Then the page should contain "RoleC Org"
+    When I click the "Roles" link
+    Then the page should contain "Create Role"
+    When I fill "input[name='role_name']" with "editor"
+    And I fill "input[name='permissions']" with "read write"
+    And I click the "Create" button
+    Then the page should contain "created"
+    And the page should contain "editor"
+    And I take a screenshot named "settings_org_role_created"
+
+  Scenario: Identity providers page shows empty state
+    Given I register and verify "org-idp@example.com" with password "securepassword123"
+    When I open the page "/ui/login"
+    And I fill "input[name='email']" with "org-idp@example.com"
+    And I fill "input[name='password']" with "securepassword123"
+    And I click the "Login" button
+    Then the page URL should contain "/"
+    When I navigate to "/ui/settings/organisations/new"
+    And I fill "input[name='slug']" with "idp-org-bdd"
+    And I fill "input[name='name']" with "IdP Org"
+    And I fill "input[name='display_name']" with "IdP Org"
+    And I click the "Create" button
+    Then the page should contain "IdP Org"
+    When I click the "Identity Providers" link
+    Then the page should contain "Identity Providers"
+    And the page should contain "Add Identity Provider"
+    And the page should contain "No identity providers configured yet"
+    And I take a screenshot named "settings_org_idps_empty"
+
+  Scenario: Branding page shows customization form
+    Given I register and verify "org-brand@example.com" with password "securepassword123"
+    When I open the page "/ui/login"
+    And I fill "input[name='email']" with "org-brand@example.com"
+    And I fill "input[name='password']" with "securepassword123"
+    And I click the "Login" button
+    Then the page URL should contain "/"
+    When I navigate to "/ui/settings/organisations/new"
+    And I fill "input[name='slug']" with "brand-org-bdd"
+    And I fill "input[name='name']" with "Brand Org"
+    And I fill "input[name='display_name']" with "Brand Org"
+    And I click the "Create" button
+    Then the page should contain "Brand Org"
+    When I click the "Branding" link
+    Then the page should contain "Branding"
+    And the page should have an element "input[name='logo_url']"
+    And the page should have an element "input[name='primary_color']"
+    And the page should have an element "input[name='font_family']"
+    And the page should contain "Save Branding"
+    And I take a screenshot named "settings_org_branding"
+
+  Scenario: Save branding settings
+    Given I register and verify "org-brand-s@example.com" with password "securepassword123"
+    When I open the page "/ui/login"
+    And I fill "input[name='email']" with "org-brand-s@example.com"
+    And I fill "input[name='password']" with "securepassword123"
+    And I click the "Login" button
+    Then the page URL should contain "/"
+    When I navigate to "/ui/settings/organisations/new"
+    And I fill "input[name='slug']" with "brands-org-bdd"
+    And I fill "input[name='name']" with "BrandS Org"
+    And I fill "input[name='display_name']" with "BrandS Org"
+    And I click the "Create" button
+    Then the page should contain "BrandS Org"
+    When I click the "Branding" link
+    And I fill "input[name='primary_color']" with "#333333"
+    And I fill "input[name='font_family']" with "Inter, sans-serif"
+    And I click the "Save Branding" button
+    Then the page should contain "updated successfully"
+    And I take a screenshot named "settings_org_branding_saved"
+
+  Scenario: Trust policies page shows trust mode and empty sources
+    Given I register and verify "org-trust@example.com" with password "securepassword123"
+    When I open the page "/ui/login"
+    And I fill "input[name='email']" with "org-trust@example.com"
+    And I fill "input[name='password']" with "securepassword123"
+    And I click the "Login" button
+    Then the page URL should contain "/"
+    When I navigate to "/ui/settings/organisations/new"
+    And I fill "input[name='slug']" with "trust-org-bdd"
+    And I fill "input[name='name']" with "Trust Org"
+    And I fill "input[name='display_name']" with "Trust Org"
+    And I click the "Create" button
+    Then the page should contain "Trust Org"
+    When I click the "Trust Policies" link
+    Then the page should contain "Trust Policies"
+    And the page should contain "Trust Mode"
+    And the page should contain "No trusted sources configured"
+    And I take a screenshot named "settings_org_trust"
+
+  Scenario: Domains page shows custom domain form
+    Given I register and verify "org-dom@example.com" with password "securepassword123"
+    When I open the page "/ui/login"
+    And I fill "input[name='email']" with "org-dom@example.com"
+    And I fill "input[name='password']" with "securepassword123"
+    And I click the "Login" button
+    Then the page URL should contain "/"
+    When I navigate to "/ui/settings/organisations/new"
+    And I fill "input[name='slug']" with "dom-org-bdd"
+    And I fill "input[name='name']" with "Dom Org"
+    And I fill "input[name='display_name']" with "Dom Org"
+    And I click the "Create" button
+    Then the page should contain "Dom Org"
+    When I click the "Domains" link
+    Then the page should contain "Custom Domain"
+    And the page should have an element "input[name='custom_domain']"
+    And I take a screenshot named "settings_org_domains"
+
+  Scenario: Templates page shows empty state and create form
+    Given I register and verify "org-tmpl@example.com" with password "securepassword123"
+    When I open the page "/ui/login"
+    And I fill "input[name='email']" with "org-tmpl@example.com"
+    And I fill "input[name='password']" with "securepassword123"
+    And I click the "Login" button
+    Then the page URL should contain "/"
+    When I navigate to "/ui/settings/organisations/new"
+    And I fill "input[name='slug']" with "tmpl-org-bdd"
+    And I fill "input[name='name']" with "Tmpl Org"
+    And I fill "input[name='display_name']" with "Tmpl Org"
+    And I click the "Create" button
+    Then the page should contain "Tmpl Org"
+    When I click the "Templates" link
+    Then the page should contain "Email Templates"
+    And the page should contain "Create Template Override"
+    And the page should contain "No custom template overrides configured"
+    And I take a screenshot named "settings_org_templates_empty"

--- a/src/shomer/app.py
+++ b/src/shomer/app.py
@@ -72,6 +72,7 @@ def create_app() -> FastAPI:
     from shomer.routes.mfa import router as mfa_router
     from shomer.routes.mfa_ui import router as mfa_ui_router
     from shomer.routes.oauth2 import router as oauth2_router
+    from shomer.routes.organisation_settings_ui import router as org_settings_ui_router
     from shomer.routes.password_ui import router as password_ui_router
     from shomer.routes.pat import router as pat_router
     from shomer.routes.pat_ui import router as pat_ui_router
@@ -94,6 +95,7 @@ def create_app() -> FastAPI:
     application.include_router(userinfo_router)
     application.include_router(profile_router)
     application.include_router(settings_ui_router)
+    application.include_router(org_settings_ui_router)
     application.include_router(device_ui_router)
     application.include_router(mfa_router)
     application.include_router(mfa_ui_router)

--- a/src/shomer/routes/organisation_settings_ui.py
+++ b/src/shomer/routes/organisation_settings_ui.py
@@ -580,3 +580,204 @@ async def settings_organisation_edit(
         "settings/organisation_detail.html",
         _detail_ctx(success="Organisation updated successfully."),
     )
+
+
+# ---------------------------------------------------------------------------
+# Custom domain verification
+# ---------------------------------------------------------------------------
+
+#: Regex for a valid domain name.
+_DOMAIN_RE = re.compile(
+    r"^(?!-)[a-zA-Z0-9-]{1,63}(?<!-)(\.[a-zA-Z0-9-]{1,63})*\.[a-zA-Z]{2,}$"
+)
+
+
+@router.get("/organisations/{org_id}/domains", response_class=HTMLResponse)
+async def settings_organisation_domains(
+    request: Request, org_id: str, db: DbSession
+) -> Any:
+    """Render the custom domain management page.
+
+    Parameters
+    ----------
+    request : Request
+        The incoming HTTP request.
+    org_id : str
+        UUID of the organisation.
+    db : DbSession
+        Database session.
+
+    Returns
+    -------
+    HTMLResponse
+        Custom domain page, or redirect to login.
+    """
+    auth = await _get_session_user(request, db)
+    if auth is None:
+        return RedirectResponse(
+            url=f"/ui/login?next=/ui/settings/organisations/{org_id}/domains",
+            status_code=302,
+        )
+
+    _, user = auth
+
+    tid = _parse_uuid(org_id)
+    if tid is None:
+        return _render(
+            request,
+            "settings/organisation_domains.html",
+            {
+                "user": user,
+                "section": "organisations",
+                "error": "Invalid organisation ID.",
+            },
+        )
+
+    result = await _get_membership(db, user.id, tid)
+    if result is None:
+        return _render(
+            request,
+            "settings/organisation_domains.html",
+            {
+                "user": user,
+                "section": "organisations",
+                "error": "Organisation not found.",
+            },
+        )
+
+    membership, tenant = result
+
+    return _render(
+        request,
+        "settings/organisation_domains.html",
+        {
+            "user": user,
+            "section": "organisations",
+            "org": {
+                "id": str(tenant.id),
+                "slug": tenant.slug,
+                "display_name": tenant.display_name,
+            },
+            "custom_domain": tenant.custom_domain,
+            "role": membership.role,
+            "error": None,
+            "success": None,
+        },
+    )
+
+
+@router.post("/organisations/{org_id}/domains", response_class=HTMLResponse)
+async def settings_organisation_domains_update(
+    request: Request,
+    org_id: str,
+    db: DbSession,
+    custom_domain: str = Form(""),
+) -> Any:
+    """Handle custom domain update form submission.
+
+    Only owners and admins can update the custom domain.
+
+    Parameters
+    ----------
+    request : Request
+        The incoming HTTP request.
+    org_id : str
+        UUID of the organisation.
+    db : DbSession
+        Database session.
+    custom_domain : str
+        The custom domain to set (empty to remove).
+
+    Returns
+    -------
+    HTMLResponse
+        Domain page with success/error message, or redirect to login.
+    """
+    auth = await _get_session_user(request, db)
+    if auth is None:
+        return RedirectResponse(
+            url=f"/ui/login?next=/ui/settings/organisations/{org_id}/domains",
+            status_code=302,
+        )
+
+    _, user = auth
+
+    tid = _parse_uuid(org_id)
+    if tid is None:
+        return _render(
+            request,
+            "settings/organisation_domains.html",
+            {
+                "user": user,
+                "section": "organisations",
+                "error": "Invalid organisation ID.",
+            },
+        )
+
+    result = await _get_membership(db, user.id, tid)
+    if result is None:
+        return _render(
+            request,
+            "settings/organisation_domains.html",
+            {
+                "user": user,
+                "section": "organisations",
+                "error": "Organisation not found.",
+            },
+        )
+
+    membership, tenant = result
+
+    def _ctx(*, error: str | None = None, success: str | None = None) -> dict[str, Any]:
+        return {
+            "user": user,
+            "section": "organisations",
+            "org": {
+                "id": str(tenant.id),
+                "slug": tenant.slug,
+                "display_name": tenant.display_name,
+            },
+            "custom_domain": tenant.custom_domain,
+            "role": membership.role,
+            "error": error,
+            "success": success,
+        }
+
+    if membership.role not in ("owner", "admin"):
+        return _render(
+            request,
+            "settings/organisation_domains.html",
+            _ctx(error="You do not have permission to update domains."),
+        )
+
+    domain = custom_domain.strip() or None
+
+    if domain is not None and not _DOMAIN_RE.match(domain):
+        return _render(
+            request,
+            "settings/organisation_domains.html",
+            _ctx(error="Invalid domain format."),
+        )
+
+    # Check uniqueness if setting a domain
+    if domain is not None:
+        dup_stmt = select(Tenant).where(
+            Tenant.custom_domain == domain, Tenant.id != tid
+        )
+        dup_result = await db.execute(dup_stmt)
+        if dup_result.scalar_one_or_none() is not None:
+            return _render(
+                request,
+                "settings/organisation_domains.html",
+                _ctx(error="This domain is already in use by another organisation."),
+            )
+
+    tenant.custom_domain = domain
+    await db.flush()
+
+    msg = "Custom domain updated." if domain else "Custom domain removed."
+    return _render(
+        request,
+        "settings/organisation_domains.html",
+        _ctx(success=msg),
+    )

--- a/src/shomer/routes/organisation_settings_ui.py
+++ b/src/shomer/routes/organisation_settings_ui.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Browser-facing organisation/tenant management UI routes (Jinja2/HTMX).
+
+Self-service organisation management pages within the user settings area.
+Allows users to list, create, view and manage their own organisations.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+from shomer.deps import DbSession
+from shomer.models.tenant import Tenant
+from shomer.models.tenant_member import TenantMember
+from shomer.models.user import User
+from shomer.services.session_service import SessionService
+
+router = APIRouter(prefix="/ui/settings", tags=["ui"], include_in_schema=False)
+
+
+def _templates() -> Jinja2Templates:
+    """Get the Jinja2 templates instance."""
+    from shomer.app import templates
+
+    return templates
+
+
+def _render(request: Request, template: str, ctx: dict[str, Any] | None = None) -> Any:
+    """Render a template with the given context.
+
+    Parameters
+    ----------
+    request : Request
+        The incoming HTTP request.
+    template : str
+        Template path relative to the templates directory.
+    ctx : dict or None
+        Template context variables.
+
+    Returns
+    -------
+    Any
+        Jinja2 template response.
+    """
+    return _templates().TemplateResponse(request, template, ctx or {})
+
+
+async def _get_session_user(request: Request, db: Any) -> tuple[Any, Any] | None:
+    """Validate session and return (session, user) or None.
+
+    Parameters
+    ----------
+    request : Request
+        The incoming HTTP request.
+    db : AsyncSession
+        Database session.
+
+    Returns
+    -------
+    tuple or None
+        (session, user) if authenticated, None otherwise.
+    """
+    session_token = request.cookies.get("session_id")
+    if not session_token:
+        return None
+
+    svc = SessionService(db)
+    session = await svc.validate(session_token)
+    if session is None:
+        return None
+
+    stmt = (
+        select(User)
+        .where(User.id == session.user_id)
+        .options(selectinload(User.profile), selectinload(User.emails))
+    )
+    result = await db.execute(stmt)
+    user = result.scalar_one_or_none()
+    if user is None:
+        return None
+
+    return session, user
+
+
+@router.get("/organisations", response_class=HTMLResponse)
+async def settings_organisations(request: Request, db: DbSession) -> Any:
+    """Render the organisations list page.
+
+    Shows all organisations the authenticated user is a member of,
+    along with their role in each organisation.
+
+    Parameters
+    ----------
+    request : Request
+        The incoming HTTP request.
+    db : DbSession
+        Database session.
+
+    Returns
+    -------
+    HTMLResponse
+        Organisations list page or redirect to login.
+    """
+    auth = await _get_session_user(request, db)
+    if auth is None:
+        return RedirectResponse(
+            url="/ui/login?next=/ui/settings/organisations", status_code=302
+        )
+
+    _, user = auth
+
+    # Fetch memberships with tenant details
+    stmt = (
+        select(TenantMember)
+        .where(TenantMember.user_id == user.id)
+        .options(selectinload(TenantMember.tenant))
+        .order_by(TenantMember.joined_at.desc())
+    )
+    result = await db.execute(stmt)
+    memberships = list(result.scalars().all())
+
+    # Build org list with role info
+    organisations: list[dict[str, Any]] = []
+    for membership in memberships:
+        tenant: Tenant = membership.tenant
+        organisations.append(
+            {
+                "id": str(tenant.id),
+                "slug": tenant.slug,
+                "name": tenant.name,
+                "display_name": tenant.display_name,
+                "is_active": tenant.is_active,
+                "is_platform": tenant.is_platform,
+                "role": membership.role,
+                "joined_at": membership.joined_at,
+            }
+        )
+
+    return _render(
+        request,
+        "settings/organisations.html",
+        {
+            "user": user,
+            "organisations": organisations,
+            "section": "organisations",
+        },
+    )

--- a/src/shomer/routes/organisation_settings_ui.py
+++ b/src/shomer/routes/organisation_settings_ui.py
@@ -9,16 +9,18 @@ Allows users to list, create, view and manage their own organisations.
 
 from __future__ import annotations
 
+import re
+from datetime import datetime, timezone
 from typing import Any
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Form, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
 from shomer.deps import DbSession
-from shomer.models.tenant import Tenant
+from shomer.models.tenant import Tenant, TenantTrustMode
 from shomer.models.tenant_member import TenantMember
 from shomer.models.user import User
 from shomer.services.session_service import SessionService
@@ -152,4 +154,144 @@ async def settings_organisations(request: Request, db: DbSession) -> Any:
             "organisations": organisations,
             "section": "organisations",
         },
+    )
+
+
+#: Regex for valid organisation slugs (lowercase alphanumeric + hyphens).
+_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$")
+
+
+@router.get("/organisations/new", response_class=HTMLResponse)
+async def settings_organisation_new(request: Request, db: DbSession) -> Any:
+    """Render the create organisation form.
+
+    Parameters
+    ----------
+    request : Request
+        The incoming HTTP request.
+    db : DbSession
+        Database session.
+
+    Returns
+    -------
+    HTMLResponse
+        Organisation creation form or redirect to login.
+    """
+    auth = await _get_session_user(request, db)
+    if auth is None:
+        return RedirectResponse(
+            url="/ui/login?next=/ui/settings/organisations/new", status_code=302
+        )
+
+    _, user = auth
+    return _render(
+        request,
+        "settings/organisation_form.html",
+        {
+            "user": user,
+            "section": "organisations",
+            "trust_modes": [m.value for m in TenantTrustMode],
+            "error": None,
+        },
+    )
+
+
+@router.post("/organisations/new", response_class=HTMLResponse)
+async def settings_organisation_create(
+    request: Request,
+    db: DbSession,
+    slug: str = Form(...),
+    name: str = Form(...),
+    display_name: str = Form(""),
+    trust_mode: str = Form("none"),
+) -> Any:
+    """Handle organisation creation form submission.
+
+    Validates the slug, creates the tenant, and adds the current user
+    as the owner.
+
+    Parameters
+    ----------
+    request : Request
+        The incoming HTTP request.
+    db : DbSession
+        Database session.
+    slug : str
+        Unique URL-safe identifier for the organisation.
+    name : str
+        Internal name.
+    display_name : str
+        Human-readable display name.
+    trust_mode : str
+        Trust mode (none, all, members_only, specific).
+
+    Returns
+    -------
+    HTMLResponse
+        Redirect to org detail on success, or form with error.
+    """
+    auth = await _get_session_user(request, db)
+    if auth is None:
+        return RedirectResponse(
+            url="/ui/login?next=/ui/settings/organisations/new", status_code=302
+        )
+
+    _, user = auth
+
+    def _form_error(msg: str) -> Any:
+        return _render(
+            request,
+            "settings/organisation_form.html",
+            {
+                "user": user,
+                "section": "organisations",
+                "trust_modes": [m.value for m in TenantTrustMode],
+                "error": msg,
+                "form_slug": slug,
+                "form_name": name,
+                "form_display_name": display_name,
+                "form_trust_mode": trust_mode,
+            },
+        )
+
+    # Validate slug format
+    if not _SLUG_RE.match(slug):
+        return _form_error(
+            "Invalid slug. Use 3-63 lowercase letters, digits, and hyphens."
+        )
+
+    # Check slug uniqueness
+    existing = await db.execute(select(Tenant).where(Tenant.slug == slug))
+    if existing.scalar_one_or_none() is not None:
+        return _form_error("This slug is already taken.")
+
+    # Validate trust mode
+    try:
+        trust = TenantTrustMode(trust_mode)
+    except ValueError:
+        return _form_error(f"Invalid trust mode: {trust_mode}")
+
+    # Create tenant
+    tenant = Tenant(
+        slug=slug,
+        name=name,
+        display_name=display_name or name,
+        trust_mode=trust,
+    )
+    db.add(tenant)
+    await db.flush()
+
+    # Add current user as owner
+    membership = TenantMember(
+        user_id=user.id,
+        tenant_id=tenant.id,
+        role="owner",
+        joined_at=datetime.now(timezone.utc),
+    )
+    db.add(membership)
+    await db.flush()
+
+    return RedirectResponse(
+        url=f"/ui/settings/organisations/{tenant.id}",
+        status_code=302,
     )

--- a/src/shomer/routes/organisation_settings_ui.py
+++ b/src/shomer/routes/organisation_settings_ui.py
@@ -23,8 +23,11 @@ from sqlalchemy.orm import selectinload
 from shomer.deps import DbSession
 from shomer.models.identity_provider import IdentityProvider, IdentityProviderType
 from shomer.models.tenant import Tenant, TenantTrustMode
+from shomer.models.tenant_branding import TenantBranding
 from shomer.models.tenant_custom_role import TenantCustomRole
 from shomer.models.tenant_member import TenantMember
+from shomer.models.tenant_template import TenantTemplate
+from shomer.models.tenant_trusted_source import TenantTrustedSource
 from shomer.models.user import User
 from shomer.models.user_email import UserEmail
 from shomer.services.session_service import SessionService
@@ -1860,5 +1863,946 @@ async def settings_organisation_idps_action(
     return _render(
         request,
         "settings/organisation_idps.html",
+        await _ctx(error="Unknown action."),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Branding customization
+# ---------------------------------------------------------------------------
+
+#: Regex for CSS hex color (3 or 6 digit).
+_HEX_COLOR_RE = re.compile(r"^#(?:[0-9a-fA-F]{3}){1,2}$")
+
+#: Branding color fields that can be updated.
+_BRANDING_COLOR_FIELDS = (
+    "primary_color",
+    "secondary_color",
+    "accent_color",
+    "background_color",
+    "surface_color",
+    "text_color",
+    "text_muted_color",
+    "error_color",
+    "success_color",
+    "border_color",
+    "warning_color",
+    "info_color",
+)
+
+
+def _branding_to_dict(branding: TenantBranding | None) -> dict[str, Any]:
+    """Convert a TenantBranding to a template-friendly dict.
+
+    Parameters
+    ----------
+    branding : TenantBranding or None
+        The branding object.
+
+    Returns
+    -------
+    dict
+        Branding fields as a dict, or empty defaults.
+    """
+    if branding is None:
+        return {
+            "logo_url": "",
+            "favicon_url": "",
+            "primary_color": "",
+            "font_family": "",
+            "custom_css": "",
+            "show_powered_by": True,
+        }
+    return {
+        "logo_url": branding.logo_url or "",
+        "favicon_url": branding.favicon_url or "",
+        "primary_color": branding.primary_color or "",
+        "secondary_color": branding.secondary_color or "",
+        "accent_color": branding.accent_color or "",
+        "background_color": branding.background_color or "",
+        "font_family": branding.font_family or "",
+        "custom_css": branding.custom_css or "",
+        "show_powered_by": branding.show_powered_by,
+    }
+
+
+@router.get("/organisations/{org_id}/branding", response_class=HTMLResponse)
+async def settings_organisation_branding(
+    request: Request, org_id: str, db: DbSession
+) -> Any:
+    """Render the branding customization page.
+
+    Parameters
+    ----------
+    request : Request
+        The incoming HTTP request.
+    org_id : str
+        UUID of the organisation.
+    db : DbSession
+        Database session.
+
+    Returns
+    -------
+    HTMLResponse
+        Branding page, or redirect to login.
+    """
+    auth = await _get_session_user(request, db)
+    if auth is None:
+        return RedirectResponse(
+            url=f"/ui/login?next=/ui/settings/organisations/{org_id}/branding",
+            status_code=302,
+        )
+
+    _, user = auth
+
+    tid = _parse_uuid(org_id)
+    if tid is None:
+        return _render(
+            request,
+            "settings/organisation_branding.html",
+            {
+                "user": user,
+                "section": "organisations",
+                "error": "Invalid organisation ID.",
+            },
+        )
+
+    result = await _get_membership(db, user.id, tid)
+    if result is None:
+        return _render(
+            request,
+            "settings/organisation_branding.html",
+            {
+                "user": user,
+                "section": "organisations",
+                "error": "Organisation not found.",
+            },
+        )
+
+    membership, tenant = result
+
+    branding_result = await db.execute(
+        select(TenantBranding).where(TenantBranding.tenant_id == tid)
+    )
+    branding = branding_result.scalar_one_or_none()
+
+    return _render(
+        request,
+        "settings/organisation_branding.html",
+        {
+            "user": user,
+            "section": "organisations",
+            "org": {
+                "id": str(tenant.id),
+                "slug": tenant.slug,
+                "display_name": tenant.display_name,
+            },
+            "branding": _branding_to_dict(branding),
+            "role": membership.role,
+            "error": None,
+            "success": None,
+        },
+    )
+
+
+@router.post("/organisations/{org_id}/branding", response_class=HTMLResponse)
+async def settings_organisation_branding_update(
+    request: Request,
+    org_id: str,
+    db: DbSession,
+    logo_url: str = Form(""),
+    favicon_url: str = Form(""),
+    primary_color: str = Form(""),
+    secondary_color: str = Form(""),
+    accent_color: str = Form(""),
+    background_color: str = Form(""),
+    font_family: str = Form(""),
+    custom_css: str = Form(""),
+    show_powered_by: str = Form(""),
+) -> Any:
+    """Handle branding update form submission.
+
+    Parameters
+    ----------
+    request : Request
+        The incoming HTTP request.
+    org_id : str
+        UUID of the organisation.
+    db : DbSession
+        Database session.
+    logo_url : str
+        Logo URL.
+    favicon_url : str
+        Favicon URL.
+    primary_color : str
+        Primary brand color (hex).
+    secondary_color : str
+        Secondary brand color (hex).
+    accent_color : str
+        Accent color (hex).
+    background_color : str
+        Background color (hex).
+    font_family : str
+        CSS font family.
+    custom_css : str
+        Custom CSS.
+    show_powered_by : str
+        Whether to show "Powered by" footer ("on" or empty).
+
+    Returns
+    -------
+    HTMLResponse
+        Branding page with success/error message, or redirect to login.
+    """
+    auth = await _get_session_user(request, db)
+    if auth is None:
+        return RedirectResponse(
+            url=f"/ui/login?next=/ui/settings/organisations/{org_id}/branding",
+            status_code=302,
+        )
+
+    _, user = auth
+
+    tid = _parse_uuid(org_id)
+    if tid is None:
+        return _render(
+            request,
+            "settings/organisation_branding.html",
+            {
+                "user": user,
+                "section": "organisations",
+                "error": "Invalid organisation ID.",
+            },
+        )
+
+    result = await _get_membership(db, user.id, tid)
+    if result is None:
+        return _render(
+            request,
+            "settings/organisation_branding.html",
+            {
+                "user": user,
+                "section": "organisations",
+                "error": "Organisation not found.",
+            },
+        )
+
+    membership, tenant = result
+
+    branding_result = await db.execute(
+        select(TenantBranding).where(TenantBranding.tenant_id == tid)
+    )
+    branding = branding_result.scalar_one_or_none()
+
+    def _ctx(*, error: str | None = None, success: str | None = None) -> dict[str, Any]:
+        return {
+            "user": user,
+            "section": "organisations",
+            "org": {
+                "id": str(tenant.id),
+                "slug": tenant.slug,
+                "display_name": tenant.display_name,
+            },
+            "branding": _branding_to_dict(branding),
+            "role": membership.role,
+            "error": error,
+            "success": success,
+        }
+
+    if membership.role not in ("owner", "admin"):
+        return _render(
+            request,
+            "settings/organisation_branding.html",
+            _ctx(error="You do not have permission to update branding."),
+        )
+
+    # Validate color fields
+    for color_val, color_name in [
+        (primary_color, "primary"),
+        (secondary_color, "secondary"),
+        (accent_color, "accent"),
+        (background_color, "background"),
+    ]:
+        if color_val.strip() and not _HEX_COLOR_RE.match(color_val.strip()):
+            return _render(
+                request,
+                "settings/organisation_branding.html",
+                _ctx(
+                    error=f"Invalid {color_name} color. Use hex format (#RGB or #RRGGBB)."
+                ),
+            )
+
+    if branding is None:
+        branding = TenantBranding(tenant_id=tid)
+        db.add(branding)
+
+    branding.logo_url = logo_url.strip() or None
+    branding.favicon_url = favicon_url.strip() or None
+    branding.primary_color = primary_color.strip() or None
+    branding.secondary_color = secondary_color.strip() or None
+    branding.accent_color = accent_color.strip() or None
+    branding.background_color = background_color.strip() or None
+    branding.font_family = font_family.strip() or None
+    branding.custom_css = custom_css.strip() or None
+    branding.show_powered_by = show_powered_by == "on"
+    await db.flush()
+
+    return _render(
+        request,
+        "settings/organisation_branding.html",
+        _ctx(success="Branding updated successfully."),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Trust policies
+# ---------------------------------------------------------------------------
+
+
+@router.get("/organisations/{org_id}/trust", response_class=HTMLResponse)
+async def settings_organisation_trust(
+    request: Request, org_id: str, db: DbSession
+) -> Any:
+    """Render the trust policies page.
+
+    Parameters
+    ----------
+    request : Request
+        The incoming HTTP request.
+    org_id : str
+        UUID of the organisation.
+    db : DbSession
+        Database session.
+
+    Returns
+    -------
+    HTMLResponse
+        Trust policies page, or redirect to login.
+    """
+    auth = await _get_session_user(request, db)
+    if auth is None:
+        return RedirectResponse(
+            url=f"/ui/login?next=/ui/settings/organisations/{org_id}/trust",
+            status_code=302,
+        )
+
+    _, user = auth
+
+    tid = _parse_uuid(org_id)
+    if tid is None:
+        return _render(
+            request,
+            "settings/organisation_trust.html",
+            {
+                "user": user,
+                "section": "organisations",
+                "error": "Invalid organisation ID.",
+            },
+        )
+
+    result = await _get_membership(db, user.id, tid)
+    if result is None:
+        return _render(
+            request,
+            "settings/organisation_trust.html",
+            {
+                "user": user,
+                "section": "organisations",
+                "error": "Organisation not found.",
+            },
+        )
+
+    membership, tenant = result
+
+    sources_stmt = (
+        select(TenantTrustedSource)
+        .where(TenantTrustedSource.tenant_id == tid)
+        .options(selectinload(TenantTrustedSource.trusted_tenant))
+        .order_by(TenantTrustedSource.created_at)
+    )
+    sources_result = await db.execute(sources_stmt)
+    sources = [
+        {
+            "id": str(s.id),
+            "trusted_tenant_slug": s.trusted_tenant.slug,
+            "trusted_tenant_name": s.trusted_tenant.display_name,
+            "description": s.description or "",
+        }
+        for s in sources_result.scalars().all()
+    ]
+
+    return _render(
+        request,
+        "settings/organisation_trust.html",
+        {
+            "user": user,
+            "section": "organisations",
+            "org": {
+                "id": str(tenant.id),
+                "slug": tenant.slug,
+                "display_name": tenant.display_name,
+            },
+            "trust_mode": _trust_mode_str(tenant),
+            "trust_modes": [m.value for m in TenantTrustMode],
+            "sources": sources,
+            "role": membership.role,
+            "error": None,
+            "success": None,
+        },
+    )
+
+
+@router.post("/organisations/{org_id}/trust", response_class=HTMLResponse)
+async def settings_organisation_trust_action(
+    request: Request,
+    org_id: str,
+    db: DbSession,
+    action: str = Form(...),
+    trust_mode: str = Form(""),
+    trusted_slug: str = Form(""),
+    description: str = Form(""),
+    source_id: str = Form(""),
+) -> Any:
+    """Handle trust policy actions (update mode, add source, remove source).
+
+    Parameters
+    ----------
+    request : Request
+        The incoming HTTP request.
+    org_id : str
+        UUID of the organisation.
+    db : DbSession
+        Database session.
+    action : str
+        Action: ``update_mode``, ``add_source``, or ``remove_source``.
+    trust_mode : str
+        New trust mode value (for update_mode).
+    trusted_slug : str
+        Slug of tenant to trust (for add_source).
+    description : str
+        Description of the trust relationship (for add_source).
+    source_id : str
+        UUID of the source to remove (for remove_source).
+
+    Returns
+    -------
+    HTMLResponse
+        Trust page with success/error message, or redirect to login.
+    """
+    auth = await _get_session_user(request, db)
+    if auth is None:
+        return RedirectResponse(
+            url=f"/ui/login?next=/ui/settings/organisations/{org_id}/trust",
+            status_code=302,
+        )
+
+    _, user = auth
+
+    tid = _parse_uuid(org_id)
+    if tid is None:
+        return _render(
+            request,
+            "settings/organisation_trust.html",
+            {
+                "user": user,
+                "section": "organisations",
+                "error": "Invalid organisation ID.",
+            },
+        )
+
+    result = await _get_membership(db, user.id, tid)
+    if result is None:
+        return _render(
+            request,
+            "settings/organisation_trust.html",
+            {
+                "user": user,
+                "section": "organisations",
+                "error": "Organisation not found.",
+            },
+        )
+
+    membership, tenant = result
+
+    async def _ctx(
+        *, error: str | None = None, success: str | None = None
+    ) -> dict[str, Any]:
+        sources_stmt = (
+            select(TenantTrustedSource)
+            .where(TenantTrustedSource.tenant_id == tid)
+            .options(selectinload(TenantTrustedSource.trusted_tenant))
+            .order_by(TenantTrustedSource.created_at)
+        )
+        sources_result = await db.execute(sources_stmt)
+        sources = [
+            {
+                "id": str(s.id),
+                "trusted_tenant_slug": s.trusted_tenant.slug,
+                "trusted_tenant_name": s.trusted_tenant.display_name,
+                "description": s.description or "",
+            }
+            for s in sources_result.scalars().all()
+        ]
+        return {
+            "user": user,
+            "section": "organisations",
+            "org": {
+                "id": str(tenant.id),
+                "slug": tenant.slug,
+                "display_name": tenant.display_name,
+            },
+            "trust_mode": _trust_mode_str(tenant),
+            "trust_modes": [m.value for m in TenantTrustMode],
+            "sources": sources,
+            "role": membership.role,
+            "error": error,
+            "success": success,
+        }
+
+    if membership.role not in ("owner", "admin"):
+        return _render(
+            request,
+            "settings/organisation_trust.html",
+            await _ctx(error="You do not have permission to manage trust policies."),
+        )
+
+    if action == "update_mode":
+        try:
+            new_mode = TenantTrustMode(trust_mode)
+        except ValueError:
+            return _render(
+                request,
+                "settings/organisation_trust.html",
+                await _ctx(error=f"Invalid trust mode: {trust_mode}"),
+            )
+        tenant.trust_mode = new_mode
+        await db.flush()
+        return _render(
+            request,
+            "settings/organisation_trust.html",
+            await _ctx(success=f"Trust mode updated to {new_mode.value}."),
+        )
+
+    elif action == "add_source":
+        slug = trusted_slug.strip()
+        if not slug:
+            return _render(
+                request,
+                "settings/organisation_trust.html",
+                await _ctx(error="Trusted organisation slug is required."),
+            )
+        trusted_result = await db.execute(select(Tenant).where(Tenant.slug == slug))
+        trusted_tenant = trusted_result.scalar_one_or_none()
+        if trusted_tenant is None:
+            return _render(
+                request,
+                "settings/organisation_trust.html",
+                await _ctx(error=f"Organisation '{slug}' not found."),
+            )
+        if trusted_tenant.id == tid:
+            return _render(
+                request,
+                "settings/organisation_trust.html",
+                await _ctx(error="Cannot trust your own organisation."),
+            )
+        # Check duplicate
+        dup_result = await db.execute(
+            select(TenantTrustedSource).where(
+                TenantTrustedSource.tenant_id == tid,
+                TenantTrustedSource.trusted_tenant_id == trusted_tenant.id,
+            )
+        )
+        if dup_result.scalar_one_or_none() is not None:
+            return _render(
+                request,
+                "settings/organisation_trust.html",
+                await _ctx(error=f"Organisation '{slug}' is already trusted."),
+            )
+        source = TenantTrustedSource(
+            tenant_id=tid,
+            trusted_tenant_id=trusted_tenant.id,
+            description=description.strip() or None,
+        )
+        db.add(source)
+        await db.flush()
+        return _render(
+            request,
+            "settings/organisation_trust.html",
+            await _ctx(success=f"Trusted source '{slug}' added."),
+        )
+
+    elif action == "remove_source":
+        sid = _parse_uuid(source_id)
+        if sid is None:
+            return _render(
+                request,
+                "settings/organisation_trust.html",
+                await _ctx(error="Invalid source ID."),
+            )
+        source_result = await db.execute(
+            select(TenantTrustedSource).where(
+                TenantTrustedSource.id == sid, TenantTrustedSource.tenant_id == tid
+            )
+        )
+        source_obj = source_result.scalar_one_or_none()
+        if source_obj is None:
+            return _render(
+                request,
+                "settings/organisation_trust.html",
+                await _ctx(error="Trusted source not found."),
+            )
+        await db.delete(source_obj)
+        await db.flush()
+        return _render(
+            request,
+            "settings/organisation_trust.html",
+            await _ctx(success="Trusted source removed."),
+        )
+
+    return _render(
+        request,
+        "settings/organisation_trust.html",
+        await _ctx(error="Unknown action."),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Email template management
+# ---------------------------------------------------------------------------
+
+
+@router.get("/organisations/{org_id}/templates", response_class=HTMLResponse)
+async def settings_organisation_templates(
+    request: Request, org_id: str, db: DbSession
+) -> Any:
+    """Render the email template management page.
+
+    Parameters
+    ----------
+    request : Request
+        The incoming HTTP request.
+    org_id : str
+        UUID of the organisation.
+    db : DbSession
+        Database session.
+
+    Returns
+    -------
+    HTMLResponse
+        Templates page, or redirect to login.
+    """
+    auth = await _get_session_user(request, db)
+    if auth is None:
+        return RedirectResponse(
+            url=f"/ui/login?next=/ui/settings/organisations/{org_id}/templates",
+            status_code=302,
+        )
+
+    _, user = auth
+
+    tid = _parse_uuid(org_id)
+    if tid is None:
+        return _render(
+            request,
+            "settings/organisation_templates.html",
+            {
+                "user": user,
+                "section": "organisations",
+                "error": "Invalid organisation ID.",
+            },
+        )
+
+    result = await _get_membership(db, user.id, tid)
+    if result is None:
+        return _render(
+            request,
+            "settings/organisation_templates.html",
+            {
+                "user": user,
+                "section": "organisations",
+                "error": "Organisation not found.",
+            },
+        )
+
+    membership, tenant = result
+
+    tmpl_stmt = (
+        select(TenantTemplate)
+        .where(TenantTemplate.tenant_id == tid)
+        .order_by(TenantTemplate.template_name)
+    )
+    tmpl_result = await db.execute(tmpl_stmt)
+    templates_list = [
+        {
+            "id": str(t.id),
+            "template_name": t.template_name,
+            "description": t.description or "",
+            "is_active": t.is_active,
+        }
+        for t in tmpl_result.scalars().all()
+    ]
+
+    return _render(
+        request,
+        "settings/organisation_templates.html",
+        {
+            "user": user,
+            "section": "organisations",
+            "org": {
+                "id": str(tenant.id),
+                "slug": tenant.slug,
+                "display_name": tenant.display_name,
+            },
+            "templates": templates_list,
+            "role": membership.role,
+            "error": None,
+            "success": None,
+        },
+    )
+
+
+@router.post("/organisations/{org_id}/templates", response_class=HTMLResponse)
+async def settings_organisation_templates_action(
+    request: Request,
+    org_id: str,
+    db: DbSession,
+    action: str = Form(...),
+    template_name: str = Form(""),
+    content: str = Form(""),
+    description: str = Form(""),
+    template_id: str = Form(""),
+) -> Any:
+    """Handle template management actions (create, update, toggle, delete).
+
+    Parameters
+    ----------
+    request : Request
+        The incoming HTTP request.
+    org_id : str
+        UUID of the organisation.
+    db : DbSession
+        Database session.
+    action : str
+        Action: ``create``, ``update``, ``toggle``, or ``delete``.
+    template_name : str
+        Template path (for create).
+    content : str
+        Template content (for create/update).
+    description : str
+        Description (for create/update).
+    template_id : str
+        UUID of the template (for update/toggle/delete).
+
+    Returns
+    -------
+    HTMLResponse
+        Templates page with success/error message, or redirect to login.
+    """
+    auth = await _get_session_user(request, db)
+    if auth is None:
+        return RedirectResponse(
+            url=f"/ui/login?next=/ui/settings/organisations/{org_id}/templates",
+            status_code=302,
+        )
+
+    _, user = auth
+
+    tid = _parse_uuid(org_id)
+    if tid is None:
+        return _render(
+            request,
+            "settings/organisation_templates.html",
+            {
+                "user": user,
+                "section": "organisations",
+                "error": "Invalid organisation ID.",
+            },
+        )
+
+    result = await _get_membership(db, user.id, tid)
+    if result is None:
+        return _render(
+            request,
+            "settings/organisation_templates.html",
+            {
+                "user": user,
+                "section": "organisations",
+                "error": "Organisation not found.",
+            },
+        )
+
+    membership, tenant = result
+
+    async def _ctx(
+        *, error: str | None = None, success: str | None = None
+    ) -> dict[str, Any]:
+        tmpl_stmt = (
+            select(TenantTemplate)
+            .where(TenantTemplate.tenant_id == tid)
+            .order_by(TenantTemplate.template_name)
+        )
+        tmpl_result = await db.execute(tmpl_stmt)
+        templates_list = [
+            {
+                "id": str(t.id),
+                "template_name": t.template_name,
+                "description": t.description or "",
+                "is_active": t.is_active,
+            }
+            for t in tmpl_result.scalars().all()
+        ]
+        return {
+            "user": user,
+            "section": "organisations",
+            "org": {
+                "id": str(tenant.id),
+                "slug": tenant.slug,
+                "display_name": tenant.display_name,
+            },
+            "templates": templates_list,
+            "role": membership.role,
+            "error": error,
+            "success": success,
+        }
+
+    if membership.role not in ("owner", "admin"):
+        return _render(
+            request,
+            "settings/organisation_templates.html",
+            await _ctx(error="You do not have permission to manage templates."),
+        )
+
+    if action == "create":
+        name = template_name.strip()
+        if not name:
+            return _render(
+                request,
+                "settings/organisation_templates.html",
+                await _ctx(error="Template name is required."),
+            )
+        if not content.strip():
+            return _render(
+                request,
+                "settings/organisation_templates.html",
+                await _ctx(error="Template content is required."),
+            )
+        # Check duplicate
+        dup_result = await db.execute(
+            select(TenantTemplate).where(
+                TenantTemplate.tenant_id == tid,
+                TenantTemplate.template_name == name,
+            )
+        )
+        if dup_result.scalar_one_or_none() is not None:
+            return _render(
+                request,
+                "settings/organisation_templates.html",
+                await _ctx(error=f"Template '{name}' already exists."),
+            )
+        tmpl = TenantTemplate(
+            tenant_id=tid,
+            template_name=name,
+            content=content.strip(),
+            description=description.strip() or None,
+        )
+        db.add(tmpl)
+        await db.flush()
+        return _render(
+            request,
+            "settings/organisation_templates.html",
+            await _ctx(success=f"Template '{name}' created."),
+        )
+
+    elif action == "update":
+        tmpl_id = _parse_uuid(template_id)
+        if tmpl_id is None:
+            return _render(
+                request,
+                "settings/organisation_templates.html",
+                await _ctx(error="Invalid template ID."),
+            )
+        update_result = await db.execute(
+            select(TenantTemplate).where(
+                TenantTemplate.id == tmpl_id, TenantTemplate.tenant_id == tid
+            )
+        )
+        update_tmpl = update_result.scalar_one_or_none()
+        if update_tmpl is None:
+            return _render(
+                request,
+                "settings/organisation_templates.html",
+                await _ctx(error="Template not found."),
+            )
+        if content.strip():
+            update_tmpl.content = content.strip()
+        if description.strip():
+            update_tmpl.description = description.strip()
+        await db.flush()
+        return _render(
+            request,
+            "settings/organisation_templates.html",
+            await _ctx(success=f"Template '{update_tmpl.template_name}' updated."),
+        )
+
+    elif action == "toggle":
+        tmpl_id = _parse_uuid(template_id)
+        if tmpl_id is None:
+            return _render(
+                request,
+                "settings/organisation_templates.html",
+                await _ctx(error="Invalid template ID."),
+            )
+        toggle_result = await db.execute(
+            select(TenantTemplate).where(
+                TenantTemplate.id == tmpl_id, TenantTemplate.tenant_id == tid
+            )
+        )
+        toggle_tmpl = toggle_result.scalar_one_or_none()
+        if toggle_tmpl is None:
+            return _render(
+                request,
+                "settings/organisation_templates.html",
+                await _ctx(error="Template not found."),
+            )
+        toggle_tmpl.is_active = not toggle_tmpl.is_active
+        await db.flush()
+        state = "enabled" if toggle_tmpl.is_active else "disabled"
+        return _render(
+            request,
+            "settings/organisation_templates.html",
+            await _ctx(success=f"Template '{toggle_tmpl.template_name}' {state}."),
+        )
+
+    elif action == "delete":
+        tmpl_id = _parse_uuid(template_id)
+        if tmpl_id is None:
+            return _render(
+                request,
+                "settings/organisation_templates.html",
+                await _ctx(error="Invalid template ID."),
+            )
+        delete_result = await db.execute(
+            select(TenantTemplate).where(
+                TenantTemplate.id == tmpl_id, TenantTemplate.tenant_id == tid
+            )
+        )
+        delete_tmpl = delete_result.scalar_one_or_none()
+        if delete_tmpl is None:
+            return _render(
+                request,
+                "settings/organisation_templates.html",
+                await _ctx(error="Template not found."),
+            )
+        await db.delete(delete_tmpl)
+        await db.flush()
+        return _render(
+            request,
+            "settings/organisation_templates.html",
+            await _ctx(success="Template deleted."),
+        )
+
+    return _render(
+        request,
+        "settings/organisation_templates.html",
         await _ctx(error="Unknown action."),
     )

--- a/src/shomer/routes/organisation_settings_ui.py
+++ b/src/shomer/routes/organisation_settings_ui.py
@@ -24,6 +24,7 @@ from shomer.deps import DbSession
 from shomer.models.tenant import Tenant, TenantTrustMode
 from shomer.models.tenant_member import TenantMember
 from shomer.models.user import User
+from shomer.models.user_email import UserEmail
 from shomer.services.session_service import SessionService
 
 router = APIRouter(prefix="/ui/settings", tags=["ui"], include_in_schema=False)
@@ -780,4 +781,467 @@ async def settings_organisation_domains_update(
         request,
         "settings/organisation_domains.html",
         _ctx(success=msg),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Member management
+# ---------------------------------------------------------------------------
+
+#: Valid member roles.
+_MEMBER_ROLES = ("owner", "admin", "member")
+
+
+async def _list_members(db: Any, tenant_id: Any) -> list[dict[str, Any]]:
+    """Fetch all members for a tenant.
+
+    Parameters
+    ----------
+    db : AsyncSession
+        Database session.
+    tenant_id : uuid.UUID
+        The tenant ID.
+
+    Returns
+    -------
+    list
+        List of member dicts with user info.
+    """
+    stmt = (
+        select(TenantMember)
+        .where(TenantMember.tenant_id == tenant_id)
+        .options(selectinload(TenantMember.user))
+        .order_by(TenantMember.joined_at)
+    )
+    result = await db.execute(stmt)
+    members_list = list(result.scalars().all())
+    items: list[dict[str, Any]] = []
+    for m in members_list:
+        items.append(
+            {
+                "id": str(m.id),
+                "user_id": str(m.user_id),
+                "username": m.user.username if m.user else "unknown",
+                "role": m.role,
+                "joined_at": m.joined_at,
+            }
+        )
+    return items
+
+
+@router.get("/organisations/{org_id}/members", response_class=HTMLResponse)
+async def settings_organisation_members(
+    request: Request, org_id: str, db: DbSession
+) -> Any:
+    """Render the member management page.
+
+    Parameters
+    ----------
+    request : Request
+        The incoming HTTP request.
+    org_id : str
+        UUID of the organisation.
+    db : DbSession
+        Database session.
+
+    Returns
+    -------
+    HTMLResponse
+        Members page, or redirect to login.
+    """
+    auth = await _get_session_user(request, db)
+    if auth is None:
+        return RedirectResponse(
+            url=f"/ui/login?next=/ui/settings/organisations/{org_id}/members",
+            status_code=302,
+        )
+
+    _, user = auth
+
+    tid = _parse_uuid(org_id)
+    if tid is None:
+        return _render(
+            request,
+            "settings/organisation_members.html",
+            {
+                "user": user,
+                "section": "organisations",
+                "error": "Invalid organisation ID.",
+            },
+        )
+
+    result = await _get_membership(db, user.id, tid)
+    if result is None:
+        return _render(
+            request,
+            "settings/organisation_members.html",
+            {
+                "user": user,
+                "section": "organisations",
+                "error": "Organisation not found.",
+            },
+        )
+
+    membership, tenant = result
+    members = await _list_members(db, tid)
+
+    return _render(
+        request,
+        "settings/organisation_members.html",
+        {
+            "user": user,
+            "section": "organisations",
+            "org": {
+                "id": str(tenant.id),
+                "slug": tenant.slug,
+                "display_name": tenant.display_name,
+            },
+            "members": members,
+            "role": membership.role,
+            "roles": _MEMBER_ROLES,
+            "error": None,
+            "success": None,
+        },
+    )
+
+
+@router.post("/organisations/{org_id}/members", response_class=HTMLResponse)
+async def settings_organisation_members_action(
+    request: Request,
+    org_id: str,
+    db: DbSession,
+    action: str = Form(...),
+    email: str = Form(""),
+    member_role: str = Form("member"),
+    member_id: str = Form(""),
+) -> Any:
+    """Handle member management actions (add, remove, update role).
+
+    Parameters
+    ----------
+    request : Request
+        The incoming HTTP request.
+    org_id : str
+        UUID of the organisation.
+    db : DbSession
+        Database session.
+    action : str
+        Action to perform: ``add``, ``remove``, or ``update_role``.
+    email : str
+        Email address of the user to add.
+    member_role : str
+        Role to assign (for add and update_role actions).
+    member_id : str
+        ID of the member to remove or update.
+
+    Returns
+    -------
+    HTMLResponse
+        Members page with success/error message, or redirect to login.
+    """
+    auth = await _get_session_user(request, db)
+    if auth is None:
+        return RedirectResponse(
+            url=f"/ui/login?next=/ui/settings/organisations/{org_id}/members",
+            status_code=302,
+        )
+
+    _, user = auth
+
+    tid = _parse_uuid(org_id)
+    if tid is None:
+        return _render(
+            request,
+            "settings/organisation_members.html",
+            {
+                "user": user,
+                "section": "organisations",
+                "error": "Invalid organisation ID.",
+            },
+        )
+
+    result = await _get_membership(db, user.id, tid)
+    if result is None:
+        return _render(
+            request,
+            "settings/organisation_members.html",
+            {
+                "user": user,
+                "section": "organisations",
+                "error": "Organisation not found.",
+            },
+        )
+
+    membership, tenant = result
+
+    async def _ctx(
+        *, error: str | None = None, success: str | None = None
+    ) -> dict[str, Any]:
+        members = await _list_members(db, tid)
+        return {
+            "user": user,
+            "section": "organisations",
+            "org": {
+                "id": str(tenant.id),
+                "slug": tenant.slug,
+                "display_name": tenant.display_name,
+            },
+            "members": members,
+            "role": membership.role,
+            "roles": _MEMBER_ROLES,
+            "error": error,
+            "success": success,
+        }
+
+    if membership.role not in ("owner", "admin"):
+        return _render(
+            request,
+            "settings/organisation_members.html",
+            await _ctx(error="You do not have permission to manage members."),
+        )
+
+    if action == "add":
+        return await _member_add(request, db, tid, email, member_role, _ctx)
+    elif action == "remove":
+        return await _member_remove(request, db, tid, member_id, user, _ctx)
+    elif action == "update_role":
+        return await _member_update_role(
+            request, db, tid, member_id, member_role, user, _ctx
+        )
+
+    return _render(
+        request,
+        "settings/organisation_members.html",
+        await _ctx(error="Unknown action."),
+    )
+
+
+async def _member_add(
+    request: Request,
+    db: Any,
+    tenant_id: uuid_mod.UUID,
+    email: str,
+    role: str,
+    ctx_fn: Any,
+) -> Any:
+    """Add a member by email.
+
+    Parameters
+    ----------
+    request : Request
+        The HTTP request.
+    db : AsyncSession
+        Database session.
+    tenant_id : uuid.UUID
+        Tenant to add the member to.
+    email : str
+        Email of the user to add.
+    role : str
+        Role to assign.
+    ctx_fn : callable
+        Async function to build template context.
+
+    Returns
+    -------
+    Any
+        Rendered template response.
+    """
+    email = email.strip().lower()
+    if not email:
+        return _render(
+            request,
+            "settings/organisation_members.html",
+            await ctx_fn(error="Please enter an email address."),
+        )
+
+    if role not in _MEMBER_ROLES:
+        return _render(
+            request,
+            "settings/organisation_members.html",
+            await ctx_fn(error=f"Invalid role: {role}"),
+        )
+
+    # Find user by email
+    email_result = await db.execute(select(UserEmail).where(UserEmail.email == email))
+    user_email = email_result.scalar_one_or_none()
+    if user_email is None:
+        return _render(
+            request,
+            "settings/organisation_members.html",
+            await ctx_fn(error=f"No user found with email {email}."),
+        )
+
+    # Check if already a member
+    existing = await db.execute(
+        select(TenantMember).where(
+            TenantMember.tenant_id == tenant_id,
+            TenantMember.user_id == user_email.user_id,
+        )
+    )
+    if existing.scalar_one_or_none() is not None:
+        return _render(
+            request,
+            "settings/organisation_members.html",
+            await ctx_fn(error="User is already a member."),
+        )
+
+    member = TenantMember(
+        tenant_id=tenant_id,
+        user_id=user_email.user_id,
+        role=role,
+        joined_at=datetime.now(timezone.utc),
+    )
+    db.add(member)
+    await db.flush()
+
+    return _render(
+        request,
+        "settings/organisation_members.html",
+        await ctx_fn(success=f"Member {email} added successfully."),
+    )
+
+
+async def _member_remove(
+    request: Request,
+    db: Any,
+    tenant_id: uuid_mod.UUID,
+    member_id: str,
+    current_user: Any,
+    ctx_fn: Any,
+) -> Any:
+    """Remove a member from the organisation.
+
+    Parameters
+    ----------
+    request : Request
+        The HTTP request.
+    db : AsyncSession
+        Database session.
+    tenant_id : uuid.UUID
+        Tenant to remove from.
+    member_id : str
+        UUID of the member to remove.
+    current_user : User
+        The currently authenticated user.
+    ctx_fn : callable
+        Async function to build template context.
+
+    Returns
+    -------
+    Any
+        Rendered template response.
+    """
+    mid = _parse_uuid(member_id)
+    if mid is None:
+        return _render(
+            request,
+            "settings/organisation_members.html",
+            await ctx_fn(error="Invalid member ID."),
+        )
+
+    result = await db.execute(
+        select(TenantMember).where(
+            TenantMember.id == mid, TenantMember.tenant_id == tenant_id
+        )
+    )
+    member = result.scalar_one_or_none()
+    if member is None:
+        return _render(
+            request,
+            "settings/organisation_members.html",
+            await ctx_fn(error="Member not found."),
+        )
+
+    if member.user_id == current_user.id:
+        return _render(
+            request,
+            "settings/organisation_members.html",
+            await ctx_fn(error="You cannot remove yourself."),
+        )
+
+    await db.delete(member)
+    await db.flush()
+
+    return _render(
+        request,
+        "settings/organisation_members.html",
+        await ctx_fn(success="Member removed."),
+    )
+
+
+async def _member_update_role(
+    request: Request,
+    db: Any,
+    tenant_id: uuid_mod.UUID,
+    member_id: str,
+    new_role: str,
+    current_user: Any,
+    ctx_fn: Any,
+) -> Any:
+    """Update a member's role.
+
+    Parameters
+    ----------
+    request : Request
+        The HTTP request.
+    db : AsyncSession
+        Database session.
+    tenant_id : uuid.UUID
+        Tenant context.
+    member_id : str
+        UUID of the member to update.
+    new_role : str
+        New role to assign.
+    current_user : User
+        The currently authenticated user.
+    ctx_fn : callable
+        Async function to build template context.
+
+    Returns
+    -------
+    Any
+        Rendered template response.
+    """
+    if new_role not in _MEMBER_ROLES:
+        return _render(
+            request,
+            "settings/organisation_members.html",
+            await ctx_fn(error=f"Invalid role: {new_role}"),
+        )
+
+    mid = _parse_uuid(member_id)
+    if mid is None:
+        return _render(
+            request,
+            "settings/organisation_members.html",
+            await ctx_fn(error="Invalid member ID."),
+        )
+
+    result = await db.execute(
+        select(TenantMember).where(
+            TenantMember.id == mid, TenantMember.tenant_id == tenant_id
+        )
+    )
+    member = result.scalar_one_or_none()
+    if member is None:
+        return _render(
+            request,
+            "settings/organisation_members.html",
+            await ctx_fn(error="Member not found."),
+        )
+
+    if member.user_id == current_user.id:
+        return _render(
+            request,
+            "settings/organisation_members.html",
+            await ctx_fn(error="You cannot change your own role."),
+        )
+
+    member.role = new_role
+    await db.flush()
+
+    return _render(
+        request,
+        "settings/organisation_members.html",
+        await ctx_fn(success=f"Role updated to {new_role}."),
     )

--- a/src/shomer/routes/organisation_settings_ui.py
+++ b/src/shomer/routes/organisation_settings_ui.py
@@ -21,6 +21,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
 from shomer.deps import DbSession
+from shomer.models.identity_provider import IdentityProvider, IdentityProviderType
 from shomer.models.tenant import Tenant, TenantTrustMode
 from shomer.models.tenant_custom_role import TenantCustomRole
 from shomer.models.tenant_member import TenantMember
@@ -1541,5 +1542,323 @@ async def settings_organisation_roles_action(
     return _render(
         request,
         "settings/organisation_roles.html",
+        await _ctx(error="Unknown action."),
+    )
+
+
+# ---------------------------------------------------------------------------
+# IdP management (CRUD + toggle)
+# ---------------------------------------------------------------------------
+
+#: Valid identity provider types.
+_IDP_TYPES = [t.value for t in IdentityProviderType]
+
+
+@router.get("/organisations/{org_id}/idps", response_class=HTMLResponse)
+async def settings_organisation_idps(
+    request: Request, org_id: str, db: DbSession
+) -> Any:
+    """Render the identity provider management page.
+
+    Parameters
+    ----------
+    request : Request
+        The incoming HTTP request.
+    org_id : str
+        UUID of the organisation.
+    db : DbSession
+        Database session.
+
+    Returns
+    -------
+    HTMLResponse
+        IdP page, or redirect to login.
+    """
+    auth = await _get_session_user(request, db)
+    if auth is None:
+        return RedirectResponse(
+            url=f"/ui/login?next=/ui/settings/organisations/{org_id}/idps",
+            status_code=302,
+        )
+
+    _, user = auth
+
+    tid = _parse_uuid(org_id)
+    if tid is None:
+        return _render(
+            request,
+            "settings/organisation_idps.html",
+            {
+                "user": user,
+                "section": "organisations",
+                "error": "Invalid organisation ID.",
+            },
+        )
+
+    result = await _get_membership(db, user.id, tid)
+    if result is None:
+        return _render(
+            request,
+            "settings/organisation_idps.html",
+            {
+                "user": user,
+                "section": "organisations",
+                "error": "Organisation not found.",
+            },
+        )
+
+    membership, tenant = result
+
+    idps_stmt = (
+        select(IdentityProvider)
+        .where(IdentityProvider.tenant_id == tid)
+        .order_by(IdentityProvider.display_order, IdentityProvider.name)
+    )
+    idps_result = await db.execute(idps_stmt)
+    idps = [
+        {
+            "id": str(idp.id),
+            "name": idp.name,
+            "provider_type": idp.provider_type.value,
+            "client_id": idp.client_id,
+            "is_active": idp.is_active,
+        }
+        for idp in idps_result.scalars().all()
+    ]
+
+    return _render(
+        request,
+        "settings/organisation_idps.html",
+        {
+            "user": user,
+            "section": "organisations",
+            "org": {
+                "id": str(tenant.id),
+                "slug": tenant.slug,
+                "display_name": tenant.display_name,
+            },
+            "idps": idps,
+            "provider_types": _IDP_TYPES,
+            "role": membership.role,
+            "error": None,
+            "success": None,
+        },
+    )
+
+
+@router.post("/organisations/{org_id}/idps", response_class=HTMLResponse)
+async def settings_organisation_idps_action(
+    request: Request,
+    org_id: str,
+    db: DbSession,
+    action: str = Form(...),
+    idp_name: str = Form(""),
+    provider_type: str = Form("oidc"),
+    client_id: str = Form(""),
+    discovery_url: str = Form(""),
+    idp_id: str = Form(""),
+) -> Any:
+    """Handle identity provider management actions (create, toggle, delete).
+
+    Parameters
+    ----------
+    request : Request
+        The incoming HTTP request.
+    org_id : str
+        UUID of the organisation.
+    db : DbSession
+        Database session.
+    action : str
+        Action to perform: ``create``, ``toggle``, or ``delete``.
+    idp_name : str
+        Name for the IdP (create).
+    provider_type : str
+        Provider type string (create).
+    client_id : str
+        OAuth2 client ID (create).
+    discovery_url : str
+        OIDC discovery URL (create, optional).
+    idp_id : str
+        UUID of the IdP (toggle/delete).
+
+    Returns
+    -------
+    HTMLResponse
+        IdP page with success/error message, or redirect to login.
+    """
+    auth = await _get_session_user(request, db)
+    if auth is None:
+        return RedirectResponse(
+            url=f"/ui/login?next=/ui/settings/organisations/{org_id}/idps",
+            status_code=302,
+        )
+
+    _, user = auth
+
+    tid = _parse_uuid(org_id)
+    if tid is None:
+        return _render(
+            request,
+            "settings/organisation_idps.html",
+            {
+                "user": user,
+                "section": "organisations",
+                "error": "Invalid organisation ID.",
+            },
+        )
+
+    result = await _get_membership(db, user.id, tid)
+    if result is None:
+        return _render(
+            request,
+            "settings/organisation_idps.html",
+            {
+                "user": user,
+                "section": "organisations",
+                "error": "Organisation not found.",
+            },
+        )
+
+    membership, tenant = result
+
+    async def _ctx(
+        *, error: str | None = None, success: str | None = None
+    ) -> dict[str, Any]:
+        idps_stmt = (
+            select(IdentityProvider)
+            .where(IdentityProvider.tenant_id == tid)
+            .order_by(IdentityProvider.display_order, IdentityProvider.name)
+        )
+        idps_result = await db.execute(idps_stmt)
+        idps = [
+            {
+                "id": str(idp.id),
+                "name": idp.name,
+                "provider_type": idp.provider_type.value,
+                "client_id": idp.client_id,
+                "is_active": idp.is_active,
+            }
+            for idp in idps_result.scalars().all()
+        ]
+        return {
+            "user": user,
+            "section": "organisations",
+            "org": {
+                "id": str(tenant.id),
+                "slug": tenant.slug,
+                "display_name": tenant.display_name,
+            },
+            "idps": idps,
+            "provider_types": _IDP_TYPES,
+            "role": membership.role,
+            "error": error,
+            "success": success,
+        }
+
+    if membership.role not in ("owner", "admin"):
+        return _render(
+            request,
+            "settings/organisation_idps.html",
+            await _ctx(
+                error="You do not have permission to manage identity providers."
+            ),
+        )
+
+    if action == "create":
+        name = idp_name.strip()
+        if not name:
+            return _render(
+                request,
+                "settings/organisation_idps.html",
+                await _ctx(error="Provider name is required."),
+            )
+        if provider_type not in _IDP_TYPES:
+            return _render(
+                request,
+                "settings/organisation_idps.html",
+                await _ctx(error=f"Invalid provider type: {provider_type}"),
+            )
+        cid = client_id.strip()
+        if not cid:
+            return _render(
+                request,
+                "settings/organisation_idps.html",
+                await _ctx(error="Client ID is required."),
+            )
+        idp_obj = IdentityProvider(
+            tenant_id=tid,
+            name=name,
+            provider_type=IdentityProviderType(provider_type),
+            client_id=cid,
+            discovery_url=discovery_url.strip() or None,
+        )
+        db.add(idp_obj)
+        await db.flush()
+        return _render(
+            request,
+            "settings/organisation_idps.html",
+            await _ctx(success=f"Identity provider '{name}' created."),
+        )
+
+    elif action == "toggle":
+        iid = _parse_uuid(idp_id)
+        if iid is None:
+            return _render(
+                request,
+                "settings/organisation_idps.html",
+                await _ctx(error="Invalid provider ID."),
+            )
+        toggle_result = await db.execute(
+            select(IdentityProvider).where(
+                IdentityProvider.id == iid, IdentityProvider.tenant_id == tid
+            )
+        )
+        toggle_idp = toggle_result.scalar_one_or_none()
+        if toggle_idp is None:
+            return _render(
+                request,
+                "settings/organisation_idps.html",
+                await _ctx(error="Provider not found."),
+            )
+        toggle_idp.is_active = not toggle_idp.is_active
+        await db.flush()
+        state = "enabled" if toggle_idp.is_active else "disabled"
+        return _render(
+            request,
+            "settings/organisation_idps.html",
+            await _ctx(success=f"Provider '{toggle_idp.name}' {state}."),
+        )
+
+    elif action == "delete":
+        iid = _parse_uuid(idp_id)
+        if iid is None:
+            return _render(
+                request,
+                "settings/organisation_idps.html",
+                await _ctx(error="Invalid provider ID."),
+            )
+        delete_result = await db.execute(
+            select(IdentityProvider).where(
+                IdentityProvider.id == iid, IdentityProvider.tenant_id == tid
+            )
+        )
+        delete_idp = delete_result.scalar_one_or_none()
+        if delete_idp is None:
+            return _render(
+                request,
+                "settings/organisation_idps.html",
+                await _ctx(error="Provider not found."),
+            )
+        await db.delete(delete_idp)
+        await db.flush()
+        return _render(
+            request,
+            "settings/organisation_idps.html",
+            await _ctx(success="Provider deleted."),
+        )
+
+    return _render(
+        request,
+        "settings/organisation_idps.html",
         await _ctx(error="Unknown action."),
     )

--- a/src/shomer/routes/organisation_settings_ui.py
+++ b/src/shomer/routes/organisation_settings_ui.py
@@ -10,6 +10,7 @@ Allows users to list, create, view and manage their own organisations.
 from __future__ import annotations
 
 import re
+import uuid as uuid_mod
 from datetime import datetime, timezone
 from typing import Any
 
@@ -294,4 +295,288 @@ async def settings_organisation_create(
     return RedirectResponse(
         url=f"/ui/settings/organisations/{tenant.id}",
         status_code=302,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_uuid(value: str) -> uuid_mod.UUID | None:
+    """Parse a UUID string, returning None on failure.
+
+    Parameters
+    ----------
+    value : str
+        String to parse.
+
+    Returns
+    -------
+    uuid.UUID or None
+        Parsed UUID or None if invalid.
+    """
+    try:
+        return uuid_mod.UUID(value)
+    except ValueError:
+        return None
+
+
+async def _get_membership(
+    db: Any, user_id: Any, tenant_id: uuid_mod.UUID
+) -> tuple[Any, Any] | None:
+    """Fetch the TenantMember and Tenant for a user, or None.
+
+    Parameters
+    ----------
+    db : AsyncSession
+        Database session.
+    user_id : uuid.UUID
+        The authenticated user ID.
+    tenant_id : uuid.UUID
+        The tenant to look up.
+
+    Returns
+    -------
+    tuple or None
+        (membership, tenant) if the user is a member, None otherwise.
+    """
+    stmt = (
+        select(TenantMember)
+        .where(TenantMember.user_id == user_id, TenantMember.tenant_id == tenant_id)
+        .options(selectinload(TenantMember.tenant))
+    )
+    result = await db.execute(stmt)
+    membership = result.scalar_one_or_none()
+    if membership is None:
+        return None
+    return membership, membership.tenant
+
+
+def _trust_mode_str(tenant: Any) -> str:
+    """Return trust_mode as plain string.
+
+    Parameters
+    ----------
+    tenant : Tenant
+        The tenant object.
+
+    Returns
+    -------
+    str
+        Trust mode value.
+    """
+    m = tenant.trust_mode
+    return m.value if hasattr(m, "value") else str(m)
+
+
+# ---------------------------------------------------------------------------
+# Organisation detail / edit
+# ---------------------------------------------------------------------------
+
+
+@router.get("/organisations/{org_id}", response_class=HTMLResponse)
+async def settings_organisation_detail(
+    request: Request, org_id: str, db: DbSession
+) -> Any:
+    """Render the organisation detail page.
+
+    Shows organisation information and management options.
+    Only accessible to members of the organisation.
+
+    Parameters
+    ----------
+    request : Request
+        The incoming HTTP request.
+    org_id : str
+        UUID of the organisation.
+    db : DbSession
+        Database session.
+
+    Returns
+    -------
+    HTMLResponse
+        Organisation detail page, 404 page, or redirect to login.
+    """
+    auth = await _get_session_user(request, db)
+    if auth is None:
+        return RedirectResponse(
+            url=f"/ui/login?next=/ui/settings/organisations/{org_id}",
+            status_code=302,
+        )
+
+    _, user = auth
+
+    tid = _parse_uuid(org_id)
+    if tid is None:
+        return _render(
+            request,
+            "settings/organisation_detail.html",
+            {
+                "user": user,
+                "section": "organisations",
+                "error": "Invalid organisation ID.",
+            },
+        )
+
+    result = await _get_membership(db, user.id, tid)
+    if result is None:
+        return _render(
+            request,
+            "settings/organisation_detail.html",
+            {
+                "user": user,
+                "section": "organisations",
+                "error": "Organisation not found.",
+            },
+        )
+
+    membership, tenant = result
+
+    return _render(
+        request,
+        "settings/organisation_detail.html",
+        {
+            "user": user,
+            "section": "organisations",
+            "org": {
+                "id": str(tenant.id),
+                "slug": tenant.slug,
+                "name": tenant.name,
+                "display_name": tenant.display_name,
+                "custom_domain": tenant.custom_domain,
+                "is_active": tenant.is_active,
+                "is_platform": tenant.is_platform,
+                "trust_mode": _trust_mode_str(tenant),
+                "created_at": tenant.created_at,
+            },
+            "role": membership.role,
+            "trust_modes": [m.value for m in TenantTrustMode],
+            "error": None,
+            "success": None,
+        },
+    )
+
+
+@router.post("/organisations/{org_id}", response_class=HTMLResponse)
+async def settings_organisation_edit(
+    request: Request,
+    org_id: str,
+    db: DbSession,
+    name: str = Form(...),
+    display_name: str = Form(""),
+    trust_mode: str = Form("none"),
+) -> Any:
+    """Handle organisation edit form submission.
+
+    Only owners and admins can edit organisation details.
+
+    Parameters
+    ----------
+    request : Request
+        The incoming HTTP request.
+    org_id : str
+        UUID of the organisation.
+    db : DbSession
+        Database session.
+    name : str
+        Updated internal name.
+    display_name : str
+        Updated display name.
+    trust_mode : str
+        Updated trust mode.
+
+    Returns
+    -------
+    HTMLResponse
+        Organisation detail page with success/error message, or redirect to login.
+    """
+    auth = await _get_session_user(request, db)
+    if auth is None:
+        return RedirectResponse(
+            url=f"/ui/login?next=/ui/settings/organisations/{org_id}",
+            status_code=302,
+        )
+
+    _, user = auth
+
+    tid = _parse_uuid(org_id)
+    if tid is None:
+        return _render(
+            request,
+            "settings/organisation_detail.html",
+            {
+                "user": user,
+                "section": "organisations",
+                "error": "Invalid organisation ID.",
+            },
+        )
+
+    result = await _get_membership(db, user.id, tid)
+    if result is None:
+        return _render(
+            request,
+            "settings/organisation_detail.html",
+            {
+                "user": user,
+                "section": "organisations",
+                "error": "Organisation not found.",
+            },
+        )
+
+    membership, tenant = result
+
+    def _detail_ctx(
+        *,
+        error: str | None = None,
+        success: str | None = None,
+    ) -> dict[str, Any]:
+        return {
+            "user": user,
+            "section": "organisations",
+            "org": {
+                "id": str(tenant.id),
+                "slug": tenant.slug,
+                "name": tenant.name,
+                "display_name": tenant.display_name,
+                "custom_domain": tenant.custom_domain,
+                "is_active": tenant.is_active,
+                "is_platform": tenant.is_platform,
+                "trust_mode": _trust_mode_str(tenant),
+                "created_at": tenant.created_at,
+            },
+            "role": membership.role,
+            "trust_modes": [m.value for m in TenantTrustMode],
+            "error": error,
+            "success": success,
+        }
+
+    # Only owners and admins can edit
+    if membership.role not in ("owner", "admin"):
+        return _render(
+            request,
+            "settings/organisation_detail.html",
+            _detail_ctx(error="You do not have permission to edit this organisation."),
+        )
+
+    # Validate trust mode
+    try:
+        trust = TenantTrustMode(trust_mode)
+    except ValueError:
+        return _render(
+            request,
+            "settings/organisation_detail.html",
+            _detail_ctx(error=f"Invalid trust mode: {trust_mode}"),
+        )
+
+    # Apply changes
+    tenant.name = name
+    tenant.display_name = display_name or name
+    tenant.trust_mode = trust
+    await db.flush()
+
+    return _render(
+        request,
+        "settings/organisation_detail.html",
+        _detail_ctx(success="Organisation updated successfully."),
     )

--- a/src/shomer/routes/organisation_settings_ui.py
+++ b/src/shomer/routes/organisation_settings_ui.py
@@ -22,6 +22,7 @@ from sqlalchemy.orm import selectinload
 
 from shomer.deps import DbSession
 from shomer.models.tenant import Tenant, TenantTrustMode
+from shomer.models.tenant_custom_role import TenantCustomRole
 from shomer.models.tenant_member import TenantMember
 from shomer.models.user import User
 from shomer.models.user_email import UserEmail
@@ -1244,4 +1245,301 @@ async def _member_update_role(
         request,
         "settings/organisation_members.html",
         await ctx_fn(success=f"Role updated to {new_role}."),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Role management (CRUD + scope assignment)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/organisations/{org_id}/roles", response_class=HTMLResponse)
+async def settings_organisation_roles(
+    request: Request, org_id: str, db: DbSession
+) -> Any:
+    """Render the role management page.
+
+    Parameters
+    ----------
+    request : Request
+        The incoming HTTP request.
+    org_id : str
+        UUID of the organisation.
+    db : DbSession
+        Database session.
+
+    Returns
+    -------
+    HTMLResponse
+        Roles page, or redirect to login.
+    """
+    auth = await _get_session_user(request, db)
+    if auth is None:
+        return RedirectResponse(
+            url=f"/ui/login?next=/ui/settings/organisations/{org_id}/roles",
+            status_code=302,
+        )
+
+    _, user = auth
+
+    tid = _parse_uuid(org_id)
+    if tid is None:
+        return _render(
+            request,
+            "settings/organisation_roles.html",
+            {
+                "user": user,
+                "section": "organisations",
+                "error": "Invalid organisation ID.",
+            },
+        )
+
+    result = await _get_membership(db, user.id, tid)
+    if result is None:
+        return _render(
+            request,
+            "settings/organisation_roles.html",
+            {
+                "user": user,
+                "section": "organisations",
+                "error": "Organisation not found.",
+            },
+        )
+
+    membership, tenant = result
+
+    roles_stmt = (
+        select(TenantCustomRole)
+        .where(TenantCustomRole.tenant_id == tid)
+        .order_by(TenantCustomRole.name)
+    )
+    roles_result = await db.execute(roles_stmt)
+    roles = [
+        {
+            "id": str(r.id),
+            "name": r.name,
+            "permissions": r.permissions,
+        }
+        for r in roles_result.scalars().all()
+    ]
+
+    return _render(
+        request,
+        "settings/organisation_roles.html",
+        {
+            "user": user,
+            "section": "organisations",
+            "org": {
+                "id": str(tenant.id),
+                "slug": tenant.slug,
+                "display_name": tenant.display_name,
+            },
+            "roles": roles,
+            "role": membership.role,
+            "error": None,
+            "success": None,
+        },
+    )
+
+
+@router.post("/organisations/{org_id}/roles", response_class=HTMLResponse)
+async def settings_organisation_roles_action(
+    request: Request,
+    org_id: str,
+    db: DbSession,
+    action: str = Form(...),
+    role_name: str = Form(""),
+    permissions: str = Form(""),
+    role_id: str = Form(""),
+) -> Any:
+    """Handle role management actions (create, update, delete).
+
+    Parameters
+    ----------
+    request : Request
+        The incoming HTTP request.
+    org_id : str
+        UUID of the organisation.
+    db : DbSession
+        Database session.
+    action : str
+        Action to perform: ``create``, ``update``, or ``delete``.
+    role_name : str
+        Name for the role (create/update).
+    permissions : str
+        Space-separated permission strings (create/update).
+    role_id : str
+        UUID of the role (update/delete).
+
+    Returns
+    -------
+    HTMLResponse
+        Roles page with success/error message, or redirect to login.
+    """
+    auth = await _get_session_user(request, db)
+    if auth is None:
+        return RedirectResponse(
+            url=f"/ui/login?next=/ui/settings/organisations/{org_id}/roles",
+            status_code=302,
+        )
+
+    _, user = auth
+
+    tid = _parse_uuid(org_id)
+    if tid is None:
+        return _render(
+            request,
+            "settings/organisation_roles.html",
+            {
+                "user": user,
+                "section": "organisations",
+                "error": "Invalid organisation ID.",
+            },
+        )
+
+    result = await _get_membership(db, user.id, tid)
+    if result is None:
+        return _render(
+            request,
+            "settings/organisation_roles.html",
+            {
+                "user": user,
+                "section": "organisations",
+                "error": "Organisation not found.",
+            },
+        )
+
+    membership, tenant = result
+
+    async def _ctx(
+        *, error: str | None = None, success: str | None = None
+    ) -> dict[str, Any]:
+        roles_stmt = (
+            select(TenantCustomRole)
+            .where(TenantCustomRole.tenant_id == tid)
+            .order_by(TenantCustomRole.name)
+        )
+        roles_result = await db.execute(roles_stmt)
+        roles = [
+            {"id": str(r.id), "name": r.name, "permissions": r.permissions}
+            for r in roles_result.scalars().all()
+        ]
+        return {
+            "user": user,
+            "section": "organisations",
+            "org": {
+                "id": str(tenant.id),
+                "slug": tenant.slug,
+                "display_name": tenant.display_name,
+            },
+            "roles": roles,
+            "role": membership.role,
+            "error": error,
+            "success": success,
+        }
+
+    if membership.role not in ("owner", "admin"):
+        return _render(
+            request,
+            "settings/organisation_roles.html",
+            await _ctx(error="You do not have permission to manage roles."),
+        )
+
+    perms_list = [p.strip() for p in permissions.split() if p.strip()]
+
+    if action == "create":
+        name = role_name.strip()
+        if not name:
+            return _render(
+                request,
+                "settings/organisation_roles.html",
+                await _ctx(error="Role name is required."),
+            )
+        existing = await db.execute(
+            select(TenantCustomRole).where(
+                TenantCustomRole.tenant_id == tid,
+                TenantCustomRole.name == name,
+            )
+        )
+        if existing.scalar_one_or_none() is not None:
+            return _render(
+                request,
+                "settings/organisation_roles.html",
+                await _ctx(error=f"Role '{name}' already exists."),
+            )
+        role_obj = TenantCustomRole(
+            tenant_id=tid,
+            name=name,
+            permissions=perms_list,
+        )
+        db.add(role_obj)
+        await db.flush()
+        return _render(
+            request,
+            "settings/organisation_roles.html",
+            await _ctx(success=f"Role '{name}' created."),
+        )
+
+    elif action == "update":
+        rid = _parse_uuid(role_id)
+        if rid is None:
+            return _render(
+                request,
+                "settings/organisation_roles.html",
+                await _ctx(error="Invalid role ID."),
+            )
+        update_result = await db.execute(
+            select(TenantCustomRole).where(
+                TenantCustomRole.id == rid, TenantCustomRole.tenant_id == tid
+            )
+        )
+        update_role = update_result.scalar_one_or_none()
+        if update_role is None:
+            return _render(
+                request,
+                "settings/organisation_roles.html",
+                await _ctx(error="Role not found."),
+            )
+        if role_name.strip():
+            update_role.name = role_name.strip()
+        update_role.permissions = perms_list
+        await db.flush()
+        return _render(
+            request,
+            "settings/organisation_roles.html",
+            await _ctx(success=f"Role '{update_role.name}' updated."),
+        )
+
+    elif action == "delete":
+        rid = _parse_uuid(role_id)
+        if rid is None:
+            return _render(
+                request,
+                "settings/organisation_roles.html",
+                await _ctx(error="Invalid role ID."),
+            )
+        delete_result = await db.execute(
+            select(TenantCustomRole).where(
+                TenantCustomRole.id == rid, TenantCustomRole.tenant_id == tid
+            )
+        )
+        delete_role = delete_result.scalar_one_or_none()
+        if delete_role is None:
+            return _render(
+                request,
+                "settings/organisation_roles.html",
+                await _ctx(error="Role not found."),
+            )
+        await db.delete(delete_role)
+        await db.flush()
+        return _render(
+            request,
+            "settings/organisation_roles.html",
+            await _ctx(success="Role deleted."),
+        )
+
+    return _render(
+        request,
+        "settings/organisation_roles.html",
+        await _ctx(error="Unknown action."),
     )

--- a/src/shomer/templates/settings/organisation_branding.html
+++ b/src/shomer/templates/settings/organisation_branding.html
@@ -1,0 +1,120 @@
+{% extends "base.html" %}
+{% block title %}Branding — Shomer{% endblock %}
+{% block content %}
+<h1>Settings</h1>
+<nav class="settings-nav">
+    <a href="/ui/settings">Overview</a>
+    <a href="/ui/settings/profile">Profile</a>
+    <a href="/ui/settings/emails">Emails</a>
+    <a href="/ui/settings/security">Security</a>
+    <a href="/ui/settings/pats">Tokens</a>
+    <a href="/ui/settings/organisations" class="active">Organisations</a>
+</nav>
+
+{% if org %}
+<div class="page-header">
+    <h2>{{ org.display_name }} — Branding</h2>
+    <a href="/ui/settings/organisations/{{ org.id }}">&larr; Back to organisation</a>
+</div>
+
+<div class="org-nav">
+    <a href="/ui/settings/organisations/{{ org.id }}">General</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/members">Members</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/roles">Roles</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/idps">Identity Providers</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/branding" class="active">Branding</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/trust">Trust Policies</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/domains">Domains</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/templates">Templates</a>
+</div>
+{% else %}
+<div class="page-header">
+    <h2>Branding</h2>
+    <a href="/ui/settings/organisations">&larr; Back to list</a>
+</div>
+{% endif %}
+
+{% if error %}<p class="error">{{ error }}</p>{% endif %}
+{% if success %}<p class="success">{{ success }}</p>{% endif %}
+
+{% if org %}
+{% if role in ('owner', 'admin') %}
+<form method="post" action="/ui/settings/organisations/{{ org.id }}/branding" class="branding-form">
+    <h3>Logo &amp; Icons</h3>
+    <div class="form-group">
+        <label for="logo_url">Logo URL</label>
+        <input type="url" id="logo_url" name="logo_url" value="{{ branding.logo_url }}" placeholder="https://...">
+    </div>
+    <div class="form-group">
+        <label for="favicon_url">Favicon URL</label>
+        <input type="url" id="favicon_url" name="favicon_url" value="{{ branding.favicon_url }}" placeholder="https://...">
+    </div>
+
+    <h3>Colors</h3>
+    <div class="color-grid">
+        <div class="form-group">
+            <label for="primary_color">Primary</label>
+            <input type="text" id="primary_color" name="primary_color" value="{{ branding.primary_color }}" placeholder="#333333" maxlength="7">
+        </div>
+        <div class="form-group">
+            <label for="secondary_color">Secondary</label>
+            <input type="text" id="secondary_color" name="secondary_color" value="{{ branding.secondary_color }}" placeholder="#666666" maxlength="7">
+        </div>
+        <div class="form-group">
+            <label for="accent_color">Accent</label>
+            <input type="text" id="accent_color" name="accent_color" value="{{ branding.accent_color }}" placeholder="#0066cc" maxlength="7">
+        </div>
+        <div class="form-group">
+            <label for="background_color">Background</label>
+            <input type="text" id="background_color" name="background_color" value="{{ branding.background_color }}" placeholder="#ffffff" maxlength="7">
+        </div>
+    </div>
+
+    <h3>Typography</h3>
+    <div class="form-group">
+        <label for="font_family">Font Family</label>
+        <input type="text" id="font_family" name="font_family" value="{{ branding.font_family }}" placeholder="Inter, system-ui, sans-serif">
+    </div>
+
+    <h3>Custom CSS</h3>
+    <div class="form-group">
+        <label for="custom_css">Custom CSS</label>
+        <textarea id="custom_css" name="custom_css" rows="6" placeholder="/* Custom styles for auth pages */">{{ branding.custom_css }}</textarea>
+    </div>
+
+    <h3>Settings</h3>
+    <div class="form-group checkbox-group">
+        <label>
+            <input type="checkbox" name="show_powered_by" {% if branding.show_powered_by %}checked{% endif %}>
+            Show "Powered by Shomer" footer
+        </label>
+    </div>
+
+    <button type="submit" class="btn-primary">Save Branding</button>
+</form>
+{% else %}
+<p>Only owners and admins can edit branding settings.</p>
+{% endif %}
+{% endif %}
+
+<style>
+    .settings-nav { display: flex; gap: 16px; margin-bottom: 24px; border-bottom: 1px solid #eee; padding-bottom: 8px; }
+    .settings-nav a { text-decoration: none; padding: 4px 8px; border-radius: 4px; }
+    .settings-nav a.active { background: #333; color: #fff; }
+    .page-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 24px; }
+    .org-nav { display: flex; gap: 8px; margin-bottom: 24px; flex-wrap: wrap; border-bottom: 1px solid #eee; padding-bottom: 8px; }
+    .org-nav a { text-decoration: none; padding: 4px 10px; border-radius: 4px; font-size: 0.9rem; color: #555; }
+    .org-nav a.active { background: #e8e8e8; color: #333; font-weight: 600; }
+    .error { color: #721c24; background: #f8d7da; padding: 12px; border-radius: 4px; margin-bottom: 16px; }
+    .success { color: #155724; background: #d4edda; padding: 12px; border-radius: 4px; margin-bottom: 16px; }
+    .branding-form { max-width: 600px; }
+    .branding-form h3 { margin-top: 24px; margin-bottom: 12px; font-size: 1rem; border-bottom: 1px solid #eee; padding-bottom: 4px; }
+    .form-group { margin-bottom: 12px; }
+    .form-group label { display: block; font-weight: 600; font-size: 0.85em; margin-bottom: 4px; color: #555; }
+    .form-group input[type="url"], .form-group input[type="text"], .form-group textarea { padding: 6px 8px; border: 1px solid #ccc; border-radius: 4px; width: 100%; box-sizing: border-box; }
+    .form-group textarea { font-family: monospace; font-size: 0.85em; }
+    .color-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+    .checkbox-group label { display: flex; align-items: center; gap: 8px; font-weight: normal; font-size: 0.9em; }
+    .btn-primary { background: #333; color: #fff; padding: 8px 20px; border: none; border-radius: 4px; cursor: pointer; margin-top: 16px; }
+</style>
+{% endblock %}

--- a/src/shomer/templates/settings/organisation_detail.html
+++ b/src/shomer/templates/settings/organisation_detail.html
@@ -1,0 +1,122 @@
+{% extends "base.html" %}
+{% block title %}{{ org.display_name if org else 'Organisation' }} — Shomer{% endblock %}
+{% block content %}
+<h1>Settings</h1>
+<nav class="settings-nav">
+    <a href="/ui/settings">Overview</a>
+    <a href="/ui/settings/profile">Profile</a>
+    <a href="/ui/settings/emails">Emails</a>
+    <a href="/ui/settings/security">Security</a>
+    <a href="/ui/settings/pats">Tokens</a>
+    <a href="/ui/settings/organisations" class="active">Organisations</a>
+</nav>
+
+<div class="page-header">
+    <h2>{{ org.display_name if org else 'Organisation' }}</h2>
+    <a href="/ui/settings/organisations">&larr; Back to list</a>
+</div>
+
+{% if error %}<p class="error">{{ error }}</p>{% endif %}
+{% if success %}<p class="success">{{ success }}</p>{% endif %}
+
+{% if org %}
+<div class="org-nav">
+    <a href="/ui/settings/organisations/{{ org.id }}" class="active">General</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/members">Members</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/roles">Roles</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/idps">Identity Providers</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/branding">Branding</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/trust">Trust Policies</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/domains">Domains</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/templates">Templates</a>
+</div>
+
+<div class="stat-grid">
+    <div class="stat-card">
+        <div class="label">Slug</div>
+        <div class="value"><code>{{ org.slug }}</code></div>
+    </div>
+    <div class="stat-card">
+        <div class="label">Status</div>
+        <div class="value status-{{ 'ok' if org.is_active else 'warn' }}">{{ "Active" if org.is_active else "Inactive" }}</div>
+    </div>
+    <div class="stat-card">
+        <div class="label">Your Role</div>
+        <div class="value"><span class="role-badge role-{{ role }}">{{ role }}</span></div>
+    </div>
+    <div class="stat-card">
+        <div class="label">Trust Mode</div>
+        <div class="value">{{ org.trust_mode }}</div>
+    </div>
+</div>
+
+{% if role in ('owner', 'admin') %}
+<h3>Edit Organisation</h3>
+<form method="post" action="/ui/settings/organisations/{{ org.id }}" class="org-form">
+    <div class="form-group">
+        <label for="name">Name</label>
+        <input type="text" id="name" name="name" value="{{ org.name }}" required>
+    </div>
+
+    <div class="form-group">
+        <label for="display_name">Display Name</label>
+        <input type="text" id="display_name" name="display_name" value="{{ org.display_name }}">
+    </div>
+
+    <div class="form-group">
+        <label for="trust_mode">Trust Mode</label>
+        <select id="trust_mode" name="trust_mode">
+            {% for mode in trust_modes %}
+            <option value="{{ mode }}" {% if org.trust_mode == mode %}selected{% endif %}>{{ mode }}</option>
+            {% endfor %}
+        </select>
+    </div>
+
+    <div class="form-actions">
+        <button type="submit" class="btn-primary">Save Changes</button>
+    </div>
+</form>
+{% endif %}
+
+<div class="info-section">
+    <h3>Details</h3>
+    <table class="info-table">
+        <tr><th>Created</th><td>{{ org.created_at.strftime('%Y-%m-%d %H:%M') if org.created_at else '—' }}</td></tr>
+        <tr><th>Custom Domain</th><td>{{ org.custom_domain or '—' }}</td></tr>
+        <tr><th>Platform</th><td>{{ 'Yes' if org.is_platform else 'No' }}</td></tr>
+    </table>
+</div>
+{% endif %}
+
+<style>
+    .settings-nav { display: flex; gap: 16px; margin-bottom: 24px; border-bottom: 1px solid #eee; padding-bottom: 8px; }
+    .settings-nav a { text-decoration: none; padding: 4px 8px; border-radius: 4px; }
+    .settings-nav a.active { background: #333; color: #fff; }
+    .page-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 24px; }
+    .org-nav { display: flex; gap: 8px; margin-bottom: 24px; flex-wrap: wrap; border-bottom: 1px solid #eee; padding-bottom: 8px; }
+    .org-nav a { text-decoration: none; padding: 4px 10px; border-radius: 4px; font-size: 0.9rem; color: #555; }
+    .org-nav a.active { background: #e8e8e8; color: #333; font-weight: 600; }
+    .error { color: #721c24; background: #f8d7da; padding: 12px; border-radius: 4px; margin-bottom: 16px; }
+    .success { color: #155724; background: #d4edda; padding: 12px; border-radius: 4px; margin-bottom: 16px; }
+    .stat-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-bottom: 24px; }
+    .stat-card { border: 1px solid #ddd; border-radius: 8px; padding: 16px; text-align: center; }
+    .stat-card .label { font-size: 0.85rem; color: #666; margin-bottom: 4px; }
+    .stat-card .value { font-size: 1.2rem; font-weight: 700; }
+    .status-ok { color: #155724; }
+    .status-warn { color: #856404; }
+    .role-badge { font-size: 0.85em; padding: 2px 8px; border-radius: 4px; }
+    .role-owner { background: #fff3cd; color: #856404; }
+    .role-admin { background: #d4edda; color: #155724; }
+    .role-member { background: #e2e3e5; color: #383d41; }
+    .org-form { max-width: 480px; margin-bottom: 32px; }
+    .form-group { margin-bottom: 16px; }
+    .form-group label { display: block; font-weight: 600; margin-bottom: 4px; }
+    .form-group input, .form-group select { width: 100%; padding: 8px; border: 1px solid #ccc; border-radius: 4px; font-size: 0.95rem; }
+    .form-actions { display: flex; gap: 12px; margin-top: 24px; }
+    .btn-primary { background: #333; color: #fff; padding: 8px 16px; border: none; border-radius: 4px; cursor: pointer; font-size: 0.9rem; }
+    .info-section { margin-top: 32px; }
+    .info-table { border-collapse: collapse; }
+    .info-table th, .info-table td { padding: 6px 12px; text-align: left; border-bottom: 1px solid #eee; }
+    .info-table th { color: #666; font-weight: 600; font-size: 0.9em; }
+</style>
+{% endblock %}

--- a/src/shomer/templates/settings/organisation_domains.html
+++ b/src/shomer/templates/settings/organisation_domains.html
@@ -1,0 +1,100 @@
+{% extends "base.html" %}
+{% block title %}Custom Domain — Shomer{% endblock %}
+{% block content %}
+<h1>Settings</h1>
+<nav class="settings-nav">
+    <a href="/ui/settings">Overview</a>
+    <a href="/ui/settings/profile">Profile</a>
+    <a href="/ui/settings/emails">Emails</a>
+    <a href="/ui/settings/security">Security</a>
+    <a href="/ui/settings/pats">Tokens</a>
+    <a href="/ui/settings/organisations" class="active">Organisations</a>
+</nav>
+
+{% if org %}
+<div class="page-header">
+    <h2>{{ org.display_name }} — Custom Domain</h2>
+    <a href="/ui/settings/organisations/{{ org.id }}">&larr; Back to organisation</a>
+</div>
+
+<div class="org-nav">
+    <a href="/ui/settings/organisations/{{ org.id }}">General</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/members">Members</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/roles">Roles</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/idps">Identity Providers</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/branding">Branding</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/trust">Trust Policies</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/domains" class="active">Domains</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/templates">Templates</a>
+</div>
+{% else %}
+<div class="page-header">
+    <h2>Custom Domain</h2>
+    <a href="/ui/settings/organisations">&larr; Back to list</a>
+</div>
+{% endif %}
+
+{% if error %}<p class="error">{{ error }}</p>{% endif %}
+{% if success %}<p class="success">{{ success }}</p>{% endif %}
+
+{% if org %}
+<div class="domain-info">
+    <h3>Current Domain</h3>
+    {% if custom_domain %}
+    <p>Your organisation is accessible at: <strong>{{ custom_domain }}</strong></p>
+    {% else %}
+    <p>No custom domain configured.</p>
+    {% endif %}
+</div>
+
+{% if role in ('owner', 'admin') %}
+<h3>{{ 'Update' if custom_domain else 'Set' }} Custom Domain</h3>
+<form method="post" action="/ui/settings/organisations/{{ org.id }}/domains" class="org-form">
+    <div class="form-group">
+        <label for="custom_domain">Domain</label>
+        <input type="text" id="custom_domain" name="custom_domain" value="{{ custom_domain or '' }}"
+               placeholder="auth.example.com">
+        <span class="hint">Enter a fully qualified domain name. Leave empty to remove.</span>
+    </div>
+
+    <div class="form-actions">
+        <button type="submit" class="btn-primary">Save Domain</button>
+    </div>
+</form>
+
+<div class="dns-instructions">
+    <h3>DNS Configuration</h3>
+    <p>To use a custom domain, add the following DNS record:</p>
+    <table class="info-table">
+        <tr><th>Type</th><td>CNAME</td></tr>
+        <tr><th>Name</th><td>{{ custom_domain or 'auth.example.com' }}</td></tr>
+        <tr><th>Value</th><td>{{ org.slug }}.shomer.app</td></tr>
+    </table>
+</div>
+{% endif %}
+{% endif %}
+
+<style>
+    .settings-nav { display: flex; gap: 16px; margin-bottom: 24px; border-bottom: 1px solid #eee; padding-bottom: 8px; }
+    .settings-nav a { text-decoration: none; padding: 4px 8px; border-radius: 4px; }
+    .settings-nav a.active { background: #333; color: #fff; }
+    .page-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 24px; }
+    .org-nav { display: flex; gap: 8px; margin-bottom: 24px; flex-wrap: wrap; border-bottom: 1px solid #eee; padding-bottom: 8px; }
+    .org-nav a { text-decoration: none; padding: 4px 10px; border-radius: 4px; font-size: 0.9rem; color: #555; }
+    .org-nav a.active { background: #e8e8e8; color: #333; font-weight: 600; }
+    .error { color: #721c24; background: #f8d7da; padding: 12px; border-radius: 4px; margin-bottom: 16px; }
+    .success { color: #155724; background: #d4edda; padding: 12px; border-radius: 4px; margin-bottom: 16px; }
+    .domain-info { margin-bottom: 24px; padding: 16px; background: #f8f9fa; border-radius: 8px; }
+    .org-form { max-width: 480px; margin-bottom: 32px; }
+    .form-group { margin-bottom: 16px; }
+    .form-group label { display: block; font-weight: 600; margin-bottom: 4px; }
+    .form-group input { width: 100%; padding: 8px; border: 1px solid #ccc; border-radius: 4px; font-size: 0.95rem; }
+    .form-group .hint { display: block; font-size: 0.8rem; color: #888; margin-top: 4px; }
+    .form-actions { display: flex; gap: 12px; margin-top: 24px; }
+    .btn-primary { background: #333; color: #fff; padding: 8px 16px; border: none; border-radius: 4px; cursor: pointer; font-size: 0.9rem; }
+    .dns-instructions { margin-top: 32px; padding: 16px; background: #e8f4fd; border-radius: 8px; }
+    .info-table { border-collapse: collapse; margin-top: 8px; }
+    .info-table th, .info-table td { padding: 6px 12px; text-align: left; border-bottom: 1px solid #cce5ff; }
+    .info-table th { color: #004085; font-weight: 600; font-size: 0.9em; }
+</style>
+{% endblock %}

--- a/src/shomer/templates/settings/organisation_form.html
+++ b/src/shomer/templates/settings/organisation_form.html
@@ -1,0 +1,74 @@
+{% extends "base.html" %}
+{% block title %}Create Organisation — Shomer{% endblock %}
+{% block content %}
+<h1>Settings</h1>
+<nav class="settings-nav">
+    <a href="/ui/settings">Overview</a>
+    <a href="/ui/settings/profile">Profile</a>
+    <a href="/ui/settings/emails">Emails</a>
+    <a href="/ui/settings/security">Security</a>
+    <a href="/ui/settings/pats">Tokens</a>
+    <a href="/ui/settings/organisations" class="active">Organisations</a>
+</nav>
+
+<div class="page-header">
+    <h2>Create Organisation</h2>
+    <a href="/ui/settings/organisations">&larr; Back to list</a>
+</div>
+
+{% if error %}<p class="error">{{ error }}</p>{% endif %}
+
+<form method="post" action="/ui/settings/organisations/new" class="org-form">
+    <div class="form-group">
+        <label for="slug">Slug</label>
+        <input type="text" id="slug" name="slug" value="{{ form_slug|default('', true) }}" required
+               pattern="[a-z0-9][a-z0-9-]{1,61}[a-z0-9]"
+               placeholder="my-organisation" autocomplete="off">
+        <span class="hint">3-63 lowercase letters, digits, and hyphens. Used in URLs.</span>
+    </div>
+
+    <div class="form-group">
+        <label for="name">Name</label>
+        <input type="text" id="name" name="name" value="{{ form_name|default('', true) }}" required
+               placeholder="My Organisation">
+    </div>
+
+    <div class="form-group">
+        <label for="display_name">Display Name</label>
+        <input type="text" id="display_name" name="display_name" value="{{ form_display_name|default('', true) }}"
+               placeholder="My Organisation Inc.">
+        <span class="hint">Optional. Shown in the UI. Defaults to the name.</span>
+    </div>
+
+    <div class="form-group">
+        <label for="trust_mode">Trust Mode</label>
+        <select id="trust_mode" name="trust_mode">
+            {% for mode in trust_modes %}
+            <option value="{{ mode }}" {% if form_trust_mode|default('none', true) == mode %}selected{% endif %}>{{ mode }}</option>
+            {% endfor %}
+        </select>
+        <span class="hint">Controls how external users can access this organisation.</span>
+    </div>
+
+    <div class="form-actions">
+        <button type="submit" class="btn-primary">Create Organisation</button>
+        <a href="/ui/settings/organisations" class="btn-secondary">Cancel</a>
+    </div>
+</form>
+
+<style>
+    .settings-nav { display: flex; gap: 16px; margin-bottom: 24px; border-bottom: 1px solid #eee; padding-bottom: 8px; }
+    .settings-nav a { text-decoration: none; padding: 4px 8px; border-radius: 4px; }
+    .settings-nav a.active { background: #333; color: #fff; }
+    .page-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 24px; }
+    .error { color: #721c24; background: #f8d7da; padding: 12px; border-radius: 4px; margin-bottom: 16px; }
+    .org-form { max-width: 480px; }
+    .form-group { margin-bottom: 16px; }
+    .form-group label { display: block; font-weight: 600; margin-bottom: 4px; }
+    .form-group input, .form-group select { width: 100%; padding: 8px; border: 1px solid #ccc; border-radius: 4px; font-size: 0.95rem; }
+    .form-group .hint { display: block; font-size: 0.8rem; color: #888; margin-top: 4px; }
+    .form-actions { display: flex; gap: 12px; margin-top: 24px; }
+    .btn-primary { background: #333; color: #fff; padding: 8px 16px; border: none; border-radius: 4px; cursor: pointer; font-size: 0.9rem; }
+    .btn-secondary { padding: 8px 16px; border: 1px solid #ccc; border-radius: 4px; text-decoration: none; color: #333; font-size: 0.9rem; }
+</style>
+{% endblock %}

--- a/src/shomer/templates/settings/organisation_idps.html
+++ b/src/shomer/templates/settings/organisation_idps.html
@@ -1,0 +1,145 @@
+{% extends "base.html" %}
+{% block title %}Identity Providers — Shomer{% endblock %}
+{% block content %}
+<h1>Settings</h1>
+<nav class="settings-nav">
+    <a href="/ui/settings">Overview</a>
+    <a href="/ui/settings/profile">Profile</a>
+    <a href="/ui/settings/emails">Emails</a>
+    <a href="/ui/settings/security">Security</a>
+    <a href="/ui/settings/pats">Tokens</a>
+    <a href="/ui/settings/organisations" class="active">Organisations</a>
+</nav>
+
+{% if org %}
+<div class="page-header">
+    <h2>{{ org.display_name }} — Identity Providers</h2>
+    <a href="/ui/settings/organisations/{{ org.id }}">&larr; Back to organisation</a>
+</div>
+
+<div class="org-nav">
+    <a href="/ui/settings/organisations/{{ org.id }}">General</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/members">Members</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/roles">Roles</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/idps" class="active">Identity Providers</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/branding">Branding</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/trust">Trust Policies</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/domains">Domains</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/templates">Templates</a>
+</div>
+{% else %}
+<div class="page-header">
+    <h2>Identity Providers</h2>
+    <a href="/ui/settings/organisations">&larr; Back to list</a>
+</div>
+{% endif %}
+
+{% if error %}<p class="error">{{ error }}</p>{% endif %}
+{% if success %}<p class="success">{{ success }}</p>{% endif %}
+
+{% if org %}
+{% if role in ('owner', 'admin') %}
+<div class="create-section">
+    <h3>Add Identity Provider</h3>
+    <form method="post" action="/ui/settings/organisations/{{ org.id }}/idps" class="idp-form">
+        <input type="hidden" name="action" value="create">
+        <div class="form-group">
+            <label for="idp_name">Name</label>
+            <input type="text" id="idp_name" name="idp_name" placeholder="e.g. Acme SSO" required>
+        </div>
+        <div class="form-group">
+            <label for="provider_type">Type</label>
+            <select id="provider_type" name="provider_type" required>
+                {% for t in provider_types %}
+                <option value="{{ t }}">{{ t }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div class="form-group">
+            <label for="client_id">Client ID</label>
+            <input type="text" id="client_id" name="client_id" placeholder="OAuth2 client ID" required>
+        </div>
+        <div class="form-group">
+            <label for="discovery_url">Discovery URL</label>
+            <input type="url" id="discovery_url" name="discovery_url" placeholder="https://.../.well-known/openid-configuration">
+        </div>
+        <button type="submit" class="btn-primary">Add Provider</button>
+    </form>
+</div>
+{% endif %}
+
+<h3>Configured Providers</h3>
+{% if idps %}
+<table class="idps-table">
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Client ID</th>
+            <th>Status</th>
+            {% if role in ('owner', 'admin') %}<th>Actions</th>{% endif %}
+        </tr>
+    </thead>
+    <tbody>
+    {% for idp in idps %}
+        <tr>
+            <td><strong>{{ idp.name }}</strong></td>
+            <td><code>{{ idp.provider_type }}</code></td>
+            <td><code>{{ idp.client_id }}</code></td>
+            <td>
+                {% if idp.is_active %}
+                    <span class="badge-active">Active</span>
+                {% else %}
+                    <span class="badge-inactive">Inactive</span>
+                {% endif %}
+            </td>
+            {% if role in ('owner', 'admin') %}
+            <td class="action-cell">
+                <form method="post" action="/ui/settings/organisations/{{ org.id }}/idps" style="display:inline">
+                    <input type="hidden" name="action" value="toggle">
+                    <input type="hidden" name="idp_id" value="{{ idp.id }}">
+                    <button type="submit" class="btn-sm">
+                        {% if idp.is_active %}Disable{% else %}Enable{% endif %}
+                    </button>
+                </form>
+                <form method="post" action="/ui/settings/organisations/{{ org.id }}/idps" style="display:inline">
+                    <input type="hidden" name="action" value="delete">
+                    <input type="hidden" name="idp_id" value="{{ idp.id }}">
+                    <button type="submit" class="remove-btn">Delete</button>
+                </form>
+            </td>
+            {% endif %}
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% else %}
+<p>No identity providers configured yet.</p>
+{% endif %}
+{% endif %}
+
+<style>
+    .settings-nav { display: flex; gap: 16px; margin-bottom: 24px; border-bottom: 1px solid #eee; padding-bottom: 8px; }
+    .settings-nav a { text-decoration: none; padding: 4px 8px; border-radius: 4px; }
+    .settings-nav a.active { background: #333; color: #fff; }
+    .page-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 24px; }
+    .org-nav { display: flex; gap: 8px; margin-bottom: 24px; flex-wrap: wrap; border-bottom: 1px solid #eee; padding-bottom: 8px; }
+    .org-nav a { text-decoration: none; padding: 4px 10px; border-radius: 4px; font-size: 0.9rem; color: #555; }
+    .org-nav a.active { background: #e8e8e8; color: #333; font-weight: 600; }
+    .error { color: #721c24; background: #f8d7da; padding: 12px; border-radius: 4px; margin-bottom: 16px; }
+    .success { color: #155724; background: #d4edda; padding: 12px; border-radius: 4px; margin-bottom: 16px; }
+    .create-section { margin-bottom: 24px; padding: 16px; background: #f8f9fa; border-radius: 8px; }
+    .idp-form .form-group { margin-bottom: 12px; }
+    .idp-form label { display: block; font-weight: 600; font-size: 0.85em; margin-bottom: 4px; color: #555; }
+    .idp-form input, .idp-form select { padding: 6px 8px; border: 1px solid #ccc; border-radius: 4px; width: 100%; max-width: 400px; box-sizing: border-box; }
+    .btn-primary { background: #333; color: #fff; padding: 6px 16px; border: none; border-radius: 4px; cursor: pointer; }
+    .idps-table { width: 100%; border-collapse: collapse; font-size: 0.9em; }
+    .idps-table th, .idps-table td { padding: 10px 8px; text-align: left; border-bottom: 1px solid #eee; }
+    .idps-table th { font-weight: 600; color: #666; font-size: 0.85em; text-transform: uppercase; }
+    .badge-active { background: #d4edda; color: #155724; padding: 2px 8px; border-radius: 3px; font-size: 0.85em; }
+    .badge-inactive { background: #f8d7da; color: #721c24; padding: 2px 8px; border-radius: 3px; font-size: 0.85em; }
+    .btn-sm { background: #333; color: #fff; padding: 4px 10px; border: none; border-radius: 3px; cursor: pointer; font-size: 0.85em; }
+    .action-cell { white-space: nowrap; }
+    .remove-btn { background: #dc3545; color: #fff; border: none; padding: 4px 10px; border-radius: 3px; cursor: pointer; font-size: 0.85em; margin-left: 4px; }
+</style>
+{% endblock %}

--- a/src/shomer/templates/settings/organisation_members.html
+++ b/src/shomer/templates/settings/organisation_members.html
@@ -1,0 +1,135 @@
+{% extends "base.html" %}
+{% block title %}Members — Shomer{% endblock %}
+{% block content %}
+<h1>Settings</h1>
+<nav class="settings-nav">
+    <a href="/ui/settings">Overview</a>
+    <a href="/ui/settings/profile">Profile</a>
+    <a href="/ui/settings/emails">Emails</a>
+    <a href="/ui/settings/security">Security</a>
+    <a href="/ui/settings/pats">Tokens</a>
+    <a href="/ui/settings/organisations" class="active">Organisations</a>
+</nav>
+
+{% if org %}
+<div class="page-header">
+    <h2>{{ org.display_name }} — Members</h2>
+    <a href="/ui/settings/organisations/{{ org.id }}">&larr; Back to organisation</a>
+</div>
+
+<div class="org-nav">
+    <a href="/ui/settings/organisations/{{ org.id }}">General</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/members" class="active">Members</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/roles">Roles</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/idps">Identity Providers</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/branding">Branding</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/trust">Trust Policies</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/domains">Domains</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/templates">Templates</a>
+</div>
+{% else %}
+<div class="page-header">
+    <h2>Members</h2>
+    <a href="/ui/settings/organisations">&larr; Back to list</a>
+</div>
+{% endif %}
+
+{% if error %}<p class="error">{{ error }}</p>{% endif %}
+{% if success %}<p class="success">{{ success }}</p>{% endif %}
+
+{% if org %}
+{% if role in ('owner', 'admin') %}
+<div class="add-section">
+    <h3>Add Member</h3>
+    <form method="post" action="/ui/settings/organisations/{{ org.id }}/members" class="inline-form">
+        <input type="hidden" name="action" value="add">
+        <input type="email" name="email" placeholder="user@example.com" required>
+        <select name="member_role">
+            {% for r in roles %}
+            <option value="{{ r }}">{{ r }}</option>
+            {% endfor %}
+        </select>
+        <button type="submit" class="btn-primary">Add</button>
+    </form>
+</div>
+{% endif %}
+
+<h3>Current Members</h3>
+{% if members %}
+<table class="members-table">
+    <thead>
+        <tr>
+            <th>User</th>
+            <th>Role</th>
+            <th>Joined</th>
+            {% if role in ('owner', 'admin') %}<th>Actions</th>{% endif %}
+        </tr>
+    </thead>
+    <tbody>
+    {% for m in members %}
+        <tr>
+            <td>{{ m.username }}</td>
+            <td>
+                {% if role in ('owner', 'admin') and m.user_id != user.id|string %}
+                <form method="post" action="/ui/settings/organisations/{{ org.id }}/members" class="inline-form">
+                    <input type="hidden" name="action" value="update_role">
+                    <input type="hidden" name="member_id" value="{{ m.id }}">
+                    <select name="member_role" onchange="this.form.submit()">
+                        {% for r in roles %}
+                        <option value="{{ r }}" {% if m.role == r %}selected{% endif %}>{{ r }}</option>
+                        {% endfor %}
+                    </select>
+                </form>
+                {% else %}
+                <span class="role-badge role-{{ m.role }}">{{ m.role }}</span>
+                {% endif %}
+            </td>
+            <td>{{ m.joined_at.strftime('%Y-%m-%d') if m.joined_at else '—' }}</td>
+            {% if role in ('owner', 'admin') %}
+            <td>
+                {% if m.user_id != user.id|string %}
+                <form method="post" action="/ui/settings/organisations/{{ org.id }}/members" style="display:inline">
+                    <input type="hidden" name="action" value="remove">
+                    <input type="hidden" name="member_id" value="{{ m.id }}">
+                    <button type="submit" class="remove-btn">Remove</button>
+                </form>
+                {% else %}
+                <span class="hint">You</span>
+                {% endif %}
+            </td>
+            {% endif %}
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% else %}
+<p>No members yet.</p>
+{% endif %}
+{% endif %}
+
+<style>
+    .settings-nav { display: flex; gap: 16px; margin-bottom: 24px; border-bottom: 1px solid #eee; padding-bottom: 8px; }
+    .settings-nav a { text-decoration: none; padding: 4px 8px; border-radius: 4px; }
+    .settings-nav a.active { background: #333; color: #fff; }
+    .page-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 24px; }
+    .org-nav { display: flex; gap: 8px; margin-bottom: 24px; flex-wrap: wrap; border-bottom: 1px solid #eee; padding-bottom: 8px; }
+    .org-nav a { text-decoration: none; padding: 4px 10px; border-radius: 4px; font-size: 0.9rem; color: #555; }
+    .org-nav a.active { background: #e8e8e8; color: #333; font-weight: 600; }
+    .error { color: #721c24; background: #f8d7da; padding: 12px; border-radius: 4px; margin-bottom: 16px; }
+    .success { color: #155724; background: #d4edda; padding: 12px; border-radius: 4px; margin-bottom: 16px; }
+    .add-section { margin-bottom: 24px; padding: 16px; background: #f8f9fa; border-radius: 8px; }
+    .inline-form { display: flex; gap: 8px; align-items: center; }
+    .inline-form input[type="email"] { padding: 6px 8px; border: 1px solid #ccc; border-radius: 4px; flex: 1; }
+    .inline-form select { padding: 6px 8px; border: 1px solid #ccc; border-radius: 4px; }
+    .btn-primary { background: #333; color: #fff; padding: 6px 16px; border: none; border-radius: 4px; cursor: pointer; }
+    .members-table { width: 100%; border-collapse: collapse; font-size: 0.9em; }
+    .members-table th, .members-table td { padding: 10px 8px; text-align: left; border-bottom: 1px solid #eee; }
+    .members-table th { font-weight: 600; color: #666; font-size: 0.85em; text-transform: uppercase; }
+    .role-badge { font-size: 0.85em; padding: 2px 8px; border-radius: 4px; }
+    .role-owner { background: #fff3cd; color: #856404; }
+    .role-admin { background: #d4edda; color: #155724; }
+    .role-member { background: #e2e3e5; color: #383d41; }
+    .remove-btn { background: #dc3545; color: #fff; border: none; padding: 4px 10px; border-radius: 4px; cursor: pointer; font-size: 0.85em; }
+    .hint { font-size: 0.8rem; color: #888; }
+</style>
+{% endblock %}

--- a/src/shomer/templates/settings/organisation_roles.html
+++ b/src/shomer/templates/settings/organisation_roles.html
@@ -1,0 +1,126 @@
+{% extends "base.html" %}
+{% block title %}Roles — Shomer{% endblock %}
+{% block content %}
+<h1>Settings</h1>
+<nav class="settings-nav">
+    <a href="/ui/settings">Overview</a>
+    <a href="/ui/settings/profile">Profile</a>
+    <a href="/ui/settings/emails">Emails</a>
+    <a href="/ui/settings/security">Security</a>
+    <a href="/ui/settings/pats">Tokens</a>
+    <a href="/ui/settings/organisations" class="active">Organisations</a>
+</nav>
+
+{% if org %}
+<div class="page-header">
+    <h2>{{ org.display_name }} — Roles</h2>
+    <a href="/ui/settings/organisations/{{ org.id }}">&larr; Back to organisation</a>
+</div>
+
+<div class="org-nav">
+    <a href="/ui/settings/organisations/{{ org.id }}">General</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/members">Members</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/roles" class="active">Roles</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/idps">Identity Providers</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/branding">Branding</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/trust">Trust Policies</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/domains">Domains</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/templates">Templates</a>
+</div>
+{% else %}
+<div class="page-header">
+    <h2>Roles</h2>
+    <a href="/ui/settings/organisations">&larr; Back to list</a>
+</div>
+{% endif %}
+
+{% if error %}<p class="error">{{ error }}</p>{% endif %}
+{% if success %}<p class="success">{{ success }}</p>{% endif %}
+
+{% if org %}
+{% if role in ('owner', 'admin') %}
+<div class="create-section">
+    <h3>Create Role</h3>
+    <form method="post" action="/ui/settings/organisations/{{ org.id }}/roles" class="role-form">
+        <input type="hidden" name="action" value="create">
+        <div class="form-row">
+            <input type="text" name="role_name" placeholder="Role name" required>
+            <input type="text" name="permissions" placeholder="Permissions (space-separated)">
+            <button type="submit" class="btn-primary">Create</button>
+        </div>
+    </form>
+</div>
+{% endif %}
+
+<h3>Custom Roles</h3>
+{% if roles %}
+<table class="roles-table">
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Permissions</th>
+            {% if role in ('owner', 'admin') %}<th>Actions</th>{% endif %}
+        </tr>
+    </thead>
+    <tbody>
+    {% for r in roles %}
+        <tr>
+            <td><strong>{{ r.name }}</strong></td>
+            <td>
+                {% if r.permissions %}
+                    {% for p in r.permissions %}<code class="perm-badge">{{ p }}</code> {% endfor %}
+                {% else %}
+                    <span class="hint">No permissions</span>
+                {% endif %}
+            </td>
+            {% if role in ('owner', 'admin') %}
+            <td class="action-cell">
+                <form method="post" action="/ui/settings/organisations/{{ org.id }}/roles" class="inline-form">
+                    <input type="hidden" name="action" value="update">
+                    <input type="hidden" name="role_id" value="{{ r.id }}">
+                    <input type="text" name="role_name" value="{{ r.name }}" size="12">
+                    <input type="text" name="permissions" value="{{ r.permissions|join(' ') }}" size="20">
+                    <button type="submit" class="btn-sm">Save</button>
+                </form>
+                <form method="post" action="/ui/settings/organisations/{{ org.id }}/roles" style="display:inline">
+                    <input type="hidden" name="action" value="delete">
+                    <input type="hidden" name="role_id" value="{{ r.id }}">
+                    <button type="submit" class="remove-btn">Delete</button>
+                </form>
+            </td>
+            {% endif %}
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% else %}
+<p>No custom roles defined yet.</p>
+{% endif %}
+{% endif %}
+
+<style>
+    .settings-nav { display: flex; gap: 16px; margin-bottom: 24px; border-bottom: 1px solid #eee; padding-bottom: 8px; }
+    .settings-nav a { text-decoration: none; padding: 4px 8px; border-radius: 4px; }
+    .settings-nav a.active { background: #333; color: #fff; }
+    .page-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 24px; }
+    .org-nav { display: flex; gap: 8px; margin-bottom: 24px; flex-wrap: wrap; border-bottom: 1px solid #eee; padding-bottom: 8px; }
+    .org-nav a { text-decoration: none; padding: 4px 10px; border-radius: 4px; font-size: 0.9rem; color: #555; }
+    .org-nav a.active { background: #e8e8e8; color: #333; font-weight: 600; }
+    .error { color: #721c24; background: #f8d7da; padding: 12px; border-radius: 4px; margin-bottom: 16px; }
+    .success { color: #155724; background: #d4edda; padding: 12px; border-radius: 4px; margin-bottom: 16px; }
+    .create-section { margin-bottom: 24px; padding: 16px; background: #f8f9fa; border-radius: 8px; }
+    .form-row { display: flex; gap: 8px; align-items: center; }
+    .form-row input { padding: 6px 8px; border: 1px solid #ccc; border-radius: 4px; }
+    .btn-primary { background: #333; color: #fff; padding: 6px 16px; border: none; border-radius: 4px; cursor: pointer; }
+    .roles-table { width: 100%; border-collapse: collapse; font-size: 0.9em; }
+    .roles-table th, .roles-table td { padding: 10px 8px; text-align: left; border-bottom: 1px solid #eee; }
+    .roles-table th { font-weight: 600; color: #666; font-size: 0.85em; text-transform: uppercase; }
+    .perm-badge { background: #e2e3e5; padding: 1px 6px; border-radius: 3px; font-size: 0.85em; }
+    .inline-form { display: inline-flex; gap: 4px; align-items: center; }
+    .inline-form input { padding: 4px 6px; border: 1px solid #ccc; border-radius: 3px; font-size: 0.85em; }
+    .btn-sm { background: #333; color: #fff; padding: 4px 10px; border: none; border-radius: 3px; cursor: pointer; font-size: 0.85em; }
+    .action-cell { white-space: nowrap; }
+    .remove-btn { background: #dc3545; color: #fff; border: none; padding: 4px 10px; border-radius: 3px; cursor: pointer; font-size: 0.85em; margin-left: 4px; }
+    .hint { font-size: 0.8rem; color: #888; }
+</style>
+{% endblock %}

--- a/src/shomer/templates/settings/organisation_templates.html
+++ b/src/shomer/templates/settings/organisation_templates.html
@@ -1,0 +1,136 @@
+{% extends "base.html" %}
+{% block title %}Email Templates — Shomer{% endblock %}
+{% block content %}
+<h1>Settings</h1>
+<nav class="settings-nav">
+    <a href="/ui/settings">Overview</a>
+    <a href="/ui/settings/profile">Profile</a>
+    <a href="/ui/settings/emails">Emails</a>
+    <a href="/ui/settings/security">Security</a>
+    <a href="/ui/settings/pats">Tokens</a>
+    <a href="/ui/settings/organisations" class="active">Organisations</a>
+</nav>
+
+{% if org %}
+<div class="page-header">
+    <h2>{{ org.display_name }} — Email Templates</h2>
+    <a href="/ui/settings/organisations/{{ org.id }}">&larr; Back to organisation</a>
+</div>
+
+<div class="org-nav">
+    <a href="/ui/settings/organisations/{{ org.id }}">General</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/members">Members</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/roles">Roles</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/idps">Identity Providers</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/branding">Branding</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/trust">Trust Policies</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/domains">Domains</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/templates" class="active">Templates</a>
+</div>
+{% else %}
+<div class="page-header">
+    <h2>Email Templates</h2>
+    <a href="/ui/settings/organisations">&larr; Back to list</a>
+</div>
+{% endif %}
+
+{% if error %}<p class="error">{{ error }}</p>{% endif %}
+{% if success %}<p class="success">{{ success }}</p>{% endif %}
+
+{% if org %}
+{% if role in ('owner', 'admin') %}
+<div class="create-section">
+    <h3>Create Template Override</h3>
+    <form method="post" action="/ui/settings/organisations/{{ org.id }}/templates" class="template-form">
+        <input type="hidden" name="action" value="create">
+        <div class="form-group">
+            <label for="template_name">Template Name</label>
+            <input type="text" id="template_name" name="template_name" placeholder="e.g. emails/mjml/password_reset.mjml" required>
+        </div>
+        <div class="form-group">
+            <label for="description">Description</label>
+            <input type="text" id="description" name="description" placeholder="Optional description">
+        </div>
+        <div class="form-group">
+            <label for="content">Content</label>
+            <textarea id="content" name="content" rows="8" placeholder="Jinja2 template content..." required></textarea>
+        </div>
+        <button type="submit" class="btn-primary">Create Template</button>
+    </form>
+</div>
+{% endif %}
+
+<h3>Template Overrides</h3>
+{% if templates %}
+<table class="templates-table">
+    <thead>
+        <tr>
+            <th>Template</th>
+            <th>Description</th>
+            <th>Status</th>
+            {% if role in ('owner', 'admin') %}<th>Actions</th>{% endif %}
+        </tr>
+    </thead>
+    <tbody>
+    {% for t in templates %}
+        <tr>
+            <td><code>{{ t.template_name }}</code></td>
+            <td>{{ t.description }}</td>
+            <td>
+                {% if t.is_active %}
+                    <span class="badge-active">Active</span>
+                {% else %}
+                    <span class="badge-inactive">Inactive</span>
+                {% endif %}
+            </td>
+            {% if role in ('owner', 'admin') %}
+            <td class="action-cell">
+                <form method="post" action="/ui/settings/organisations/{{ org.id }}/templates" style="display:inline">
+                    <input type="hidden" name="action" value="toggle">
+                    <input type="hidden" name="template_id" value="{{ t.id }}">
+                    <button type="submit" class="btn-sm">
+                        {% if t.is_active %}Disable{% else %}Enable{% endif %}
+                    </button>
+                </form>
+                <form method="post" action="/ui/settings/organisations/{{ org.id }}/templates" style="display:inline">
+                    <input type="hidden" name="action" value="delete">
+                    <input type="hidden" name="template_id" value="{{ t.id }}">
+                    <button type="submit" class="remove-btn">Delete</button>
+                </form>
+            </td>
+            {% endif %}
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% else %}
+<p>No custom template overrides configured.</p>
+{% endif %}
+{% endif %}
+
+<style>
+    .settings-nav { display: flex; gap: 16px; margin-bottom: 24px; border-bottom: 1px solid #eee; padding-bottom: 8px; }
+    .settings-nav a { text-decoration: none; padding: 4px 8px; border-radius: 4px; }
+    .settings-nav a.active { background: #333; color: #fff; }
+    .page-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 24px; }
+    .org-nav { display: flex; gap: 8px; margin-bottom: 24px; flex-wrap: wrap; border-bottom: 1px solid #eee; padding-bottom: 8px; }
+    .org-nav a { text-decoration: none; padding: 4px 10px; border-radius: 4px; font-size: 0.9rem; color: #555; }
+    .org-nav a.active { background: #e8e8e8; color: #333; font-weight: 600; }
+    .error { color: #721c24; background: #f8d7da; padding: 12px; border-radius: 4px; margin-bottom: 16px; }
+    .success { color: #155724; background: #d4edda; padding: 12px; border-radius: 4px; margin-bottom: 16px; }
+    .create-section { margin-bottom: 24px; padding: 16px; background: #f8f9fa; border-radius: 8px; }
+    .template-form .form-group { margin-bottom: 12px; }
+    .template-form label { display: block; font-weight: 600; font-size: 0.85em; margin-bottom: 4px; color: #555; }
+    .template-form input, .template-form textarea { padding: 6px 8px; border: 1px solid #ccc; border-radius: 4px; width: 100%; max-width: 500px; box-sizing: border-box; }
+    .template-form textarea { font-family: monospace; font-size: 0.85em; }
+    .btn-primary { background: #333; color: #fff; padding: 6px 16px; border: none; border-radius: 4px; cursor: pointer; }
+    .templates-table { width: 100%; border-collapse: collapse; font-size: 0.9em; }
+    .templates-table th, .templates-table td { padding: 10px 8px; text-align: left; border-bottom: 1px solid #eee; }
+    .templates-table th { font-weight: 600; color: #666; font-size: 0.85em; text-transform: uppercase; }
+    .badge-active { background: #d4edda; color: #155724; padding: 2px 8px; border-radius: 3px; font-size: 0.85em; }
+    .badge-inactive { background: #f8d7da; color: #721c24; padding: 2px 8px; border-radius: 3px; font-size: 0.85em; }
+    .btn-sm { background: #333; color: #fff; padding: 4px 10px; border: none; border-radius: 3px; cursor: pointer; font-size: 0.85em; }
+    .action-cell { white-space: nowrap; }
+    .remove-btn { background: #dc3545; color: #fff; border: none; padding: 4px 10px; border-radius: 3px; cursor: pointer; font-size: 0.85em; margin-left: 4px; }
+</style>
+{% endblock %}

--- a/src/shomer/templates/settings/organisation_trust.html
+++ b/src/shomer/templates/settings/organisation_trust.html
@@ -1,0 +1,124 @@
+{% extends "base.html" %}
+{% block title %}Trust Policies — Shomer{% endblock %}
+{% block content %}
+<h1>Settings</h1>
+<nav class="settings-nav">
+    <a href="/ui/settings">Overview</a>
+    <a href="/ui/settings/profile">Profile</a>
+    <a href="/ui/settings/emails">Emails</a>
+    <a href="/ui/settings/security">Security</a>
+    <a href="/ui/settings/pats">Tokens</a>
+    <a href="/ui/settings/organisations" class="active">Organisations</a>
+</nav>
+
+{% if org %}
+<div class="page-header">
+    <h2>{{ org.display_name }} — Trust Policies</h2>
+    <a href="/ui/settings/organisations/{{ org.id }}">&larr; Back to organisation</a>
+</div>
+
+<div class="org-nav">
+    <a href="/ui/settings/organisations/{{ org.id }}">General</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/members">Members</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/roles">Roles</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/idps">Identity Providers</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/branding">Branding</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/trust" class="active">Trust Policies</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/domains">Domains</a>
+    <a href="/ui/settings/organisations/{{ org.id }}/templates">Templates</a>
+</div>
+{% else %}
+<div class="page-header">
+    <h2>Trust Policies</h2>
+    <a href="/ui/settings/organisations">&larr; Back to list</a>
+</div>
+{% endif %}
+
+{% if error %}<p class="error">{{ error }}</p>{% endif %}
+{% if success %}<p class="success">{{ success }}</p>{% endif %}
+
+{% if org %}
+{% if role in ('owner', 'admin') %}
+<div class="section">
+    <h3>Trust Mode</h3>
+    <form method="post" action="/ui/settings/organisations/{{ org.id }}/trust" class="inline-form">
+        <input type="hidden" name="action" value="update_mode">
+        <select name="trust_mode">
+            {% for mode in trust_modes %}
+            <option value="{{ mode }}" {% if mode == trust_mode %}selected{% endif %}>{{ mode }}</option>
+            {% endfor %}
+        </select>
+        <button type="submit" class="btn-primary">Update</button>
+    </form>
+    <p class="hint">Current mode: <strong>{{ trust_mode }}</strong></p>
+</div>
+
+<div class="section">
+    <h3>Add Trusted Source</h3>
+    <form method="post" action="/ui/settings/organisations/{{ org.id }}/trust" class="source-form">
+        <input type="hidden" name="action" value="add_source">
+        <div class="form-row">
+            <input type="text" name="trusted_slug" placeholder="Organisation slug" required>
+            <input type="text" name="description" placeholder="Description (optional)">
+            <button type="submit" class="btn-primary">Add</button>
+        </div>
+    </form>
+</div>
+{% endif %}
+
+<h3>Trusted Sources</h3>
+{% if sources %}
+<table class="sources-table">
+    <thead>
+        <tr>
+            <th>Organisation</th>
+            <th>Description</th>
+            {% if role in ('owner', 'admin') %}<th>Actions</th>{% endif %}
+        </tr>
+    </thead>
+    <tbody>
+    {% for s in sources %}
+        <tr>
+            <td><strong>{{ s.trusted_tenant_name }}</strong> <code>{{ s.trusted_tenant_slug }}</code></td>
+            <td>{{ s.description }}</td>
+            {% if role in ('owner', 'admin') %}
+            <td>
+                <form method="post" action="/ui/settings/organisations/{{ org.id }}/trust" style="display:inline">
+                    <input type="hidden" name="action" value="remove_source">
+                    <input type="hidden" name="source_id" value="{{ s.id }}">
+                    <button type="submit" class="remove-btn">Remove</button>
+                </form>
+            </td>
+            {% endif %}
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% else %}
+<p>No trusted sources configured.</p>
+{% endif %}
+{% endif %}
+
+<style>
+    .settings-nav { display: flex; gap: 16px; margin-bottom: 24px; border-bottom: 1px solid #eee; padding-bottom: 8px; }
+    .settings-nav a { text-decoration: none; padding: 4px 8px; border-radius: 4px; }
+    .settings-nav a.active { background: #333; color: #fff; }
+    .page-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 24px; }
+    .org-nav { display: flex; gap: 8px; margin-bottom: 24px; flex-wrap: wrap; border-bottom: 1px solid #eee; padding-bottom: 8px; }
+    .org-nav a { text-decoration: none; padding: 4px 10px; border-radius: 4px; font-size: 0.9rem; color: #555; }
+    .org-nav a.active { background: #e8e8e8; color: #333; font-weight: 600; }
+    .error { color: #721c24; background: #f8d7da; padding: 12px; border-radius: 4px; margin-bottom: 16px; }
+    .success { color: #155724; background: #d4edda; padding: 12px; border-radius: 4px; margin-bottom: 16px; }
+    .section { margin-bottom: 24px; padding: 16px; background: #f8f9fa; border-radius: 8px; }
+    .inline-form { display: flex; gap: 8px; align-items: center; margin-bottom: 8px; }
+    .inline-form select { padding: 6px 8px; border: 1px solid #ccc; border-radius: 4px; }
+    .source-form .form-row { display: flex; gap: 8px; align-items: center; }
+    .source-form input { padding: 6px 8px; border: 1px solid #ccc; border-radius: 4px; }
+    .btn-primary { background: #333; color: #fff; padding: 6px 16px; border: none; border-radius: 4px; cursor: pointer; }
+    .sources-table { width: 100%; border-collapse: collapse; font-size: 0.9em; }
+    .sources-table th, .sources-table td { padding: 10px 8px; text-align: left; border-bottom: 1px solid #eee; }
+    .sources-table th { font-weight: 600; color: #666; font-size: 0.85em; text-transform: uppercase; }
+    .remove-btn { background: #dc3545; color: #fff; border: none; padding: 4px 10px; border-radius: 3px; cursor: pointer; font-size: 0.85em; }
+    .hint { font-size: 0.85rem; color: #888; margin-top: 4px; }
+</style>
+{% endblock %}

--- a/src/shomer/templates/settings/organisations.html
+++ b/src/shomer/templates/settings/organisations.html
@@ -1,0 +1,79 @@
+{% extends "base.html" %}
+{% block title %}Organisations — Shomer{% endblock %}
+{% block content %}
+<h1>Settings</h1>
+<nav class="settings-nav">
+    <a href="/ui/settings">Overview</a>
+    <a href="/ui/settings/profile">Profile</a>
+    <a href="/ui/settings/emails">Emails</a>
+    <a href="/ui/settings/security">Security</a>
+    <a href="/ui/settings/pats">Tokens</a>
+    <a href="/ui/settings/organisations" class="active">Organisations</a>
+</nav>
+
+<div class="page-header">
+    <h2>Organisations</h2>
+    <a href="/ui/settings/organisations/new" class="btn-primary">Create Organisation</a>
+</div>
+
+{% if organisations %}
+<table class="org-table">
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Slug</th>
+            <th>Role</th>
+            <th>Status</th>
+            <th>Joined</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+    {% for org in organisations %}
+        <tr>
+            <td>
+                <strong>{{ org.display_name or org.name }}</strong>
+                {% if org.is_platform %}<span class="platform-badge">Platform</span>{% endif %}
+            </td>
+            <td><code>{{ org.slug }}</code></td>
+            <td><span class="role-badge role-{{ org.role }}">{{ org.role }}</span></td>
+            <td>
+                {% if org.is_active %}
+                    <span class="active-badge">Active</span>
+                {% else %}
+                    <span class="inactive-badge">Inactive</span>
+                {% endif %}
+            </td>
+            <td>{{ org.joined_at.strftime('%Y-%m-%d') if org.joined_at else '—' }}</td>
+            <td><a href="/ui/settings/organisations/{{ org.id }}">Manage</a></td>
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% else %}
+<div class="empty-state">
+    <p>You are not a member of any organisation yet.</p>
+    <a href="/ui/settings/organisations/new" class="btn-primary">Create your first organisation</a>
+</div>
+{% endif %}
+
+<style>
+    .settings-nav { display: flex; gap: 16px; margin-bottom: 24px; border-bottom: 1px solid #eee; padding-bottom: 8px; }
+    .settings-nav a { text-decoration: none; padding: 4px 8px; border-radius: 4px; }
+    .settings-nav a.active { background: #333; color: #fff; }
+    .page-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 24px; }
+    .btn-primary { background: #333; color: #fff; padding: 8px 16px; border-radius: 4px; text-decoration: none; font-size: 0.9rem; }
+    .org-table { width: 100%; border-collapse: collapse; font-size: 0.9em; }
+    .org-table th, .org-table td { padding: 10px 8px; text-align: left; border-bottom: 1px solid #eee; }
+    .org-table th { font-weight: 600; color: #666; font-size: 0.85em; text-transform: uppercase; }
+    .role-badge { font-size: 0.85em; padding: 2px 8px; border-radius: 4px; }
+    .role-owner { background: #fff3cd; color: #856404; }
+    .role-admin { background: #d4edda; color: #155724; }
+    .role-member { background: #e2e3e5; color: #383d41; }
+    .platform-badge { font-size: 0.75em; background: #cce5ff; color: #004085; padding: 1px 6px; border-radius: 3px; margin-left: 6px; }
+    .active-badge { color: #155724; font-size: 0.85em; }
+    .inactive-badge { color: #721c24; font-size: 0.85em; }
+    .empty-state { text-align: center; padding: 48px 16px; color: #666; }
+    .empty-state .btn-primary { display: inline-block; margin-top: 16px; }
+</style>
+{% endblock %}

--- a/tests/routes/test_organisation_settings_ui_unit.py
+++ b/tests/routes/test_organisation_settings_ui_unit.py
@@ -21,6 +21,8 @@ from shomer.routes.organisation_settings_ui import (
     settings_organisation_domains,
     settings_organisation_domains_update,
     settings_organisation_edit,
+    settings_organisation_members,
+    settings_organisation_members_action,
     settings_organisation_new,
     settings_organisations,
 )
@@ -990,5 +992,332 @@ class TestSettingsOrganisationEdit:
 
             ctx = mock_render.call_args[0][2]
             assert "Invalid trust mode" in ctx["error"]
+
+        asyncio.run(_run())
+
+
+class TestSettingsOrganisationMembers:
+    """Tests for GET /ui/settings/organisations/{org_id}/members."""
+
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_unauthenticated_redirects(self, mock_auth: AsyncMock) -> None:
+        """Redirect to login when not authenticated."""
+
+        async def _run() -> None:
+            mock_auth.return_value = None
+            resp = await settings_organisation_members(
+                _req(), str(uuid.uuid4()), AsyncMock()
+            )
+            assert resp.status_code == 302
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._list_members")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_renders_members_page(
+        self,
+        mock_auth: AsyncMock,
+        mock_mem: AsyncMock,
+        mock_list: AsyncMock,
+        mock_render: MagicMock,
+    ) -> None:
+        """Render members page for a member."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_list.return_value = [
+                {"user_id": str(user.id), "username": "alice", "role": "owner"}
+            ]
+            mock_render.return_value = MagicMock()
+
+            await settings_organisation_members(
+                _req({"session_id": "tok"}), str(tenant.id), AsyncMock()
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert len(ctx["members"]) == 1
+            assert ctx["error"] is None
+
+        asyncio.run(_run())
+
+
+class TestSettingsOrganisationMembersAction:
+    """Tests for POST /ui/settings/organisations/{org_id}/members."""
+
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_unauthenticated_redirects(self, mock_auth: AsyncMock) -> None:
+        """Redirect to login when not authenticated."""
+
+        async def _run() -> None:
+            mock_auth.return_value = None
+            resp = await settings_organisation_members_action(
+                _req(), str(uuid.uuid4()), AsyncMock(), action="add"
+            )
+            assert resp.status_code == 302
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._list_members")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_member_cannot_manage(
+        self,
+        mock_auth: AsyncMock,
+        mock_mem: AsyncMock,
+        mock_list: AsyncMock,
+        mock_render: MagicMock,
+    ) -> None:
+        """Show error when regular member tries to manage."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="member", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_list.return_value = []
+            mock_render.return_value = MagicMock()
+
+            await settings_organisation_members_action(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                AsyncMock(),
+                action="add",
+                email="new@example.com",
+                member_role="member",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "permission" in ctx["error"]
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._list_members")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_add_member_success(
+        self,
+        mock_auth: AsyncMock,
+        mock_mem: AsyncMock,
+        mock_list: AsyncMock,
+        mock_render: MagicMock,
+    ) -> None:
+        """Owner can add a member by email."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_list.return_value = []
+            mock_render.return_value = MagicMock()
+
+            db = AsyncMock()
+            # First call: find user by email
+            user_email_result = MagicMock()
+            user_email_mock = MagicMock(user_id=uuid.uuid4())
+            user_email_result.scalar_one_or_none.return_value = user_email_mock
+            # Second call: check existing membership
+            existing_result = MagicMock()
+            existing_result.scalar_one_or_none.return_value = None
+            db.execute.side_effect = [user_email_result, existing_result]
+
+            await settings_organisation_members_action(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                action="add",
+                email="new@example.com",
+                member_role="member",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "added" in ctx["success"]
+            db.add.assert_called_once()
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._list_members")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_add_member_not_found(
+        self,
+        mock_auth: AsyncMock,
+        mock_mem: AsyncMock,
+        mock_list: AsyncMock,
+        mock_render: MagicMock,
+    ) -> None:
+        """Show error when email not found."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_list.return_value = []
+            mock_render.return_value = MagicMock()
+
+            db = AsyncMock()
+            result_mock = MagicMock()
+            result_mock.scalar_one_or_none.return_value = None
+            db.execute.return_value = result_mock
+
+            await settings_organisation_members_action(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                action="add",
+                email="nobody@example.com",
+                member_role="member",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "No user found" in ctx["error"]
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._list_members")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_remove_member_success(
+        self,
+        mock_auth: AsyncMock,
+        mock_mem: AsyncMock,
+        mock_list: AsyncMock,
+        mock_render: MagicMock,
+    ) -> None:
+        """Owner can remove a member."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_list.return_value = []
+            mock_render.return_value = MagicMock()
+
+            other_member = MagicMock()
+            other_member.user_id = uuid.uuid4()  # different from user.id
+            mid = uuid.uuid4()
+
+            db = AsyncMock()
+            result_mock = MagicMock()
+            result_mock.scalar_one_or_none.return_value = other_member
+            db.execute.return_value = result_mock
+
+            await settings_organisation_members_action(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                action="remove",
+                member_id=str(mid),
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "removed" in ctx["success"]
+            db.delete.assert_called_once()
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._list_members")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_cannot_remove_self(
+        self,
+        mock_auth: AsyncMock,
+        mock_mem: AsyncMock,
+        mock_list: AsyncMock,
+        mock_render: MagicMock,
+    ) -> None:
+        """Cannot remove yourself."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_list.return_value = []
+            mock_render.return_value = MagicMock()
+
+            self_member = MagicMock()
+            self_member.user_id = user.id  # same as current user
+            mid = uuid.uuid4()
+
+            db = AsyncMock()
+            result_mock = MagicMock()
+            result_mock.scalar_one_or_none.return_value = self_member
+            db.execute.return_value = result_mock
+
+            await settings_organisation_members_action(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                action="remove",
+                member_id=str(mid),
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "cannot remove yourself" in ctx["error"]
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._list_members")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_update_role_success(
+        self,
+        mock_auth: AsyncMock,
+        mock_mem: AsyncMock,
+        mock_list: AsyncMock,
+        mock_render: MagicMock,
+    ) -> None:
+        """Owner can update another member's role."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_list.return_value = []
+            mock_render.return_value = MagicMock()
+
+            other_member = MagicMock()
+            other_member.user_id = uuid.uuid4()
+            mid = uuid.uuid4()
+
+            db = AsyncMock()
+            result_mock = MagicMock()
+            result_mock.scalar_one_or_none.return_value = other_member
+            db.execute.return_value = result_mock
+
+            await settings_organisation_members_action(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                action="update_role",
+                member_id=str(mid),
+                member_role="admin",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "updated" in ctx["success"]
+            assert other_member.role == "admin"
 
         asyncio.run(_run())

--- a/tests/routes/test_organisation_settings_ui_unit.py
+++ b/tests/routes/test_organisation_settings_ui_unit.py
@@ -16,6 +16,8 @@ from shomer.routes.organisation_settings_ui import (
     _get_membership,
     _get_session_user,
     _parse_uuid,
+    settings_organisation_branding,
+    settings_organisation_branding_update,
     settings_organisation_create,
     settings_organisation_detail,
     settings_organisation_domains,
@@ -28,6 +30,10 @@ from shomer.routes.organisation_settings_ui import (
     settings_organisation_new,
     settings_organisation_roles,
     settings_organisation_roles_action,
+    settings_organisation_templates,
+    settings_organisation_templates_action,
+    settings_organisation_trust,
+    settings_organisation_trust_action,
     settings_organisations,
 )
 
@@ -2595,6 +2601,831 @@ class TestSettingsOrganisationIdpsAction:
                 client_id="",
                 discovery_url="",
                 idp_id="",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "unknown" in ctx["error"].lower()
+
+        asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# Branding tests
+# ---------------------------------------------------------------------------
+
+
+class TestSettingsOrganisationBranding:
+    """Tests for GET /ui/settings/organisations/{org_id}/branding."""
+
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_unauthenticated_redirects(self, mock_auth: AsyncMock) -> None:
+        """Redirect to login when not authenticated."""
+
+        async def _run() -> None:
+            mock_auth.return_value = None
+            resp = await settings_organisation_branding(_req(), "x", AsyncMock())
+            assert resp.status_code == 302
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_renders_branding_page(
+        self, mock_auth: AsyncMock, mock_mem: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Render branding page for authenticated member."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            db = AsyncMock()
+            result_mock = MagicMock()
+            result_mock.scalar_one_or_none.return_value = None
+            db.execute.return_value = result_mock
+
+            await settings_organisation_branding(
+                _req({"session_id": "tok"}), str(tenant.id), db
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "branding" in ctx
+            assert ctx["branding"]["show_powered_by"] is True
+
+        asyncio.run(_run())
+
+
+class TestSettingsOrganisationBrandingUpdate:
+    """Tests for POST /ui/settings/organisations/{org_id}/branding."""
+
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_unauthenticated_redirects(self, mock_auth: AsyncMock) -> None:
+        """Redirect to login when not authenticated."""
+
+        async def _run() -> None:
+            mock_auth.return_value = None
+            resp = await settings_organisation_branding_update(
+                _req(),
+                "x",
+                AsyncMock(),
+                logo_url="",
+                favicon_url="",
+                primary_color="",
+                secondary_color="",
+                accent_color="",
+                background_color="",
+                font_family="",
+                custom_css="",
+                show_powered_by="",
+            )
+            assert resp.status_code == 302
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_non_admin_denied(
+        self, mock_auth: AsyncMock, mock_mem: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Members cannot update branding."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="member", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            db = AsyncMock()
+            result_mock = MagicMock()
+            result_mock.scalar_one_or_none.return_value = None
+            db.execute.return_value = result_mock
+
+            await settings_organisation_branding_update(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                logo_url="",
+                favicon_url="",
+                primary_color="",
+                secondary_color="",
+                accent_color="",
+                background_color="",
+                font_family="",
+                custom_css="",
+                show_powered_by="",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "permission" in ctx["error"].lower()
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_invalid_color_error(
+        self, mock_auth: AsyncMock, mock_mem: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Invalid hex color shows error."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            db = AsyncMock()
+            result_mock = MagicMock()
+            result_mock.scalar_one_or_none.return_value = None
+            db.execute.return_value = result_mock
+
+            await settings_organisation_branding_update(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                logo_url="",
+                favicon_url="",
+                primary_color="notacolor",
+                secondary_color="",
+                accent_color="",
+                background_color="",
+                font_family="",
+                custom_css="",
+                show_powered_by="",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "color" in ctx["error"].lower()
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_update_success_creates_branding(
+        self, mock_auth: AsyncMock, mock_mem: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Owner can save branding (creates new record if none exists)."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            db = AsyncMock()
+            result_mock = MagicMock()
+            result_mock.scalar_one_or_none.return_value = None
+            db.execute.return_value = result_mock
+
+            await settings_organisation_branding_update(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                logo_url="https://example.com/logo.png",
+                favicon_url="",
+                primary_color="#333",
+                secondary_color="",
+                accent_color="",
+                background_color="",
+                font_family="Inter",
+                custom_css="",
+                show_powered_by="on",
+            )
+
+            db.add.assert_called_once()
+            ctx = mock_render.call_args[0][2]
+            assert "updated" in ctx["success"].lower()
+
+        asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# Trust policy tests
+# ---------------------------------------------------------------------------
+
+
+class TestSettingsOrganisationTrust:
+    """Tests for GET /ui/settings/organisations/{org_id}/trust."""
+
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_unauthenticated_redirects(self, mock_auth: AsyncMock) -> None:
+        """Redirect to login when not authenticated."""
+
+        async def _run() -> None:
+            mock_auth.return_value = None
+            resp = await settings_organisation_trust(_req(), "x", AsyncMock())
+            assert resp.status_code == 302
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_renders_trust_page(
+        self, mock_auth: AsyncMock, mock_mem: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Render trust page with sources list."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            db = AsyncMock()
+            scalars_mock = MagicMock()
+            scalars_mock.all.return_value = []
+            result_mock = MagicMock()
+            result_mock.scalars.return_value = scalars_mock
+            db.execute.return_value = result_mock
+
+            await settings_organisation_trust(
+                _req({"session_id": "tok"}), str(tenant.id), db
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "trust_mode" in ctx
+            assert ctx["sources"] == []
+
+        asyncio.run(_run())
+
+
+class TestSettingsOrganisationTrustAction:
+    """Tests for POST /ui/settings/organisations/{org_id}/trust."""
+
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_unauthenticated_redirects(self, mock_auth: AsyncMock) -> None:
+        """Redirect to login when not authenticated."""
+
+        async def _run() -> None:
+            mock_auth.return_value = None
+            resp = await settings_organisation_trust_action(
+                _req(),
+                "x",
+                AsyncMock(),
+                action="update_mode",
+                trust_mode="",
+                trusted_slug="",
+                description="",
+                source_id="",
+            )
+            assert resp.status_code == 302
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_non_admin_denied(
+        self, mock_auth: AsyncMock, mock_mem: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Members cannot manage trust policies."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="member", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            db = AsyncMock()
+            scalars_mock = MagicMock()
+            scalars_mock.all.return_value = []
+            result_mock = MagicMock()
+            result_mock.scalars.return_value = scalars_mock
+            db.execute.return_value = result_mock
+
+            await settings_organisation_trust_action(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                action="update_mode",
+                trust_mode="none",
+                trusted_slug="",
+                description="",
+                source_id="",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "permission" in ctx["error"].lower()
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_update_mode_success(
+        self, mock_auth: AsyncMock, mock_mem: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Owner can update trust mode."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            db = AsyncMock()
+            scalars_mock = MagicMock()
+            scalars_mock.all.return_value = []
+            result_mock = MagicMock()
+            result_mock.scalars.return_value = scalars_mock
+            db.execute.return_value = result_mock
+
+            await settings_organisation_trust_action(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                action="update_mode",
+                trust_mode="none",
+                trusted_slug="",
+                description="",
+                source_id="",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "updated" in ctx["success"].lower()
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_add_source_empty_slug_error(
+        self, mock_auth: AsyncMock, mock_mem: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Adding a source with empty slug shows error."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            db = AsyncMock()
+            scalars_mock = MagicMock()
+            scalars_mock.all.return_value = []
+            result_mock = MagicMock()
+            result_mock.scalars.return_value = scalars_mock
+            db.execute.return_value = result_mock
+
+            await settings_organisation_trust_action(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                action="add_source",
+                trust_mode="",
+                trusted_slug="",
+                description="",
+                source_id="",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "required" in ctx["error"].lower()
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_unknown_action_error(
+        self, mock_auth: AsyncMock, mock_mem: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Unknown action shows error."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            db = AsyncMock()
+            scalars_mock = MagicMock()
+            scalars_mock.all.return_value = []
+            result_mock = MagicMock()
+            result_mock.scalars.return_value = scalars_mock
+            db.execute.return_value = result_mock
+
+            await settings_organisation_trust_action(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                action="foobar",
+                trust_mode="",
+                trusted_slug="",
+                description="",
+                source_id="",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "unknown" in ctx["error"].lower()
+
+        asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# Email template tests
+# ---------------------------------------------------------------------------
+
+
+class TestSettingsOrganisationTemplates:
+    """Tests for GET /ui/settings/organisations/{org_id}/templates."""
+
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_unauthenticated_redirects(self, mock_auth: AsyncMock) -> None:
+        """Redirect to login when not authenticated."""
+
+        async def _run() -> None:
+            mock_auth.return_value = None
+            resp = await settings_organisation_templates(_req(), "x", AsyncMock())
+            assert resp.status_code == 302
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_renders_templates_page(
+        self, mock_auth: AsyncMock, mock_mem: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Render templates page with list."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            db = AsyncMock()
+            scalars_mock = MagicMock()
+            scalars_mock.all.return_value = []
+            result_mock = MagicMock()
+            result_mock.scalars.return_value = scalars_mock
+            db.execute.return_value = result_mock
+
+            await settings_organisation_templates(
+                _req({"session_id": "tok"}), str(tenant.id), db
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert ctx["templates"] == []
+
+        asyncio.run(_run())
+
+
+class TestSettingsOrganisationTemplatesAction:
+    """Tests for POST /ui/settings/organisations/{org_id}/templates."""
+
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_unauthenticated_redirects(self, mock_auth: AsyncMock) -> None:
+        """Redirect to login when not authenticated."""
+
+        async def _run() -> None:
+            mock_auth.return_value = None
+            resp = await settings_organisation_templates_action(
+                _req(),
+                "x",
+                AsyncMock(),
+                action="create",
+                template_name="",
+                content="",
+                description="",
+                template_id="",
+            )
+            assert resp.status_code == 302
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_non_admin_denied(
+        self, mock_auth: AsyncMock, mock_mem: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Members cannot manage templates."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="member", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            db = AsyncMock()
+            scalars_mock = MagicMock()
+            scalars_mock.all.return_value = []
+            result_mock = MagicMock()
+            result_mock.scalars.return_value = scalars_mock
+            db.execute.return_value = result_mock
+
+            await settings_organisation_templates_action(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                action="create",
+                template_name="test",
+                content="body",
+                description="",
+                template_id="",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "permission" in ctx["error"].lower()
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_create_empty_name_error(
+        self, mock_auth: AsyncMock, mock_mem: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Creating a template with empty name shows error."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            db = AsyncMock()
+            scalars_mock = MagicMock()
+            scalars_mock.all.return_value = []
+            result_mock = MagicMock()
+            result_mock.scalars.return_value = scalars_mock
+            db.execute.return_value = result_mock
+
+            await settings_organisation_templates_action(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                action="create",
+                template_name="",
+                content="body",
+                description="",
+                template_id="",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "name" in ctx["error"].lower() and "required" in ctx["error"].lower()
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_create_empty_content_error(
+        self, mock_auth: AsyncMock, mock_mem: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Creating a template with empty content shows error."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            db = AsyncMock()
+            scalars_mock = MagicMock()
+            scalars_mock.all.return_value = []
+            result_mock = MagicMock()
+            result_mock.scalars.return_value = scalars_mock
+            db.execute.return_value = result_mock
+
+            await settings_organisation_templates_action(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                action="create",
+                template_name="test.html",
+                content="",
+                description="",
+                template_id="",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "content" in ctx["error"].lower()
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_create_success(
+        self, mock_auth: AsyncMock, mock_mem: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Owner can create a template override."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            call_count = 0
+
+            def execute_side_effect(*args: object, **kwargs: object) -> MagicMock:
+                nonlocal call_count
+                call_count += 1
+                result_mock = MagicMock()
+                if call_count == 1:
+                    # Duplicate check
+                    result_mock.scalar_one_or_none.return_value = None
+                else:
+                    scalars_mock = MagicMock()
+                    scalars_mock.all.return_value = []
+                    result_mock.scalars.return_value = scalars_mock
+                return result_mock
+
+            db = AsyncMock()
+            db.execute = AsyncMock(side_effect=execute_side_effect)
+
+            await settings_organisation_templates_action(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                action="create",
+                template_name="emails/welcome.html",
+                content="<h1>Welcome</h1>",
+                description="Welcome email",
+                template_id="",
+            )
+
+            db.add.assert_called_once()
+            ctx = mock_render.call_args[0][2]
+            assert "created" in ctx["success"]
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_delete_success(
+        self, mock_auth: AsyncMock, mock_mem: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Owner can delete a template."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            tmpl_obj = MagicMock()
+
+            call_count = 0
+
+            def execute_side_effect(*args: object, **kwargs: object) -> MagicMock:
+                nonlocal call_count
+                call_count += 1
+                result_mock = MagicMock()
+                if call_count == 1:
+                    result_mock.scalar_one_or_none.return_value = tmpl_obj
+                else:
+                    scalars_mock = MagicMock()
+                    scalars_mock.all.return_value = []
+                    result_mock.scalars.return_value = scalars_mock
+                return result_mock
+
+            db = AsyncMock()
+            db.execute = AsyncMock(side_effect=execute_side_effect)
+
+            await settings_organisation_templates_action(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                action="delete",
+                template_id=str(uuid.uuid4()),
+                template_name="",
+                content="",
+                description="",
+            )
+
+            db.delete.assert_called_once_with(tmpl_obj)
+            ctx = mock_render.call_args[0][2]
+            assert "deleted" in ctx["success"].lower()
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_toggle_success(
+        self, mock_auth: AsyncMock, mock_mem: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Owner can toggle a template active/inactive."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            tmpl_obj = MagicMock()
+            tmpl_obj.is_active = True
+            tmpl_obj.template_name = "test.html"
+
+            call_count = 0
+
+            def execute_side_effect(*args: object, **kwargs: object) -> MagicMock:
+                nonlocal call_count
+                call_count += 1
+                result_mock = MagicMock()
+                if call_count == 1:
+                    result_mock.scalar_one_or_none.return_value = tmpl_obj
+                else:
+                    scalars_mock = MagicMock()
+                    scalars_mock.all.return_value = []
+                    result_mock.scalars.return_value = scalars_mock
+                return result_mock
+
+            db = AsyncMock()
+            db.execute = AsyncMock(side_effect=execute_side_effect)
+
+            await settings_organisation_templates_action(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                action="toggle",
+                template_id=str(uuid.uuid4()),
+                template_name="",
+                content="",
+                description="",
+            )
+
+            assert tmpl_obj.is_active is False
+            ctx = mock_render.call_args[0][2]
+            assert "disabled" in ctx["success"]
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_unknown_action_error(
+        self, mock_auth: AsyncMock, mock_mem: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Unknown action shows error."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            db = AsyncMock()
+            scalars_mock = MagicMock()
+            scalars_mock.all.return_value = []
+            result_mock = MagicMock()
+            result_mock.scalars.return_value = scalars_mock
+            db.execute.return_value = result_mock
+
+            await settings_organisation_templates_action(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                action="foobar",
+                template_name="",
+                content="",
+                description="",
+                template_id="",
             )
 
             ctx = mock_render.call_args[0][2]

--- a/tests/routes/test_organisation_settings_ui_unit.py
+++ b/tests/routes/test_organisation_settings_ui_unit.py
@@ -12,8 +12,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from shomer.routes.organisation_settings_ui import (
     _SLUG_RE,
+    _get_membership,
     _get_session_user,
+    _parse_uuid,
     settings_organisation_create,
+    settings_organisation_detail,
+    settings_organisation_edit,
     settings_organisation_new,
     settings_organisations,
 )
@@ -395,5 +399,330 @@ class TestSettingsOrganisationCreate:
             assert "/ui/settings/organisations/" in resp.headers["location"]
             assert db.add.call_count == 2  # tenant + membership
             assert db.flush.call_count == 2
+
+        asyncio.run(_run())
+
+
+class TestParseUuid:
+    """Tests for _parse_uuid()."""
+
+    def test_valid_uuid(self) -> None:
+        """Parse a valid UUID string."""
+        uid = uuid.uuid4()
+        assert _parse_uuid(str(uid)) == uid
+
+    def test_invalid_uuid(self) -> None:
+        """Return None for an invalid UUID."""
+        assert _parse_uuid("not-a-uuid") is None
+
+
+class TestGetMembership:
+    """Tests for _get_membership()."""
+
+    def test_no_membership(self) -> None:
+        """Return None when user is not a member."""
+
+        async def _run() -> None:
+            db = AsyncMock()
+            result_mock = MagicMock()
+            result_mock.scalar_one_or_none.return_value = None
+            db.execute.return_value = result_mock
+
+            result = await _get_membership(db, uuid.uuid4(), uuid.uuid4())
+            assert result is None
+
+        asyncio.run(_run())
+
+    def test_has_membership(self) -> None:
+        """Return (membership, tenant) when user is a member."""
+
+        async def _run() -> None:
+            tenant = MagicMock()
+            membership = MagicMock()
+            membership.tenant = tenant
+
+            db = AsyncMock()
+            result_mock = MagicMock()
+            result_mock.scalar_one_or_none.return_value = membership
+            db.execute.return_value = result_mock
+
+            result = await _get_membership(db, uuid.uuid4(), uuid.uuid4())
+            assert result is not None
+            assert result[0] is membership
+            assert result[1] is tenant
+
+        asyncio.run(_run())
+
+
+class TestSettingsOrganisationDetail:
+    """Tests for GET /ui/settings/organisations/{org_id}."""
+
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_unauthenticated_redirects(self, mock_auth: AsyncMock) -> None:
+        """Redirect to login when not authenticated."""
+
+        async def _run() -> None:
+            mock_auth.return_value = None
+            resp = await settings_organisation_detail(
+                _req(), str(uuid.uuid4()), AsyncMock()
+            )
+            assert resp.status_code == 302
+            assert "/ui/login" in resp.headers["location"]
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_invalid_uuid_shows_error(
+        self, mock_auth: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Show error for invalid UUID."""
+
+        async def _run() -> None:
+            mock_auth.return_value = (MagicMock(), _mock_user())
+            mock_render.return_value = MagicMock()
+
+            await settings_organisation_detail(
+                _req({"session_id": "tok"}), "bad-id", AsyncMock()
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "Invalid" in ctx["error"]
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_not_member_shows_error(
+        self,
+        mock_auth: AsyncMock,
+        mock_membership: AsyncMock,
+        mock_render: MagicMock,
+    ) -> None:
+        """Show error when user is not a member."""
+
+        async def _run() -> None:
+            mock_auth.return_value = (MagicMock(), _mock_user())
+            mock_membership.return_value = None
+            mock_render.return_value = MagicMock()
+
+            await settings_organisation_detail(
+                _req({"session_id": "tok"}), str(uuid.uuid4()), AsyncMock()
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "not found" in ctx["error"]
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_member_renders_detail(
+        self,
+        mock_auth: AsyncMock,
+        mock_membership: AsyncMock,
+        mock_render: MagicMock,
+    ) -> None:
+        """Render detail page for a member."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+
+            tenant = MagicMock()
+            tenant.id = uuid.uuid4()
+            tenant.slug = "acme"
+            tenant.name = "Acme"
+            tenant.display_name = "Acme Corp"
+            tenant.custom_domain = None
+            tenant.is_active = True
+            tenant.is_platform = False
+            tenant.trust_mode = MagicMock(value="none")
+            tenant.created_at = datetime(2025, 1, 1, tzinfo=timezone.utc)
+
+            membership = MagicMock()
+            membership.role = "owner"
+            membership.tenant = tenant
+
+            mock_membership.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            await settings_organisation_detail(
+                _req({"session_id": "tok"}), str(tenant.id), AsyncMock()
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert ctx["org"]["slug"] == "acme"
+            assert ctx["role"] == "owner"
+            assert ctx["error"] is None
+
+        asyncio.run(_run())
+
+
+class TestSettingsOrganisationEdit:
+    """Tests for POST /ui/settings/organisations/{org_id}."""
+
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_unauthenticated_redirects(self, mock_auth: AsyncMock) -> None:
+        """Redirect to login when not authenticated."""
+
+        async def _run() -> None:
+            mock_auth.return_value = None
+            resp = await settings_organisation_edit(
+                _req(),
+                str(uuid.uuid4()),
+                AsyncMock(),
+                name="X",
+                display_name="X",
+                trust_mode="none",
+            )
+            assert resp.status_code == 302
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_member_cannot_edit(
+        self,
+        mock_auth: AsyncMock,
+        mock_membership: AsyncMock,
+        mock_render: MagicMock,
+    ) -> None:
+        """Show error when a regular member tries to edit."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+
+            tenant = MagicMock()
+            tenant.id = uuid.uuid4()
+            tenant.slug = "acme"
+            tenant.name = "Acme"
+            tenant.display_name = "Acme"
+            tenant.custom_domain = None
+            tenant.is_active = True
+            tenant.is_platform = False
+            tenant.trust_mode = MagicMock(value="none")
+            tenant.created_at = None
+
+            membership = MagicMock()
+            membership.role = "member"
+            membership.tenant = tenant
+
+            mock_membership.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            await settings_organisation_edit(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                AsyncMock(),
+                name="New",
+                display_name="New",
+                trust_mode="none",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "permission" in ctx["error"]
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_owner_can_edit(
+        self,
+        mock_auth: AsyncMock,
+        mock_membership: AsyncMock,
+        mock_render: MagicMock,
+    ) -> None:
+        """Owner can successfully edit the organisation."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+
+            tenant = MagicMock()
+            tenant.id = uuid.uuid4()
+            tenant.slug = "acme"
+            tenant.name = "Acme"
+            tenant.display_name = "Acme"
+            tenant.custom_domain = None
+            tenant.is_active = True
+            tenant.is_platform = False
+            tenant.trust_mode = MagicMock(value="none")
+            tenant.created_at = None
+
+            membership = MagicMock()
+            membership.role = "owner"
+            membership.tenant = tenant
+
+            mock_membership.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            db = AsyncMock()
+            await settings_organisation_edit(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                name="New Name",
+                display_name="New Display",
+                trust_mode="all",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert ctx["success"] == "Organisation updated successfully."
+            assert tenant.name == "New Name"
+            assert tenant.display_name == "New Display"
+            db.flush.assert_awaited_once()
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_invalid_trust_mode(
+        self,
+        mock_auth: AsyncMock,
+        mock_membership: AsyncMock,
+        mock_render: MagicMock,
+    ) -> None:
+        """Show error for invalid trust mode."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+
+            tenant = MagicMock()
+            tenant.id = uuid.uuid4()
+            tenant.slug = "acme"
+            tenant.name = "Acme"
+            tenant.display_name = "Acme"
+            tenant.custom_domain = None
+            tenant.is_active = True
+            tenant.is_platform = False
+            tenant.trust_mode = MagicMock(value="none")
+            tenant.created_at = None
+
+            membership = MagicMock()
+            membership.role = "owner"
+            membership.tenant = tenant
+
+            mock_membership.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            await settings_organisation_edit(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                AsyncMock(),
+                name="Acme",
+                display_name="Acme",
+                trust_mode="invalid",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "Invalid trust mode" in ctx["error"]
 
         asyncio.run(_run())

--- a/tests/routes/test_organisation_settings_ui_unit.py
+++ b/tests/routes/test_organisation_settings_ui_unit.py
@@ -11,12 +11,15 @@ from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from shomer.routes.organisation_settings_ui import (
+    _DOMAIN_RE,
     _SLUG_RE,
     _get_membership,
     _get_session_user,
     _parse_uuid,
     settings_organisation_create,
     settings_organisation_detail,
+    settings_organisation_domains,
+    settings_organisation_domains_update,
     settings_organisation_edit,
     settings_organisation_new,
     settings_organisations,
@@ -44,6 +47,24 @@ def _mock_user() -> MagicMock:
     e.is_verified = True
     u.emails = [e]
     return u
+
+
+def _mock_tenant(
+    slug: str = "acme",
+    custom_domain: str | None = None,
+) -> MagicMock:
+    """Build a mock Tenant."""
+    tenant = MagicMock()
+    tenant.id = uuid.uuid4()
+    tenant.slug = slug
+    tenant.name = slug.capitalize()
+    tenant.display_name = f"{slug.capitalize()} Corp"
+    tenant.custom_domain = custom_domain
+    tenant.is_active = True
+    tenant.is_platform = False
+    tenant.trust_mode = MagicMock(value="none")
+    tenant.created_at = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    return tenant
 
 
 def _mock_membership(
@@ -366,6 +387,251 @@ class TestSettingsOrganisationCreate:
             mock_render.assert_called_once()
             ctx = mock_render.call_args[0][2]
             assert "Invalid trust mode" in ctx["error"]
+
+        asyncio.run(_run())
+
+
+class TestDomainRegex:
+    """Tests for _DOMAIN_RE validation."""
+
+    def test_valid_domains(self) -> None:
+        """Accept valid domain names."""
+        for d in ("example.com", "auth.example.com", "a.b.co"):
+            assert _DOMAIN_RE.match(d), f"Expected valid: {d}"
+
+    def test_invalid_domains(self) -> None:
+        """Reject invalid domain names."""
+        for d in ("", "localhost", "-bad.com", "no_under.com"):
+            assert not _DOMAIN_RE.match(d), f"Expected invalid: {d}"
+
+
+class TestSettingsOrganisationDomains:
+    """Tests for GET /ui/settings/organisations/{org_id}/domains."""
+
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_unauthenticated_redirects(self, mock_auth: AsyncMock) -> None:
+        """Redirect to login when not authenticated."""
+
+        async def _run() -> None:
+            mock_auth.return_value = None
+            resp = await settings_organisation_domains(
+                _req(), str(uuid.uuid4()), AsyncMock()
+            )
+            assert resp.status_code == 302
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_renders_domain_page(
+        self,
+        mock_auth: AsyncMock,
+        mock_mem: AsyncMock,
+        mock_render: MagicMock,
+    ) -> None:
+        """Render domain page for a member."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant(custom_domain="auth.acme.com")
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            await settings_organisation_domains(
+                _req({"session_id": "tok"}), str(tenant.id), AsyncMock()
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert ctx["custom_domain"] == "auth.acme.com"
+            assert ctx["error"] is None
+
+        asyncio.run(_run())
+
+
+class TestSettingsOrganisationDomainsUpdate:
+    """Tests for POST /ui/settings/organisations/{org_id}/domains."""
+
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_unauthenticated_redirects(self, mock_auth: AsyncMock) -> None:
+        """Redirect to login when not authenticated."""
+
+        async def _run() -> None:
+            mock_auth.return_value = None
+            resp = await settings_organisation_domains_update(
+                _req(), str(uuid.uuid4()), AsyncMock(), custom_domain=""
+            )
+            assert resp.status_code == 302
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_member_cannot_update(
+        self,
+        mock_auth: AsyncMock,
+        mock_mem: AsyncMock,
+        mock_render: MagicMock,
+    ) -> None:
+        """Show error when regular member tries to update domain."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="member", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            await settings_organisation_domains_update(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                AsyncMock(),
+                custom_domain="new.com",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "permission" in ctx["error"]
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_invalid_domain_format(
+        self,
+        mock_auth: AsyncMock,
+        mock_mem: AsyncMock,
+        mock_render: MagicMock,
+    ) -> None:
+        """Show error for invalid domain format."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            await settings_organisation_domains_update(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                AsyncMock(),
+                custom_domain="-invalid",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "Invalid domain" in ctx["error"]
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_owner_sets_domain(
+        self,
+        mock_auth: AsyncMock,
+        mock_mem: AsyncMock,
+        mock_render: MagicMock,
+    ) -> None:
+        """Owner can set a custom domain."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            db = AsyncMock()
+            dup_result = MagicMock()
+            dup_result.scalar_one_or_none.return_value = None
+            db.execute.return_value = dup_result
+
+            await settings_organisation_domains_update(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                custom_domain="auth.acme.com",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "updated" in ctx["success"]
+            assert tenant.custom_domain == "auth.acme.com"
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_owner_removes_domain(
+        self,
+        mock_auth: AsyncMock,
+        mock_mem: AsyncMock,
+        mock_render: MagicMock,
+    ) -> None:
+        """Owner can remove a custom domain by submitting empty."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant(custom_domain="old.com")
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            db = AsyncMock()
+            await settings_organisation_domains_update(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                custom_domain="",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "removed" in ctx["success"]
+            assert tenant.custom_domain is None
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_duplicate_domain_error(
+        self,
+        mock_auth: AsyncMock,
+        mock_mem: AsyncMock,
+        mock_render: MagicMock,
+    ) -> None:
+        """Show error when domain is used by another org."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            db = AsyncMock()
+            dup_result = MagicMock()
+            dup_result.scalar_one_or_none.return_value = MagicMock()  # duplicate
+            db.execute.return_value = dup_result
+
+            await settings_organisation_domains_update(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                custom_domain="taken.com",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "already in use" in ctx["error"]
 
         asyncio.run(_run())
 

--- a/tests/routes/test_organisation_settings_ui_unit.py
+++ b/tests/routes/test_organisation_settings_ui_unit.py
@@ -24,6 +24,8 @@ from shomer.routes.organisation_settings_ui import (
     settings_organisation_members,
     settings_organisation_members_action,
     settings_organisation_new,
+    settings_organisation_roles,
+    settings_organisation_roles_action,
     settings_organisations,
 )
 
@@ -1319,5 +1321,678 @@ class TestSettingsOrganisationMembersAction:
             ctx = mock_render.call_args[0][2]
             assert "updated" in ctx["success"]
             assert other_member.role == "admin"
+
+        asyncio.run(_run())
+
+
+class TestSettingsOrganisationRoles:
+    """Tests for GET /ui/settings/organisations/{org_id}/roles."""
+
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_unauthenticated_redirects(self, mock_auth: AsyncMock) -> None:
+        """Redirect to login when not authenticated."""
+
+        async def _run() -> None:
+            mock_auth.return_value = None
+            resp = await settings_organisation_roles(_req(), "some-id", AsyncMock())
+            assert resp.status_code == 302
+            assert "/ui/login" in resp.headers["location"]
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_invalid_org_id(self, mock_auth: AsyncMock, mock_render: MagicMock) -> None:
+        """Show error for invalid org ID."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            mock_render.return_value = MagicMock()
+
+            await settings_organisation_roles(
+                _req({"session_id": "tok"}), "not-a-uuid", AsyncMock()
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "Invalid organisation ID" in ctx["error"]
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_not_member_shows_error(
+        self, mock_auth: AsyncMock, mock_mem: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Show error when user is not a member."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            mock_mem.return_value = None
+            mock_render.return_value = MagicMock()
+
+            await settings_organisation_roles(
+                _req({"session_id": "tok"}), str(uuid.uuid4()), AsyncMock()
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "not found" in ctx["error"]
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_renders_roles_list(
+        self, mock_auth: AsyncMock, mock_mem: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Render roles page with list of custom roles."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            role1 = MagicMock()
+            role1.id = uuid.uuid4()
+            role1.name = "editor"
+            role1.permissions = ["read", "write"]
+
+            db = AsyncMock()
+            scalars_mock = MagicMock()
+            scalars_mock.all.return_value = [role1]
+            result_mock = MagicMock()
+            result_mock.scalars.return_value = scalars_mock
+            db.execute.return_value = result_mock
+
+            await settings_organisation_roles(
+                _req({"session_id": "tok"}), str(tenant.id), db
+            )
+
+            mock_render.assert_called_once()
+            ctx = mock_render.call_args[0][2]
+            assert ctx["role"] == "owner"
+            assert len(ctx["roles"]) == 1
+            assert ctx["roles"][0]["name"] == "editor"
+            assert ctx["roles"][0]["permissions"] == ["read", "write"]
+
+        asyncio.run(_run())
+
+
+class TestSettingsOrganisationRolesAction:
+    """Tests for POST /ui/settings/organisations/{org_id}/roles."""
+
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_unauthenticated_redirects(self, mock_auth: AsyncMock) -> None:
+        """Redirect to login when not authenticated."""
+
+        async def _run() -> None:
+            mock_auth.return_value = None
+            resp = await settings_organisation_roles_action(
+                _req(),
+                "some-id",
+                AsyncMock(),
+                action="create",
+                role_name="",
+                permissions="",
+                role_id="",
+            )
+            assert resp.status_code == 302
+            assert "/ui/login" in resp.headers["location"]
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_invalid_org_id(self, mock_auth: AsyncMock, mock_render: MagicMock) -> None:
+        """Show error for invalid org ID."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            mock_render.return_value = MagicMock()
+
+            await settings_organisation_roles_action(
+                _req({"session_id": "tok"}),
+                "bad-uuid",
+                AsyncMock(),
+                action="create",
+                role_name="",
+                permissions="",
+                role_id="",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "Invalid organisation ID" in ctx["error"]
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_not_member_shows_error(
+        self, mock_auth: AsyncMock, mock_mem: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Show error when user is not a member."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            mock_mem.return_value = None
+            mock_render.return_value = MagicMock()
+
+            await settings_organisation_roles_action(
+                _req({"session_id": "tok"}),
+                str(uuid.uuid4()),
+                AsyncMock(),
+                action="create",
+                role_name="",
+                permissions="",
+                role_id="",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "not found" in ctx["error"]
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_non_admin_denied(
+        self, mock_auth: AsyncMock, mock_mem: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Members without owner/admin role cannot manage roles."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="member", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            db = AsyncMock()
+            scalars_mock = MagicMock()
+            scalars_mock.all.return_value = []
+            result_mock = MagicMock()
+            result_mock.scalars.return_value = scalars_mock
+            db.execute.return_value = result_mock
+
+            await settings_organisation_roles_action(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                action="create",
+                role_name="editor",
+                permissions="",
+                role_id="",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "permission" in ctx["error"].lower()
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_create_empty_name_error(
+        self, mock_auth: AsyncMock, mock_mem: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Creating a role with empty name shows error."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            db = AsyncMock()
+            scalars_mock = MagicMock()
+            scalars_mock.all.return_value = []
+            result_mock = MagicMock()
+            result_mock.scalars.return_value = scalars_mock
+            db.execute.return_value = result_mock
+
+            await settings_organisation_roles_action(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                action="create",
+                role_name="",
+                permissions="",
+                role_id="",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "required" in ctx["error"].lower()
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_create_duplicate_name_error(
+        self, mock_auth: AsyncMock, mock_mem: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Creating a role with duplicate name shows error."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            existing_role = MagicMock()
+            db = AsyncMock()
+
+            call_count = 0
+
+            def execute_side_effect(*args: object, **kwargs: object) -> MagicMock:
+                nonlocal call_count
+                call_count += 1
+                result_mock = MagicMock()
+                if call_count == 1:
+                    # First call: duplicate check returns existing role
+                    result_mock.scalar_one_or_none.return_value = existing_role
+                else:
+                    # Subsequent calls for _ctx: roles list
+                    scalars_mock = MagicMock()
+                    scalars_mock.all.return_value = []
+                    result_mock.scalars.return_value = scalars_mock
+                return result_mock
+
+            db.execute = AsyncMock(side_effect=execute_side_effect)
+
+            await settings_organisation_roles_action(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                action="create",
+                role_name="editor",
+                permissions="",
+                role_id="",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "already exists" in ctx["error"]
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_create_role_success(
+        self, mock_auth: AsyncMock, mock_mem: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Owner can create a new custom role."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            call_count = 0
+
+            def execute_side_effect(*args: object, **kwargs: object) -> MagicMock:
+                nonlocal call_count
+                call_count += 1
+                result_mock = MagicMock()
+                if call_count == 1:
+                    # First call: uniqueness check returns None
+                    result_mock.scalar_one_or_none.return_value = None
+                else:
+                    # Subsequent calls for _ctx: roles list
+                    scalars_mock = MagicMock()
+                    scalars_mock.all.return_value = []
+                    result_mock.scalars.return_value = scalars_mock
+                return result_mock
+
+            db = AsyncMock()
+            db.execute = AsyncMock(side_effect=execute_side_effect)
+
+            await settings_organisation_roles_action(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                action="create",
+                role_name="editor",
+                permissions="read write",
+            )
+
+            db.add.assert_called_once()
+            ctx = mock_render.call_args[0][2]
+            assert "created" in ctx["success"]
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_update_role_success(
+        self, mock_auth: AsyncMock, mock_mem: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Owner can update an existing custom role."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            role_obj = MagicMock()
+            role_obj.name = "editor"
+            rid = uuid.uuid4()
+
+            call_count = 0
+
+            def execute_side_effect(*args: object, **kwargs: object) -> MagicMock:
+                nonlocal call_count
+                call_count += 1
+                result_mock = MagicMock()
+                if call_count == 1:
+                    # First call: find role
+                    result_mock.scalar_one_or_none.return_value = role_obj
+                else:
+                    # Subsequent calls for _ctx: roles list
+                    scalars_mock = MagicMock()
+                    scalars_mock.all.return_value = []
+                    result_mock.scalars.return_value = scalars_mock
+                return result_mock
+
+            db = AsyncMock()
+            db.execute = AsyncMock(side_effect=execute_side_effect)
+
+            await settings_organisation_roles_action(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                action="update",
+                role_id=str(rid),
+                role_name="reviewer",
+                permissions="read review",
+            )
+
+            assert role_obj.name == "reviewer"
+            assert role_obj.permissions == ["read", "review"]
+            ctx = mock_render.call_args[0][2]
+            assert "updated" in ctx["success"]
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_update_role_not_found(
+        self, mock_auth: AsyncMock, mock_mem: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Updating a non-existent role shows error."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            call_count = 0
+
+            def execute_side_effect(*args: object, **kwargs: object) -> MagicMock:
+                nonlocal call_count
+                call_count += 1
+                result_mock = MagicMock()
+                if call_count == 1:
+                    result_mock.scalar_one_or_none.return_value = None
+                else:
+                    scalars_mock = MagicMock()
+                    scalars_mock.all.return_value = []
+                    result_mock.scalars.return_value = scalars_mock
+                return result_mock
+
+            db = AsyncMock()
+            db.execute = AsyncMock(side_effect=execute_side_effect)
+
+            await settings_organisation_roles_action(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                action="update",
+                role_id=str(uuid.uuid4()),
+                role_name="editor",
+                permissions="",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "not found" in ctx["error"].lower()
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_delete_role_success(
+        self, mock_auth: AsyncMock, mock_mem: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Owner can delete a custom role."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            role_obj = MagicMock()
+            rid = uuid.uuid4()
+
+            call_count = 0
+
+            def execute_side_effect(*args: object, **kwargs: object) -> MagicMock:
+                nonlocal call_count
+                call_count += 1
+                result_mock = MagicMock()
+                if call_count == 1:
+                    result_mock.scalar_one_or_none.return_value = role_obj
+                else:
+                    scalars_mock = MagicMock()
+                    scalars_mock.all.return_value = []
+                    result_mock.scalars.return_value = scalars_mock
+                return result_mock
+
+            db = AsyncMock()
+            db.execute = AsyncMock(side_effect=execute_side_effect)
+
+            await settings_organisation_roles_action(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                action="delete",
+                role_id=str(rid),
+                role_name="",
+                permissions="",
+            )
+
+            db.delete.assert_called_once_with(role_obj)
+            ctx = mock_render.call_args[0][2]
+            assert "deleted" in ctx["success"].lower()
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_delete_role_not_found(
+        self, mock_auth: AsyncMock, mock_mem: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Deleting a non-existent role shows error."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            call_count = 0
+
+            def execute_side_effect(*args: object, **kwargs: object) -> MagicMock:
+                nonlocal call_count
+                call_count += 1
+                result_mock = MagicMock()
+                if call_count == 1:
+                    result_mock.scalar_one_or_none.return_value = None
+                else:
+                    scalars_mock = MagicMock()
+                    scalars_mock.all.return_value = []
+                    result_mock.scalars.return_value = scalars_mock
+                return result_mock
+
+            db = AsyncMock()
+            db.execute = AsyncMock(side_effect=execute_side_effect)
+
+            await settings_organisation_roles_action(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                action="delete",
+                role_id=str(uuid.uuid4()),
+                role_name="",
+                permissions="",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "not found" in ctx["error"].lower()
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_unknown_action_error(
+        self, mock_auth: AsyncMock, mock_mem: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Unknown action shows error."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            db = AsyncMock()
+            scalars_mock = MagicMock()
+            scalars_mock.all.return_value = []
+            result_mock = MagicMock()
+            result_mock.scalars.return_value = scalars_mock
+            db.execute.return_value = result_mock
+
+            await settings_organisation_roles_action(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                action="foobar",
+                role_name="",
+                permissions="",
+                role_id="",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "unknown" in ctx["error"].lower()
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_update_invalid_role_id(
+        self, mock_auth: AsyncMock, mock_mem: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Updating with invalid role ID shows error."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            db = AsyncMock()
+            scalars_mock = MagicMock()
+            scalars_mock.all.return_value = []
+            result_mock = MagicMock()
+            result_mock.scalars.return_value = scalars_mock
+            db.execute.return_value = result_mock
+
+            await settings_organisation_roles_action(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                action="update",
+                role_id="bad-uuid",
+                role_name="editor",
+                permissions="",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "invalid role id" in ctx["error"].lower()
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_delete_invalid_role_id(
+        self, mock_auth: AsyncMock, mock_mem: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Deleting with invalid role ID shows error."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            db = AsyncMock()
+            scalars_mock = MagicMock()
+            scalars_mock.all.return_value = []
+            result_mock = MagicMock()
+            result_mock.scalars.return_value = scalars_mock
+            db.execute.return_value = result_mock
+
+            await settings_organisation_roles_action(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                action="delete",
+                role_id="bad-uuid",
+                role_name="",
+                permissions="",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "invalid role id" in ctx["error"].lower()
 
         asyncio.run(_run())

--- a/tests/routes/test_organisation_settings_ui_unit.py
+++ b/tests/routes/test_organisation_settings_ui_unit.py
@@ -1,0 +1,207 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Chris <goabonga@pm.me>
+
+"""Unit tests for organisation settings UI routes."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from shomer.routes.organisation_settings_ui import (
+    _get_session_user,
+    settings_organisations,
+)
+
+
+def _req(cookies: dict[str, str] | None = None) -> MagicMock:
+    """Build a mock Request with optional cookies."""
+    cookie_data = cookies or {}
+    r = MagicMock()
+    r.cookies = MagicMock()
+    r.cookies.get = lambda k, d=None: cookie_data.get(k, d)
+    return r
+
+
+def _mock_user() -> MagicMock:
+    """Build a mock authenticated user."""
+    u = MagicMock()
+    u.id = uuid.uuid4()
+    u.username = "testuser"
+    u.profile = MagicMock(name="Test", locale="en-US")
+    e = MagicMock()
+    e.email = "test@example.com"
+    e.is_primary = True
+    e.is_verified = True
+    u.emails = [e]
+    return u
+
+
+def _mock_membership(
+    tenant_name: str = "acme",
+    role: str = "member",
+) -> MagicMock:
+    """Build a mock TenantMember with associated Tenant."""
+    tenant = MagicMock()
+    tenant.id = uuid.uuid4()
+    tenant.slug = tenant_name
+    tenant.name = tenant_name.capitalize()
+    tenant.display_name = f"{tenant_name.capitalize()} Corp"
+    tenant.is_active = True
+    tenant.is_platform = False
+
+    membership = MagicMock()
+    membership.tenant = tenant
+    membership.role = role
+    membership.joined_at = datetime(2025, 1, 15, tzinfo=timezone.utc)
+    return membership
+
+
+class TestGetSessionUser:
+    """Tests for _get_session_user()."""
+
+    def test_no_cookie_returns_none(self) -> None:
+        """Return None when no session cookie is present."""
+
+        async def _run() -> None:
+            result = await _get_session_user(_req(), AsyncMock())
+            assert result is None
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui.SessionService")
+    def test_invalid_session_returns_none(self, mock_cls: MagicMock) -> None:
+        """Return None when session token is invalid."""
+
+        async def _run() -> None:
+            mock_svc = AsyncMock()
+            mock_svc.validate.return_value = None
+            mock_cls.return_value = mock_svc
+            result = await _get_session_user(_req({"session_id": "bad"}), AsyncMock())
+            assert result is None
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui.SessionService")
+    def test_valid_session_returns_tuple(self, mock_cls: MagicMock) -> None:
+        """Return (session, user) for a valid session."""
+
+        async def _run() -> None:
+            mock_session = MagicMock(user_id=uuid.uuid4())
+            mock_svc = AsyncMock()
+            mock_svc.validate.return_value = mock_session
+            mock_cls.return_value = mock_svc
+
+            db = AsyncMock()
+            mock_user = _mock_user()
+            result_mock = MagicMock()
+            result_mock.scalar_one_or_none.return_value = mock_user
+            db.execute.return_value = result_mock
+
+            result = await _get_session_user(_req({"session_id": "good"}), db)
+            assert result is not None
+            assert result[1].username == "testuser"
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui.SessionService")
+    def test_user_not_found_returns_none(self, mock_cls: MagicMock) -> None:
+        """Return None when session is valid but user is missing."""
+
+        async def _run() -> None:
+            mock_session = MagicMock(user_id=uuid.uuid4())
+            mock_svc = AsyncMock()
+            mock_svc.validate.return_value = mock_session
+            mock_cls.return_value = mock_svc
+
+            db = AsyncMock()
+            result_mock = MagicMock()
+            result_mock.scalar_one_or_none.return_value = None
+            db.execute.return_value = result_mock
+
+            result = await _get_session_user(_req({"session_id": "good"}), db)
+            assert result is None
+
+        asyncio.run(_run())
+
+
+class TestSettingsOrganisations:
+    """Tests for GET /ui/settings/organisations."""
+
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_unauthenticated_redirects(self, mock_auth: AsyncMock) -> None:
+        """Redirect to login when not authenticated."""
+
+        async def _run() -> None:
+            mock_auth.return_value = None
+            resp = await settings_organisations(_req(), AsyncMock())
+            assert resp.status_code == 302
+            assert "/ui/login" in resp.headers["location"]
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_authenticated_renders_orgs(
+        self, mock_auth: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Render organisations page with membership list."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+
+            m1 = _mock_membership("acme", "owner")
+            m2 = _mock_membership("beta", "member")
+
+            db = AsyncMock()
+            scalars_mock = MagicMock()
+            scalars_mock.all.return_value = [m1, m2]
+            result_mock = MagicMock()
+            result_mock.scalars.return_value = scalars_mock
+            db.execute.return_value = result_mock
+
+            mock_render.return_value = MagicMock()
+
+            await settings_organisations(_req({"session_id": "tok"}), db)
+
+            mock_render.assert_called_once()
+            call_args = mock_render.call_args
+            ctx = call_args[0][2]
+            assert ctx["section"] == "organisations"
+            assert len(ctx["organisations"]) == 2
+            assert ctx["organisations"][0]["slug"] == "acme"
+            assert ctx["organisations"][0]["role"] == "owner"
+            assert ctx["organisations"][1]["slug"] == "beta"
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_authenticated_no_orgs(
+        self, mock_auth: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Render organisations page with empty list."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+
+            db = AsyncMock()
+            scalars_mock = MagicMock()
+            scalars_mock.all.return_value = []
+            result_mock = MagicMock()
+            result_mock.scalars.return_value = scalars_mock
+            db.execute.return_value = result_mock
+
+            mock_render.return_value = MagicMock()
+
+            await settings_organisations(_req({"session_id": "tok"}), db)
+
+            mock_render.assert_called_once()
+            ctx = mock_render.call_args[0][2]
+            assert ctx["organisations"] == []
+
+        asyncio.run(_run())

--- a/tests/routes/test_organisation_settings_ui_unit.py
+++ b/tests/routes/test_organisation_settings_ui_unit.py
@@ -11,7 +11,10 @@ from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from shomer.routes.organisation_settings_ui import (
+    _SLUG_RE,
     _get_session_user,
+    settings_organisation_create,
+    settings_organisation_new,
     settings_organisations,
 )
 
@@ -203,5 +206,194 @@ class TestSettingsOrganisations:
             mock_render.assert_called_once()
             ctx = mock_render.call_args[0][2]
             assert ctx["organisations"] == []
+
+        asyncio.run(_run())
+
+
+class TestSlugRegex:
+    """Tests for _SLUG_RE validation."""
+
+    def test_valid_slugs(self) -> None:
+        """Accept valid slugs."""
+        for slug in ("acme", "my-org", "a1b2c3", "org-123-test"):
+            assert _SLUG_RE.match(slug), f"Expected valid: {slug}"
+
+    def test_invalid_slugs(self) -> None:
+        """Reject invalid slugs."""
+        for slug in ("", "a", "AB", "-start", "end-", "has space", "UPPER"):
+            assert not _SLUG_RE.match(slug), f"Expected invalid: {slug}"
+
+
+class TestSettingsOrganisationNew:
+    """Tests for GET /ui/settings/organisations/new."""
+
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_unauthenticated_redirects(self, mock_auth: AsyncMock) -> None:
+        """Redirect to login when not authenticated."""
+
+        async def _run() -> None:
+            mock_auth.return_value = None
+            resp = await settings_organisation_new(_req(), AsyncMock())
+            assert resp.status_code == 302
+            assert "/ui/login" in resp.headers["location"]
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_authenticated_renders_form(
+        self, mock_auth: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Render the create organisation form."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            mock_render.return_value = MagicMock()
+
+            await settings_organisation_new(_req({"session_id": "tok"}), AsyncMock())
+
+            mock_render.assert_called_once()
+            ctx = mock_render.call_args[0][2]
+            assert ctx["section"] == "organisations"
+            assert "trust_modes" in ctx
+            assert ctx["error"] is None
+
+        asyncio.run(_run())
+
+
+class TestSettingsOrganisationCreate:
+    """Tests for POST /ui/settings/organisations/new."""
+
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_unauthenticated_redirects(self, mock_auth: AsyncMock) -> None:
+        """Redirect to login when not authenticated."""
+
+        async def _run() -> None:
+            mock_auth.return_value = None
+            resp = await settings_organisation_create(
+                _req(), AsyncMock(), slug="test", name="Test"
+            )
+            assert resp.status_code == 302
+            assert "/ui/login" in resp.headers["location"]
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_invalid_slug_shows_error(
+        self, mock_auth: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Show error when slug is invalid."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            mock_render.return_value = MagicMock()
+
+            await settings_organisation_create(
+                _req({"session_id": "tok"}),
+                AsyncMock(),
+                slug="A",
+                name="Test",
+            )
+
+            mock_render.assert_called_once()
+            ctx = mock_render.call_args[0][2]
+            assert "Invalid slug" in ctx["error"]
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_duplicate_slug_shows_error(
+        self, mock_auth: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Show error when slug already exists."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            mock_render.return_value = MagicMock()
+
+            db = AsyncMock()
+            result_mock = MagicMock()
+            result_mock.scalar_one_or_none.return_value = MagicMock()  # existing
+            db.execute.return_value = result_mock
+
+            await settings_organisation_create(
+                _req({"session_id": "tok"}),
+                db,
+                slug="acme-corp",
+                name="Acme",
+            )
+
+            mock_render.assert_called_once()
+            ctx = mock_render.call_args[0][2]
+            assert "already taken" in ctx["error"]
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_invalid_trust_mode_shows_error(
+        self, mock_auth: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Show error for invalid trust mode."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            mock_render.return_value = MagicMock()
+
+            db = AsyncMock()
+            result_mock = MagicMock()
+            result_mock.scalar_one_or_none.return_value = None
+            db.execute.return_value = result_mock
+
+            await settings_organisation_create(
+                _req({"session_id": "tok"}),
+                db,
+                slug="acme-corp",
+                name="Acme",
+                trust_mode="invalid",
+            )
+
+            mock_render.assert_called_once()
+            ctx = mock_render.call_args[0][2]
+            assert "Invalid trust mode" in ctx["error"]
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_success_redirects(
+        self, mock_auth: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Redirect to org detail on successful creation."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+
+            db = AsyncMock()
+            result_mock = MagicMock()
+            result_mock.scalar_one_or_none.return_value = None
+            db.execute.return_value = result_mock
+
+            resp = await settings_organisation_create(
+                _req({"session_id": "tok"}),
+                db,
+                slug="acme-corp",
+                name="Acme Corp",
+                display_name="Acme Corp Inc.",
+                trust_mode="none",
+            )
+
+            mock_render.assert_not_called()
+            assert resp.status_code == 302
+            assert "/ui/settings/organisations/" in resp.headers["location"]
+            assert db.add.call_count == 2  # tenant + membership
+            assert db.flush.call_count == 2
 
         asyncio.run(_run())

--- a/tests/routes/test_organisation_settings_ui_unit.py
+++ b/tests/routes/test_organisation_settings_ui_unit.py
@@ -21,6 +21,8 @@ from shomer.routes.organisation_settings_ui import (
     settings_organisation_domains,
     settings_organisation_domains_update,
     settings_organisation_edit,
+    settings_organisation_idps,
+    settings_organisation_idps_action,
     settings_organisation_members,
     settings_organisation_members_action,
     settings_organisation_new,
@@ -1994,5 +1996,608 @@ class TestSettingsOrganisationRolesAction:
 
             ctx = mock_render.call_args[0][2]
             assert "invalid role id" in ctx["error"].lower()
+
+        asyncio.run(_run())
+
+
+class TestSettingsOrganisationIdps:
+    """Tests for GET /ui/settings/organisations/{org_id}/idps."""
+
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_unauthenticated_redirects(self, mock_auth: AsyncMock) -> None:
+        """Redirect to login when not authenticated."""
+
+        async def _run() -> None:
+            mock_auth.return_value = None
+            resp = await settings_organisation_idps(_req(), "some-id", AsyncMock())
+            assert resp.status_code == 302
+            assert "/ui/login" in resp.headers["location"]
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_invalid_org_id(self, mock_auth: AsyncMock, mock_render: MagicMock) -> None:
+        """Show error for invalid org ID."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            mock_render.return_value = MagicMock()
+
+            await settings_organisation_idps(
+                _req({"session_id": "tok"}), "not-a-uuid", AsyncMock()
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "Invalid organisation ID" in ctx["error"]
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_not_member_shows_error(
+        self, mock_auth: AsyncMock, mock_mem: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Show error when user is not a member."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            mock_mem.return_value = None
+            mock_render.return_value = MagicMock()
+
+            await settings_organisation_idps(
+                _req({"session_id": "tok"}), str(uuid.uuid4()), AsyncMock()
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "not found" in ctx["error"]
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_renders_idps_list(
+        self, mock_auth: AsyncMock, mock_mem: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Render IdPs page with list of providers."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            idp1 = MagicMock()
+            idp1.id = uuid.uuid4()
+            idp1.name = "Acme SSO"
+            idp1.provider_type = MagicMock(value="oidc")
+            idp1.client_id = "acme-client"
+            idp1.is_active = True
+
+            db = AsyncMock()
+            scalars_mock = MagicMock()
+            scalars_mock.all.return_value = [idp1]
+            result_mock = MagicMock()
+            result_mock.scalars.return_value = scalars_mock
+            db.execute.return_value = result_mock
+
+            await settings_organisation_idps(
+                _req({"session_id": "tok"}), str(tenant.id), db
+            )
+
+            mock_render.assert_called_once()
+            ctx = mock_render.call_args[0][2]
+            assert ctx["role"] == "owner"
+            assert len(ctx["idps"]) == 1
+            assert ctx["idps"][0]["name"] == "Acme SSO"
+            assert ctx["idps"][0]["is_active"] is True
+
+        asyncio.run(_run())
+
+
+class TestSettingsOrganisationIdpsAction:
+    """Tests for POST /ui/settings/organisations/{org_id}/idps."""
+
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_unauthenticated_redirects(self, mock_auth: AsyncMock) -> None:
+        """Redirect to login when not authenticated."""
+
+        async def _run() -> None:
+            mock_auth.return_value = None
+            resp = await settings_organisation_idps_action(
+                _req(),
+                "some-id",
+                AsyncMock(),
+                action="create",
+                idp_name="",
+                provider_type="oidc",
+                client_id="",
+                discovery_url="",
+                idp_id="",
+            )
+            assert resp.status_code == 302
+            assert "/ui/login" in resp.headers["location"]
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_invalid_org_id(self, mock_auth: AsyncMock, mock_render: MagicMock) -> None:
+        """Show error for invalid org ID."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            mock_render.return_value = MagicMock()
+
+            await settings_organisation_idps_action(
+                _req({"session_id": "tok"}),
+                "bad-uuid",
+                AsyncMock(),
+                action="create",
+                idp_name="",
+                provider_type="oidc",
+                client_id="",
+                discovery_url="",
+                idp_id="",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "Invalid organisation ID" in ctx["error"]
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_non_admin_denied(
+        self, mock_auth: AsyncMock, mock_mem: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Members without owner/admin role cannot manage IdPs."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="member", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            db = AsyncMock()
+            scalars_mock = MagicMock()
+            scalars_mock.all.return_value = []
+            result_mock = MagicMock()
+            result_mock.scalars.return_value = scalars_mock
+            db.execute.return_value = result_mock
+
+            await settings_organisation_idps_action(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                action="create",
+                idp_name="test",
+                provider_type="oidc",
+                client_id="cid",
+                discovery_url="",
+                idp_id="",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "permission" in ctx["error"].lower()
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_create_empty_name_error(
+        self, mock_auth: AsyncMock, mock_mem: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Creating an IdP with empty name shows error."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            db = AsyncMock()
+            scalars_mock = MagicMock()
+            scalars_mock.all.return_value = []
+            result_mock = MagicMock()
+            result_mock.scalars.return_value = scalars_mock
+            db.execute.return_value = result_mock
+
+            await settings_organisation_idps_action(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                action="create",
+                idp_name="",
+                provider_type="oidc",
+                client_id="cid",
+                discovery_url="",
+                idp_id="",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "required" in ctx["error"].lower()
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_create_empty_client_id_error(
+        self, mock_auth: AsyncMock, mock_mem: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Creating an IdP with empty client ID shows error."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            db = AsyncMock()
+            scalars_mock = MagicMock()
+            scalars_mock.all.return_value = []
+            result_mock = MagicMock()
+            result_mock.scalars.return_value = scalars_mock
+            db.execute.return_value = result_mock
+
+            await settings_organisation_idps_action(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                action="create",
+                idp_name="Acme SSO",
+                provider_type="oidc",
+                client_id="",
+                discovery_url="",
+                idp_id="",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "client id" in ctx["error"].lower()
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_create_invalid_type_error(
+        self, mock_auth: AsyncMock, mock_mem: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Creating an IdP with invalid type shows error."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            db = AsyncMock()
+            scalars_mock = MagicMock()
+            scalars_mock.all.return_value = []
+            result_mock = MagicMock()
+            result_mock.scalars.return_value = scalars_mock
+            db.execute.return_value = result_mock
+
+            await settings_organisation_idps_action(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                action="create",
+                idp_name="Acme SSO",
+                provider_type="ldap",
+                client_id="cid",
+                discovery_url="",
+                idp_id="",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "invalid provider type" in ctx["error"].lower()
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_create_idp_success(
+        self, mock_auth: AsyncMock, mock_mem: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Owner can create a new identity provider."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            db = AsyncMock()
+            scalars_mock = MagicMock()
+            scalars_mock.all.return_value = []
+            result_mock = MagicMock()
+            result_mock.scalars.return_value = scalars_mock
+            db.execute.return_value = result_mock
+
+            await settings_organisation_idps_action(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                action="create",
+                idp_name="Acme SSO",
+                provider_type="oidc",
+                client_id="acme-client",
+                discovery_url="https://sso.acme.com/.well-known/openid-configuration",
+                idp_id="",
+            )
+
+            db.add.assert_called_once()
+            ctx = mock_render.call_args[0][2]
+            assert "created" in ctx["success"]
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_toggle_idp_success(
+        self, mock_auth: AsyncMock, mock_mem: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Owner can toggle an IdP active/inactive."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            idp_obj = MagicMock()
+            idp_obj.is_active = True
+            idp_obj.name = "Acme SSO"
+
+            call_count = 0
+
+            def execute_side_effect(*args: object, **kwargs: object) -> MagicMock:
+                nonlocal call_count
+                call_count += 1
+                result_mock = MagicMock()
+                if call_count == 1:
+                    result_mock.scalar_one_or_none.return_value = idp_obj
+                else:
+                    scalars_mock = MagicMock()
+                    scalars_mock.all.return_value = []
+                    result_mock.scalars.return_value = scalars_mock
+                return result_mock
+
+            db = AsyncMock()
+            db.execute = AsyncMock(side_effect=execute_side_effect)
+
+            await settings_organisation_idps_action(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                action="toggle",
+                idp_id=str(uuid.uuid4()),
+                idp_name="",
+                provider_type="oidc",
+                client_id="",
+                discovery_url="",
+            )
+
+            assert idp_obj.is_active is False
+            ctx = mock_render.call_args[0][2]
+            assert "disabled" in ctx["success"]
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_toggle_idp_not_found(
+        self, mock_auth: AsyncMock, mock_mem: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Toggling a non-existent IdP shows error."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            call_count = 0
+
+            def execute_side_effect(*args: object, **kwargs: object) -> MagicMock:
+                nonlocal call_count
+                call_count += 1
+                result_mock = MagicMock()
+                if call_count == 1:
+                    result_mock.scalar_one_or_none.return_value = None
+                else:
+                    scalars_mock = MagicMock()
+                    scalars_mock.all.return_value = []
+                    result_mock.scalars.return_value = scalars_mock
+                return result_mock
+
+            db = AsyncMock()
+            db.execute = AsyncMock(side_effect=execute_side_effect)
+
+            await settings_organisation_idps_action(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                action="toggle",
+                idp_id=str(uuid.uuid4()),
+                idp_name="",
+                provider_type="oidc",
+                client_id="",
+                discovery_url="",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "not found" in ctx["error"].lower()
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_delete_idp_success(
+        self, mock_auth: AsyncMock, mock_mem: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Owner can delete an IdP."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            idp_obj = MagicMock()
+
+            call_count = 0
+
+            def execute_side_effect(*args: object, **kwargs: object) -> MagicMock:
+                nonlocal call_count
+                call_count += 1
+                result_mock = MagicMock()
+                if call_count == 1:
+                    result_mock.scalar_one_or_none.return_value = idp_obj
+                else:
+                    scalars_mock = MagicMock()
+                    scalars_mock.all.return_value = []
+                    result_mock.scalars.return_value = scalars_mock
+                return result_mock
+
+            db = AsyncMock()
+            db.execute = AsyncMock(side_effect=execute_side_effect)
+
+            await settings_organisation_idps_action(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                action="delete",
+                idp_id=str(uuid.uuid4()),
+                idp_name="",
+                provider_type="oidc",
+                client_id="",
+                discovery_url="",
+            )
+
+            db.delete.assert_called_once_with(idp_obj)
+            ctx = mock_render.call_args[0][2]
+            assert "deleted" in ctx["success"].lower()
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_delete_idp_not_found(
+        self, mock_auth: AsyncMock, mock_mem: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Deleting a non-existent IdP shows error."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            call_count = 0
+
+            def execute_side_effect(*args: object, **kwargs: object) -> MagicMock:
+                nonlocal call_count
+                call_count += 1
+                result_mock = MagicMock()
+                if call_count == 1:
+                    result_mock.scalar_one_or_none.return_value = None
+                else:
+                    scalars_mock = MagicMock()
+                    scalars_mock.all.return_value = []
+                    result_mock.scalars.return_value = scalars_mock
+                return result_mock
+
+            db = AsyncMock()
+            db.execute = AsyncMock(side_effect=execute_side_effect)
+
+            await settings_organisation_idps_action(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                action="delete",
+                idp_id=str(uuid.uuid4()),
+                idp_name="",
+                provider_type="oidc",
+                client_id="",
+                discovery_url="",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "not found" in ctx["error"].lower()
+
+        asyncio.run(_run())
+
+    @patch("shomer.routes.organisation_settings_ui._render")
+    @patch("shomer.routes.organisation_settings_ui._get_membership")
+    @patch("shomer.routes.organisation_settings_ui._get_session_user")
+    def test_unknown_action_error(
+        self, mock_auth: AsyncMock, mock_mem: AsyncMock, mock_render: MagicMock
+    ) -> None:
+        """Unknown action shows error."""
+
+        async def _run() -> None:
+            user = _mock_user()
+            mock_auth.return_value = (MagicMock(), user)
+            tenant = _mock_tenant()
+            membership = MagicMock(role="owner", tenant=tenant)
+            mock_mem.return_value = (membership, tenant)
+            mock_render.return_value = MagicMock()
+
+            db = AsyncMock()
+            scalars_mock = MagicMock()
+            scalars_mock.all.return_value = []
+            result_mock = MagicMock()
+            result_mock.scalars.return_value = scalars_mock
+            db.execute.return_value = result_mock
+
+            await settings_organisation_idps_action(
+                _req({"session_id": "tok"}),
+                str(tenant.id),
+                db,
+                action="foobar",
+                idp_name="",
+                provider_type="oidc",
+                client_id="",
+                discovery_url="",
+                idp_id="",
+            )
+
+            ctx = mock_render.call_args[0][2]
+            assert "unknown" in ctx["error"].lower()
 
         asyncio.run(_run())


### PR DESCRIPTION
## feat(ui): organisation/tenant self-service management in settings

## Summary

- Add user-facing tenant/organisation management to the settings UI
- Includes ~30 routes: list orgs, create org, detail/edit, members, roles, IdP, branding, trust policies, custom domains, email templates

## Changes

- [x] GET /ui/settings/organisations list
- [x] POST create organisation
- [x] GET/POST org detail/edit
- [x] Custom domain verification
- [x] Member management (add/remove/update role)
- [x] Role management (CRUD + scope assignment)
- [x] IdP management (CRUD + toggle)
- [x] Branding customization
- [x] Trust policies
- [x] Email template management
- [x] Unit tests
- [x] BDD tests

## Dependencies

- #79 — models tenant
- #82 — tenant branding
- #83 — tenant trust policy
- #84 — models identity provider

## Related Issue

Closes #281

## Test Plan

- [x] `make format` - code formatted
- [x] `make lint` - no linting errors
- [x] `make typecheck` - type checks pass
- [x] `make test` - all unit tests pass (1373 passed)
- [x] `make bdd` - all BDD tests pass (14 scenarios, 219 steps)
- [x] `make check-license` - SPDX headers present
